### PR TITLE
Relax minor version in dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
 install:
   - npm install
   - pip install .[dependencies]
+  - pip install dash[dev]
   - pip install .[tests]
   - pip install dash[testing]
   - wget https://chromedriver.storage.googleapis.com/76.0.3809.12/chromedriver_linux64.zip

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ If you have selected install_dependencies during the prompt, you can skip this p
 3. Install python packages required to build components.
     ```
     pip install .[dependencies]
+    pip install dash[dev]
     ```
 4. Install the python packages for testing (optional)
     ```

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join('webviz_subsurface_components', 'package.json')) as f:
 package_name = package['name'].replace(' ', '_').replace('-', '_')
 
 install_requires = [
-    'dash~=1.0.1'
+    'dash~=1.1'
 ]
 
 tests_require = [
@@ -43,7 +43,7 @@ setup(
         'tests': tests_require,
         'dependencies': install_requires
     },
-    setup_requires=['setuptools_scm>=3.2.0'],
+    setup_requires=['setuptools_scm~=3.2'],
     use_scm_version=True,
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Currently some requirements versions are given as `~= x.y.z`. This increases likelihood of version conflicts. Assuming dependencies are well behaving with respect to semantic versioning, it is better to state `~= x.y` in order to reduce risk of verson conflict. 

See [PEP 440](https://www.python.org/dev/peps/pep-0440/#compatible-release) for more information on compatible version specifiers.