### PR TITLE
Specify version on Travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,9 @@ script:
   - pytest
 
 before_deploy:
-  # Set the version tag back to what was sent from the git release
-  # This changed locally due to local building of the code
-  - git tag --delete $(git tag --list)
-  - git tag $TRAVIS_TAG
+  # Set the version back to what was sent from the git release.
+  # This changed locally due to local building of the code.
+  - export SETUPTOOLS_SCM_PRETEND_VERSION=$TRAVIS_TAG
 deploy:
   - provider: pypi
     skip_cleanup: true


### PR DESCRIPTION
On git code release, the tag is sent to Travis. However, since artifacts are built on Travis before release, the git tag automatically changes to a `dev` tag locally.

Therefore: After building of the artifacts, set tag back to what was sent from git initially on release, and use that when deploying to pypi.