### PR TITLE
Travis git release tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,12 @@ before_install:
   - pip install --upgrade pip
 
 install:
+  - export GIT_TAG=$(git describe --tags)
+  - echo $GIT_TAG
+  - git tag --delete $(git tag --list)
+  - git tag $GIT_TAG
   - npm install
   - pip install .[dependencies]
-  - pip install dash[dev]
   - pip install .[tests]
   - pip install dash[testing]
   - wget https://chromedriver.storage.googleapis.com/76.0.3809.12/chromedriver_linux64.zip
@@ -36,7 +39,6 @@ script:
 
 deploy:
   - provider: pypi
-    skip_cleanup: true
     user: webviz
     password:
       secure: XhoUT3skRNVZLuSxK8TOPwTUNF6p7xdZ5xU+lPGcLNRoWFUUZHyKiwI3CAuRPP01bMl4ifM0V+4Y3ov4XDNnotr6fL/xhIaK83wBfUW0w9u6FCmsfXBHh8qj5ELgqdJPdecJNXR3UVHSpnX5zuGzlOeTKpRL1iKNO5vOF9vRmJxG0J3sdqkrp8ZraEtBU8pgq5+reMduX309aXYBrhvnedI1L0d7IeYBCAhilEcmA+yngifyssaxIZIa9jMPyGIPcEihlZ2eho5yiko1Pg/jrZQRrK9s4IkUgJnyNuxYrRz0OjDCeWPThzXhdPo0PnXkChDPjcy00cVE7R8qFYAo/npCELsmaSiQHc0JY1RsmCM7T2ptKy4iQgh9q2wUVZN8csflHHgzY4FPR+w3fjtJ5O3RSjObutyM/ByAU+Qq/59D5tUPMDA+6lHQPTZaDbiKcH/a9QUszsEYf0m7e3ViMJcZfauSshGu8517yNKbRuwWTRILONjryKov0eqeTM47lNTVOXeUkhHyQpHpSl4rSm28yaTMnmFohbWITbr3Oy4nOCuV/RSAom0b6n60UP4KFtoNq7Y8u+IftTc1E9JueVXyaqSCEBbxOMhpzDh7f92xQliOw0/vTmy8OaLjaX8K/A0YrhvtKgVhOahFStaMjcr67LqR3hr++bBXMAw9mP4=

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,8 @@ before_deploy:
   - git tag $GIT_TAG
 deploy:
   - provider: pypi
-    user: webviz
     skip_cleanup: true
+    user: webviz
     password:
       secure: XhoUT3skRNVZLuSxK8TOPwTUNF6p7xdZ5xU+lPGcLNRoWFUUZHyKiwI3CAuRPP01bMl4ifM0V+4Y3ov4XDNnotr6fL/xhIaK83wBfUW0w9u6FCmsfXBHh8qj5ELgqdJPdecJNXR3UVHSpnX5zuGzlOeTKpRL1iKNO5vOF9vRmJxG0J3sdqkrp8ZraEtBU8pgq5+reMduX309aXYBrhvnedI1L0d7IeYBCAhilEcmA+yngifyssaxIZIa9jMPyGIPcEihlZ2eho5yiko1Pg/jrZQRrK9s4IkUgJnyNuxYrRz0OjDCeWPThzXhdPo0PnXkChDPjcy00cVE7R8qFYAo/npCELsmaSiQHc0JY1RsmCM7T2ptKy4iQgh9q2wUVZN8csflHHgzY4FPR+w3fjtJ5O3RSjObutyM/ByAU+Qq/59D5tUPMDA+6lHQPTZaDbiKcH/a9QUszsEYf0m7e3ViMJcZfauSshGu8517yNKbRuwWTRILONjryKov0eqeTM47lNTVOXeUkhHyQpHpSl4rSm28yaTMnmFohbWITbr3Oy4nOCuV/RSAom0b6n60UP4KFtoNq7Y8u+IftTc1E9JueVXyaqSCEBbxOMhpzDh7f92xQliOw0/vTmy8OaLjaX8K/A0YrhvtKgVhOahFStaMjcr67LqR3hr++bBXMAw9mP4=
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
   - export GIT_TAG=$(git describe --tags)
   - npm install
   - pip install .[dependencies]
+  - pip install dash[dev]
   - pip install .[tests]
   - pip install dash[testing]
   - wget https://chromedriver.storage.googleapis.com/76.0.3809.12/chromedriver_linux64.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_install:
   - pip install --upgrade pip
 
 install:
-  - export GIT_TAG=$(git describe --tags)
   - npm install
   - pip install .[dependencies]
   - pip install dash[dev]
@@ -39,7 +38,7 @@ before_deploy:
   # Set the version tag back to what was sent from the git release
   # This changed locally due to local building of the code
   - git tag --delete $(git tag --list)
-  - git tag $GIT_TAG
+  - git tag $TRAVIS_TAG
 deploy:
   - provider: pypi
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_deploy:
 deploy:
   - provider: pypi
     user: webviz
+    skip_cleanup: true
     password:
       secure: XhoUT3skRNVZLuSxK8TOPwTUNF6p7xdZ5xU+lPGcLNRoWFUUZHyKiwI3CAuRPP01bMl4ifM0V+4Y3ov4XDNnotr6fL/xhIaK83wBfUW0w9u6FCmsfXBHh8qj5ELgqdJPdecJNXR3UVHSpnX5zuGzlOeTKpRL1iKNO5vOF9vRmJxG0J3sdqkrp8ZraEtBU8pgq5+reMduX309aXYBrhvnedI1L0d7IeYBCAhilEcmA+yngifyssaxIZIa9jMPyGIPcEihlZ2eho5yiko1Pg/jrZQRrK9s4IkUgJnyNuxYrRz0OjDCeWPThzXhdPo0PnXkChDPjcy00cVE7R8qFYAo/npCELsmaSiQHc0JY1RsmCM7T2ptKy4iQgh9q2wUVZN8csflHHgzY4FPR+w3fjtJ5O3RSjObutyM/ByAU+Qq/59D5tUPMDA+6lHQPTZaDbiKcH/a9QUszsEYf0m7e3ViMJcZfauSshGu8517yNKbRuwWTRILONjryKov0eqeTM47lNTVOXeUkhHyQpHpSl4rSm28yaTMnmFohbWITbr3Oy4nOCuV/RSAom0b6n60UP4KFtoNq7Y8u+IftTc1E9JueVXyaqSCEBbxOMhpzDh7f92xQliOw0/vTmy8OaLjaX8K/A0YrhvtKgVhOahFStaMjcr67LqR3hr++bBXMAw9mP4=
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ before_install:
 
 install:
   - export GIT_TAG=$(git describe --tags)
-  - echo $GIT_TAG
-  - git tag --delete $(git tag --list)
-  - git tag $GIT_TAG
   - npm install
   - pip install .[dependencies]
   - pip install .[tests]
@@ -37,6 +34,11 @@ script:
   - pip install .
   - pytest
 
+before_deploy:
+  # Set the version tag back to what was sent from the git release
+  # This changed locally due to local building of the code
+  - git tag --delete $(git tag --list)
+  - git tag $GIT_TAG
 deploy:
   - provider: pypi
     user: webviz


### PR DESCRIPTION
On git code release, the tag is sent to Travis. However, since artifacts are built on Travis before release, the git tag automatically changes to a `dev` tag locally.

Therefore: After building of the artifacts, set tag back to what was sent from git initially on release, and use that when deploying to pypi.