### PR TITLE
Conditional layer control

### DIFF
--- a/src/lib/components/LayeredMap.js
+++ b/src/lib/components/LayeredMap.js
@@ -53,7 +53,7 @@ class LayeredMap extends Component {
             />
         );
 
-        const renderOverlayLayer = (layer, key) => (
+        const renderOverlay = (layer, key) => (
             <CompositeMapLayer
                 layer={layer}
                 key={key}
@@ -113,10 +113,10 @@ class LayeredMap extends Component {
                                     name={layer.name}
                                     key={layer.name}
                                 >
-                                    {renderOverlayLayer(layer)}
+                                    {renderOverlay(layer)}
                                 </Overlay>
                             ) : (
-                                renderOverlayLayer(layer, layer.name)
+                                renderOverlay(layer, layer.name)
                             )
                         )}
                 </OptionalLayerControl>

--- a/src/lib/components/LayeredMap.js
+++ b/src/lib/components/LayeredMap.js
@@ -26,6 +26,7 @@ class LayerWrapper extends Component {
         );
     }
 }
+
 class LayeredMap extends Component {
     constructor(props) {
         super(props);

--- a/src/lib/components/LayeredMap.js
+++ b/src/lib/components/LayeredMap.js
@@ -5,6 +5,7 @@ import "leaflet/dist/leaflet.css";
 import { CRS } from "leaflet";
 import { LayersControl, Map, ScaleControl, FeatureGroup } from "react-leaflet";
 import Switch from "../private_components/layered-map-resources/Switch.react";
+import OptionalLayerControl from "../private_components/layered-map-resources/OptionalLayerControl.react";
 import CompositeMapLayer from "../private_components/layered-map-resources/CompositeMapLayer.react";
 import DrawControls from "../private_components/layered-map-resources/DrawControls.react";
 import VerticalZoom from "../private_components/layered-map-resources/VerticalZoom.react";
@@ -14,18 +15,6 @@ const { BaseLayer, Overlay } = LayersControl;
 const yx = ([x, y]) => {
     return [y, x];
 };
-
-class LayerWrapper extends Component {
-    render() {
-        return this.props.showLayersControl ? (
-            <LayersControl position="topright" hideSingleBase={true}>
-                {this.props.children}
-            </LayersControl>
-        ) : (
-            this.props.children
-        );
-    }
-}
 
 class LayeredMap extends Component {
     constructor(props) {
@@ -99,7 +88,7 @@ class LayeredMap extends Component {
                     imperial={false}
                     metric={true}
                 />
-                <LayerWrapper showLayersControl={showLayersControl}>
+                <OptionalLayerControl showLayersControl={showLayersControl}>
                     {this.props.layers
                         .filter(layer => layer.base_layer)
                         .map(layer =>
@@ -130,7 +119,7 @@ class LayeredMap extends Component {
                                 renderOverlayLayer(layer, layer.name)
                             )
                         )}
-                </LayerWrapper>
+                </OptionalLayerControl>
                 {showDrawControls && (
                     <FeatureGroup>
                         <DrawControls

--- a/src/lib/private_components/layered-map-resources/OptionalLayerControl.react.js
+++ b/src/lib/private_components/layered-map-resources/OptionalLayerControl.react.js
@@ -1,0 +1,25 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { LayersControl } from "react-leaflet";
+
+class OptionalLayerControl extends React.Component {
+    render() {
+        return this.props.showLayersControl ? (
+            <LayersControl position="topright" hideSingleBase={true}>
+                {this.props.children}
+            </LayersControl>
+        ) : (
+            this.props.children
+        );
+    }
+}
+
+OptionalLayerControl.propTypes = {
+    /* If to show the leaflet layer control */
+    showLayersControl: PropTypes.bool,
+
+    /* Children of the wrapper element */
+    children: PropTypes.node,
+};
+
+export default OptionalLayerControl;


### PR DESCRIPTION
Resolves #57. In addition, if `(more than one layer) and (only one base layer)`, the base layer selection part of the layer control is hidden (i.e. only overlay layers can be selected/deselected).

The changes are a bit involved since the conditional elements to include or not are components with children.