### PR TITLE
Update Chrome driver and Travis dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
 
 before_install:
   - sudo apt-get -qq update
-  - export DISPLAY=:99.0
   - pip freeze | grep -vw "pip" | xargs pip uninstall -y
   - pip install --upgrade pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
-cache: pip
+dist: bionic
 
 addons:
-    chrome: stable
+  chrome: stable
+
+services:
+  - xvfb
 
 python:
   - "3.6"
@@ -14,7 +17,6 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install node
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - pip freeze | grep -vw "pip" | xargs pip uninstall -y
   - pip install --upgrade pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - pip install .[tests]
   - pip install dash[testing]
   - npm install
-  - wget https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip
+  - wget https://chromedriver.storage.googleapis.com/76.0.3809.12/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - export PATH=$PATH:$PWD
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install node
   - export DISPLAY=:99.0
   - pip freeze | grep -vw "pip" | xargs pip uninstall -y
   - pip install --upgrade pip


### PR DESCRIPTION
- Update chrome driver in `.travis.yml` (since Travis has jumped to Chrome version 76).
- Update to _Ubuntu Bionic 18.04_ (from default Travis Ubuntu Trusty 14.04) as that [is now the recommended way of using `xvfb` in Travis](https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui).
- Remove `apt-get install node` on Travis as that is then [pre-installed](https://docs.travis-ci.com/user/reference/bionic/#javascript-and-nodejs-support).