### PR TITLE
Make leaflet draw optional

### DIFF
--- a/src/demo/LayeredMapDemo.js
+++ b/src/demo/LayeredMapDemo.js
@@ -5,12 +5,16 @@ const data = require('./example-data/layered-map.json');
 
 class LayeredMapDemo extends Component {
   render() {
-    return <LayeredMap id={'layered-map-demo'} 
+    return <LayeredMap id={'layered-map-demo'}
                        map_bounds={data.map_bounds}
                        center={data.center}
                        layers={data.layers}
                        overlay_layers={data.overlay_layers}
                        setProps={(e) => console.log(e)}
+                       show_marker={true}
+                       show_polygon={true}
+                       show_polyline={true}
+
            />
   }
 }

--- a/src/demo/LayeredMapDemo.js
+++ b/src/demo/LayeredMapDemo.js
@@ -11,9 +11,9 @@ class LayeredMapDemo extends Component {
                        layers={data.layers}
                        overlay_layers={data.overlay_layers}
                        setProps={(e) => console.log(e)}
-                       draw_marker={true}
-                       draw_polygon={true}
-                       draw_polyline={true }
+                       draw_toolbar_marker={true}
+                       draw_toolbar_polygon={true}
+                       draw_toolbar_polyline={true }
 
            />
   }

--- a/src/demo/LayeredMapDemo.js
+++ b/src/demo/LayeredMapDemo.js
@@ -11,9 +11,9 @@ class LayeredMapDemo extends Component {
                        layers={data.layers}
                        overlay_layers={data.overlay_layers}
                        setProps={(e) => console.log(e)}
-                       show_marker={true}
-                       show_polygon={true}
-                       show_polyline={true}
+                       draw_marker={true}
+                       draw_polygon={true}
+                       draw_polyline={true }
 
            />
   }

--- a/src/lib/components/LayeredMap.js
+++ b/src/lib/components/LayeredMap.js
@@ -25,8 +25,8 @@ class LayeredMap extends Component {
     }
 
     render() {
-        const {draw_marker, draw_polygon, draw_polyline, setProps} = this.props
-        const showDrawControls = (draw_marker || draw_polygon || draw_polyline) ? true : false
+        const {draw_toolbar_marker, draw_toolbar_polygon, draw_toolbar_polyline, setProps} = this.props
+        const showDrawControls = (draw_toolbar_marker || draw_toolbar_polygon || draw_toolbar_polyline) ? true : false
         return (
                 <Map id={this.props.id} style={{height: this.props.height}}
                      ref={this.mapRef}
@@ -52,9 +52,9 @@ class LayeredMap extends Component {
                     { showDrawControls  && (
                         <FeatureGroup>
                             <DrawControls
-                                drawMarker={draw_marker}
-                                drawPolygon={draw_polygon}
-                                drawPolyline={draw_polyline}
+                                drawMarker={draw_toolbar_marker}
+                                drawPolygon={draw_toolbar_polygon}
+                                drawPolyline={draw_toolbar_polyline}
                                 lineCoords={(coords) => setProps({'polyline_points': coords})}
                                 markerCoords={(coords) => setProps({'marker_point': coords})}
                                 polygonCoords={(coords) => setProps({'polygon_points': coords})}
@@ -69,9 +69,9 @@ class LayeredMap extends Component {
 LayeredMap.defaultProps = {
     height: 800,
     hillShading: true,
-    draw_marker: false,
-    draw_polygon: false,
-    draw_polyline: false
+    draw_toolbar_marker: false,
+    draw_toolbar_polygon: false,
+    draw_toolbar_polyline: false
 };
 
 LayeredMap.propTypes = {
@@ -103,17 +103,17 @@ LayeredMap.propTypes = {
     /**
      * Add button to draw a polyline
      */
-    draw_polyline: PropTypes.bool,
+    draw_toolbar_polyline: PropTypes.bool,
 
     /**
      * Add button to draw a polygon
      */
-    draw_polygon: PropTypes.bool,
+    draw_toolbar_polygon: PropTypes.bool,
 
     /**
      * Add button to draw a marker
      */
-    draw_marker: PropTypes.bool,
+    draw_toolbar_marker: PropTypes.bool,
 
     /**
      * The coordinates of the edited polyline

--- a/src/lib/components/LayeredMap.js
+++ b/src/lib/components/LayeredMap.js
@@ -55,7 +55,7 @@ class LayeredMap extends Component {
                                 drawMarker={draw_marker}
                                 drawPolygon={draw_polygon}
                                 drawPolyline={draw_polyline}
-                                lineCoords={(coords) => setProps({'line_points': coords})}
+                                lineCoords={(coords) => setProps({'polyline_points': coords})}
                                 markerCoords={(coords) => setProps({'marker_point': coords})}
                                 polygonCoords={(coords) => setProps({'polygon_points': coords})}
                             />
@@ -118,7 +118,7 @@ LayeredMap.propTypes = {
     /**
      * The coordinates of the edited polyline
      */
-    line_points: PropTypes.array,
+    polyline_points: PropTypes.array,
 
     /**
      * The coordinates of the edited closed polygon

--- a/src/lib/components/LayeredMap.js
+++ b/src/lib/components/LayeredMap.js
@@ -25,6 +25,8 @@ class LayeredMap extends Component {
     }
 
     render() {
+        const {show_marker, show_polygon, show_polyline, setProps} = this.props
+        const showDrawControls = (show_marker || show_polygon || show_polyline) ? true: false
         return (
                 <Map id={this.props.id} style={{height: this.props.height}}
                      ref={this.mapRef}
@@ -47,12 +49,17 @@ class LayeredMap extends Component {
                             </Overlay>
                         ))}
                     </LayersControl>
-                    <FeatureGroup>
-                        <DrawControls
-                            lineCoords={(coords) => this.props.setProps({'line_points': coords})}
-                            markerCoords={(coords) => this.props.setProps({'marker_point': coords})}
-                            polygonCoords={(coords) => this.props.setProps({'polygon_points': coords})} />
-                    </FeatureGroup>
+                    { showDrawControls  && (
+                        <FeatureGroup>
+                            <DrawControls
+                                showMarker={show_marker}
+                                showPolygon={show_polygon}
+                                showPolyline={show_polyline}
+                                lineCoords={(coords) => setProps({'line_points': coords})}
+                                markerCoords={(coords) => setProps({'marker_point': coords})}
+                                polygonCoords={(coords) => setProps({'polygon_points': coords})} />
+                                </FeatureGroup>
+                    )}
                 </Map>
         );
     }
@@ -60,7 +67,10 @@ class LayeredMap extends Component {
 
 LayeredMap.defaultProps = {
     height: 800,
-    hillShading: true
+    hillShading: true,
+    show_marker: false,
+    show_polygon: false,
+    show_polyline: false
 };
 
 LayeredMap.propTypes = {
@@ -90,17 +100,32 @@ LayeredMap.propTypes = {
     ]),
 
     /**
-     * The coordinates of the last edited polyline
+     * Add button to draw a polyline
+     */
+    show_polyline: PropTypes.bool,
+
+    /**
+     * Add button to draw a polygon
+     */
+    show_polygon: PropTypes.bool,
+
+    /**
+     * Add button to draw a marker
+     */
+    show_marker: PropTypes.bool,
+
+    /**
+     * The coordinates of the edited polyline
      */
     line_points: PropTypes.array,
 
     /**
-     * The coordinates of the last edited closed polygon
+     * The coordinates of the edited closed polygon
      */
     polygon_points: PropTypes.array,
 
     /**
-     * The coordinates of the last edited marker
+     * The coordinates of the edited marker
      */
     marker_point: PropTypes.array,
 

--- a/src/lib/components/LayeredMap.js
+++ b/src/lib/components/LayeredMap.js
@@ -25,8 +25,8 @@ class LayeredMap extends Component {
     }
 
     render() {
-        const {show_marker, show_polygon, show_polyline, setProps} = this.props
-        const showDrawControls = (show_marker || show_polygon || show_polyline) ? true: false
+        const {draw_marker, draw_polygon, draw_polyline, setProps} = this.props
+        const showDrawControls = (draw_marker || draw_polygon || draw_polyline) ? true : false
         return (
                 <Map id={this.props.id} style={{height: this.props.height}}
                      ref={this.mapRef}
@@ -52,13 +52,14 @@ class LayeredMap extends Component {
                     { showDrawControls  && (
                         <FeatureGroup>
                             <DrawControls
-                                showMarker={show_marker}
-                                showPolygon={show_polygon}
-                                showPolyline={show_polyline}
+                                drawMarker={draw_marker}
+                                drawPolygon={draw_polygon}
+                                drawPolyline={draw_polyline}
                                 lineCoords={(coords) => setProps({'line_points': coords})}
                                 markerCoords={(coords) => setProps({'marker_point': coords})}
-                                polygonCoords={(coords) => setProps({'polygon_points': coords})} />
-                                </FeatureGroup>
+                                polygonCoords={(coords) => setProps({'polygon_points': coords})}
+                            />
+                        </FeatureGroup>
                     )}
                 </Map>
         );
@@ -68,9 +69,9 @@ class LayeredMap extends Component {
 LayeredMap.defaultProps = {
     height: 800,
     hillShading: true,
-    show_marker: false,
-    show_polygon: false,
-    show_polyline: false
+    draw_marker: false,
+    draw_polygon: false,
+    draw_polyline: false
 };
 
 LayeredMap.propTypes = {
@@ -102,17 +103,17 @@ LayeredMap.propTypes = {
     /**
      * Add button to draw a polyline
      */
-    show_polyline: PropTypes.bool,
+    draw_polyline: PropTypes.bool,
 
     /**
      * Add button to draw a polygon
      */
-    show_polygon: PropTypes.bool,
+    draw_polygon: PropTypes.bool,
 
     /**
      * Add button to draw a marker
      */
-    show_marker: PropTypes.bool,
+    draw_marker: PropTypes.bool,
 
     /**
      * The coordinates of the edited polyline

--- a/src/lib/private_components/layered-map-resources/DrawControls.react.js
+++ b/src/lib/private_components/layered-map-resources/DrawControls.react.js
@@ -100,6 +100,7 @@ class DrawControls extends Component {
     }
 
     render() {
+        const {showPolygon, showMarker, showPolyline} = this.props
         return (
             <EditControl
               ref={'edit'}
@@ -109,7 +110,10 @@ class DrawControls extends Component {
               draw={{
                   rectangle: false,
                   circle: false,
-                  circlemarker: false
+                  circlemarker: false,
+                  polygon: showPolygon,
+                  marker: showMarker,
+                  polyline: showPolyline
               }}/>
         )
     }

--- a/src/lib/private_components/layered-map-resources/DrawControls.react.js
+++ b/src/lib/private_components/layered-map-resources/DrawControls.react.js
@@ -100,7 +100,7 @@ class DrawControls extends Component {
     }
 
     render() {
-        const {showPolygon, showMarker, showPolyline} = this.props
+        const {drawPolygon, drawMarker, drawPolyline} = this.props
         return (
             <EditControl
               ref={'edit'}
@@ -111,15 +111,29 @@ class DrawControls extends Component {
                   rectangle: false,
                   circle: false,
                   circlemarker: false,
-                  polygon: showPolygon,
-                  marker: showMarker,
-                  polyline: showPolyline
+                  polygon: drawPolygon,
+                  marker: drawMarker,
+                  polyline: drawPolyline
               }}/>
         )
     }
 }
+DrawControls.defaultProps = {
+    drawMarker: true,
+    drawPolygon: true,
+    drawPolyline: true
+};
 
 DrawControls.propTypes = {
+    /* Show marker button*/
+    drawMarker: PropTypes.bool,
+
+    /* Show polygon button*/
+    drawPolygon: PropTypes.bool,
+
+    /* Show polyline button*/
+    drawPolyline: PropTypes.bool,
+
     /* Coordinates for selected marker*/
     markerCoords: PropTypes.func,
 


### PR DESCRIPTION
Closes #34 

Added 3  new bool props to LayeredMap

`draw_toolbar_marker`, `draw_toolbar_polyline`, `draw_toolbar_polygon`.

When all are `false` the Leaflet Draw toolbar is not shown.