### PR TITLE
Update Dash test framework

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,0 @@
-{
-  "presets": [
-    "@babel/preset-env",
-    "@babel/preset-react"
-  ]
-}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,10 @@
+const presets = [
+    '@babel/env',
+    '@babel/preset-react'
+];
+
+const plugins = [
+    '@babel/plugin-syntax-dynamic-import'
+];
+
+module.exports = { presets, plugins };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,8 @@
 {
     "name": "webviz_subsurface_components",
-    "requires": true,
+    "version": "1.0.0",
     "lockfileVersion": 1,
+    "requires": true,
     "dependencies": {
         "@babel/code-frame": {
             "version": "7.5.5",
@@ -9,7 +10,7 @@
             "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.0.0"
+                "@babel/highlight": "7.5.0"
             }
         },
         "@babel/core": {
@@ -18,20 +19,20 @@
             "integrity": "sha512-l8zto/fuoZIbncm+01p8zPSDZu/VuuJhAfA7d/AbzM09WR7iVhavvfNDYCNpo1VvLk6E6xgAoP9P+/EMJHuRkQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.5.5",
-                "@babel/generator": "^7.6.2",
-                "@babel/helpers": "^7.6.2",
-                "@babel/parser": "^7.6.2",
-                "@babel/template": "^7.6.0",
-                "@babel/traverse": "^7.6.2",
-                "@babel/types": "^7.6.0",
-                "convert-source-map": "^1.1.0",
-                "debug": "^4.1.0",
-                "json5": "^2.1.0",
-                "lodash": "^4.17.13",
-                "resolve": "^1.3.2",
-                "semver": "^5.4.1",
-                "source-map": "^0.5.0"
+                "@babel/code-frame": "7.5.5",
+                "@babel/generator": "7.6.2",
+                "@babel/helpers": "7.6.2",
+                "@babel/parser": "7.6.2",
+                "@babel/template": "7.6.0",
+                "@babel/traverse": "7.6.2",
+                "@babel/types": "7.6.1",
+                "convert-source-map": "1.6.0",
+                "debug": "4.1.1",
+                "json5": "2.1.0",
+                "lodash": "4.17.15",
+                "resolve": "1.12.0",
+                "semver": "5.7.1",
+                "source-map": "0.5.7"
             }
         },
         "@babel/generator": {
@@ -40,10 +41,10 @@
             "integrity": "sha512-j8iHaIW4gGPnViaIHI7e9t/Hl8qLjERI6DcV9kEpAIDJsAOrcnXqRS7t+QbhL76pwbtqP+QCQLL0z1CyVmtjjQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.6.0",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
-                "source-map": "^0.5.0"
+                "@babel/types": "7.6.1",
+                "jsesc": "2.5.2",
+                "lodash": "4.17.15",
+                "source-map": "0.5.7"
             }
         },
         "@babel/helper-annotate-as-pure": {
@@ -52,7 +53,7 @@
             "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -61,8 +62,8 @@
             "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
             "dev": true,
             "requires": {
-                "@babel/helper-explode-assignable-expression": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-explode-assignable-expression": "7.1.0",
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helper-builder-react-jsx": {
@@ -71,8 +72,8 @@
             "integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.3.0",
-                "esutils": "^2.0.0"
+                "@babel/types": "7.6.1",
+                "esutils": "2.0.3"
             }
         },
         "@babel/helper-call-delegate": {
@@ -81,9 +82,9 @@
             "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-hoist-variables": "^7.4.4",
-                "@babel/traverse": "^7.4.4",
-                "@babel/types": "^7.4.4"
+                "@babel/helper-hoist-variables": "7.4.4",
+                "@babel/traverse": "7.6.2",
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helper-define-map": {
@@ -92,9 +93,9 @@
             "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/types": "^7.5.5",
-                "lodash": "^4.17.13"
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/types": "7.6.1",
+                "lodash": "4.17.15"
             }
         },
         "@babel/helper-explode-assignable-expression": {
@@ -103,8 +104,8 @@
             "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/traverse": "7.6.2",
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helper-function-name": {
@@ -113,9 +114,9 @@
             "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.0.0",
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-get-function-arity": "7.0.0",
+                "@babel/template": "7.6.0",
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helper-get-function-arity": {
@@ -124,7 +125,7 @@
             "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helper-hoist-variables": {
@@ -133,7 +134,7 @@
             "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.4.4"
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helper-member-expression-to-functions": {
@@ -142,7 +143,7 @@
             "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.5.5"
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helper-module-imports": {
@@ -151,7 +152,7 @@
             "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helper-module-transforms": {
@@ -160,12 +161,12 @@
             "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@babel/helper-simple-access": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.4.4",
-                "@babel/template": "^7.4.4",
-                "@babel/types": "^7.5.5",
-                "lodash": "^4.17.13"
+                "@babel/helper-module-imports": "7.0.0",
+                "@babel/helper-simple-access": "7.1.0",
+                "@babel/helper-split-export-declaration": "7.4.4",
+                "@babel/template": "7.6.0",
+                "@babel/types": "7.6.1",
+                "lodash": "4.17.15"
             }
         },
         "@babel/helper-optimise-call-expression": {
@@ -174,7 +175,7 @@
             "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -189,7 +190,7 @@
             "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.13"
+                "lodash": "4.17.15"
             }
         },
         "@babel/helper-remap-async-to-generator": {
@@ -198,11 +199,11 @@
             "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
-                "@babel/helper-wrap-function": "^7.1.0",
-                "@babel/template": "^7.1.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-annotate-as-pure": "7.0.0",
+                "@babel/helper-wrap-function": "7.2.0",
+                "@babel/template": "7.6.0",
+                "@babel/traverse": "7.6.2",
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helper-replace-supers": {
@@ -211,10 +212,10 @@
             "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.5.5",
-                "@babel/helper-optimise-call-expression": "^7.0.0",
-                "@babel/traverse": "^7.5.5",
-                "@babel/types": "^7.5.5"
+                "@babel/helper-member-expression-to-functions": "7.5.5",
+                "@babel/helper-optimise-call-expression": "7.0.0",
+                "@babel/traverse": "7.6.2",
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helper-simple-access": {
@@ -223,8 +224,8 @@
             "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/template": "7.6.0",
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -233,7 +234,7 @@
             "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.4.4"
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helper-wrap-function": {
@@ -242,10 +243,10 @@
             "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/template": "^7.1.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.2.0"
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/template": "7.6.0",
+                "@babel/traverse": "7.6.2",
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/helpers": {
@@ -254,9 +255,9 @@
             "integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.6.0",
-                "@babel/traverse": "^7.6.2",
-                "@babel/types": "^7.6.0"
+                "@babel/template": "7.6.0",
+                "@babel/traverse": "7.6.2",
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/highlight": {
@@ -265,9 +266,9 @@
             "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
-                "js-tokens": "^4.0.0"
+                "chalk": "2.4.2",
+                "esutils": "2.0.3",
+                "js-tokens": "4.0.0"
             }
         },
         "@babel/parser": {
@@ -282,9 +283,9 @@
             "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-remap-async-to-generator": "^7.1.0",
-                "@babel/plugin-syntax-async-generators": "^7.2.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-remap-async-to-generator": "7.1.0",
+                "@babel/plugin-syntax-async-generators": "7.2.0"
             }
         },
         "@babel/plugin-proposal-dynamic-import": {
@@ -293,8 +294,8 @@
             "integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-dynamic-import": "^7.2.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-dynamic-import": "7.2.0"
             }
         },
         "@babel/plugin-proposal-json-strings": {
@@ -303,8 +304,8 @@
             "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-json-strings": "^7.2.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-json-strings": "7.2.0"
             }
         },
         "@babel/plugin-proposal-object-rest-spread": {
@@ -313,8 +314,8 @@
             "integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "7.2.0"
             }
         },
         "@babel/plugin-proposal-optional-catch-binding": {
@@ -323,8 +324,8 @@
             "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "7.2.0"
             }
         },
         "@babel/plugin-proposal-unicode-property-regex": {
@@ -333,9 +334,9 @@
             "integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.4.4",
-                "regexpu-core": "^4.6.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.5.5",
+                "regexpu-core": "4.6.0"
             }
         },
         "@babel/plugin-syntax-async-generators": {
@@ -344,7 +345,7 @@
             "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-syntax-dynamic-import": {
@@ -353,7 +354,7 @@
             "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-syntax-json-strings": {
@@ -362,7 +363,7 @@
             "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-syntax-jsx": {
@@ -371,7 +372,7 @@
             "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-syntax-object-rest-spread": {
@@ -380,7 +381,7 @@
             "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-syntax-optional-catch-binding": {
@@ -389,7 +390,7 @@
             "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-arrow-functions": {
@@ -398,7 +399,7 @@
             "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-async-to-generator": {
@@ -407,9 +408,9 @@
             "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-remap-async-to-generator": "^7.1.0"
+                "@babel/helper-module-imports": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-remap-async-to-generator": "7.1.0"
             }
         },
         "@babel/plugin-transform-block-scoped-functions": {
@@ -418,7 +419,7 @@
             "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-block-scoping": {
@@ -427,8 +428,8 @@
             "integrity": "sha512-zZT8ivau9LOQQaOGC7bQLQOT4XPkPXgN2ERfUgk1X8ql+mVkLc4E8eKk+FO3o0154kxzqenWCorfmEXpEZcrSQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "lodash": "^4.17.13"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "lodash": "4.17.15"
             }
         },
         "@babel/plugin-transform-classes": {
@@ -437,14 +438,14 @@
             "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
-                "@babel/helper-define-map": "^7.5.5",
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-optimise-call-expression": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-replace-supers": "^7.5.5",
-                "@babel/helper-split-export-declaration": "^7.4.4",
-                "globals": "^11.1.0"
+                "@babel/helper-annotate-as-pure": "7.0.0",
+                "@babel/helper-define-map": "7.5.5",
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-optimise-call-expression": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-replace-supers": "7.5.5",
+                "@babel/helper-split-export-declaration": "7.4.4",
+                "globals": "11.12.0"
             }
         },
         "@babel/plugin-transform-computed-properties": {
@@ -453,7 +454,7 @@
             "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-destructuring": {
@@ -462,7 +463,7 @@
             "integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-dotall-regex": {
@@ -471,9 +472,9 @@
             "integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.4.4",
-                "regexpu-core": "^4.6.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.5.5",
+                "regexpu-core": "4.6.0"
             }
         },
         "@babel/plugin-transform-duplicate-keys": {
@@ -482,7 +483,7 @@
             "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-exponentiation-operator": {
@@ -491,8 +492,8 @@
             "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-for-of": {
@@ -501,7 +502,7 @@
             "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-function-name": {
@@ -510,8 +511,8 @@
             "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-literals": {
@@ -520,7 +521,7 @@
             "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-member-expression-literals": {
@@ -529,7 +530,7 @@
             "integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-modules-amd": {
@@ -538,9 +539,9 @@
             "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "babel-plugin-dynamic-import-node": "^2.3.0"
+                "@babel/helper-module-transforms": "7.5.5",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "babel-plugin-dynamic-import-node": "2.3.0"
             }
         },
         "@babel/plugin-transform-modules-commonjs": {
@@ -549,10 +550,10 @@
             "integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.4.4",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-simple-access": "^7.1.0",
-                "babel-plugin-dynamic-import-node": "^2.3.0"
+                "@babel/helper-module-transforms": "7.5.5",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-simple-access": "7.1.0",
+                "babel-plugin-dynamic-import-node": "2.3.0"
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
@@ -561,9 +562,9 @@
             "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
             "dev": true,
             "requires": {
-                "@babel/helper-hoist-variables": "^7.4.4",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "babel-plugin-dynamic-import-node": "^2.3.0"
+                "@babel/helper-hoist-variables": "7.4.4",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "babel-plugin-dynamic-import-node": "2.3.0"
             }
         },
         "@babel/plugin-transform-modules-umd": {
@@ -572,8 +573,8 @@
             "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-module-transforms": "7.5.5",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-named-capturing-groups-regex": {
@@ -582,7 +583,7 @@
             "integrity": "sha512-xBdB+XOs+lgbZc2/4F5BVDVcDNS4tcSKQc96KmlqLEAwz6tpYPEvPdmDfvVG0Ssn8lAhronaRs6Z6KSexIpK5g==",
             "dev": true,
             "requires": {
-                "regexpu-core": "^4.6.0"
+                "regexpu-core": "4.6.0"
             }
         },
         "@babel/plugin-transform-new-target": {
@@ -591,7 +592,7 @@
             "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-object-super": {
@@ -600,8 +601,8 @@
             "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-replace-supers": "^7.5.5"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-replace-supers": "7.5.5"
             }
         },
         "@babel/plugin-transform-parameters": {
@@ -610,9 +611,9 @@
             "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
             "dev": true,
             "requires": {
-                "@babel/helper-call-delegate": "^7.4.4",
-                "@babel/helper-get-function-arity": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-call-delegate": "7.4.4",
+                "@babel/helper-get-function-arity": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-property-literals": {
@@ -621,7 +622,7 @@
             "integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-react-display-name": {
@@ -630,7 +631,7 @@
             "integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-react-jsx": {
@@ -639,9 +640,9 @@
             "integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-react-jsx": "^7.3.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-jsx": "^7.2.0"
+                "@babel/helper-builder-react-jsx": "7.3.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-jsx": "7.2.0"
             }
         },
         "@babel/plugin-transform-react-jsx-self": {
@@ -650,8 +651,8 @@
             "integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-jsx": "^7.2.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-jsx": "7.2.0"
             }
         },
         "@babel/plugin-transform-react-jsx-source": {
@@ -660,8 +661,8 @@
             "integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-jsx": "^7.2.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-jsx": "7.2.0"
             }
         },
         "@babel/plugin-transform-regenerator": {
@@ -670,7 +671,7 @@
             "integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
             "dev": true,
             "requires": {
-                "regenerator-transform": "^0.14.0"
+                "regenerator-transform": "0.14.1"
             }
         },
         "@babel/plugin-transform-reserved-words": {
@@ -679,7 +680,7 @@
             "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-shorthand-properties": {
@@ -688,7 +689,7 @@
             "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-spread": {
@@ -697,7 +698,7 @@
             "integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-sticky-regex": {
@@ -706,8 +707,8 @@
             "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.5.5"
             }
         },
         "@babel/plugin-transform-template-literals": {
@@ -716,8 +717,8 @@
             "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-annotate-as-pure": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-typeof-symbol": {
@@ -726,7 +727,7 @@
             "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-unicode-regex": {
@@ -735,9 +736,9 @@
             "integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.4.4",
-                "regexpu-core": "^4.6.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.5.5",
+                "regexpu-core": "4.6.0"
             }
         },
         "@babel/preset-env": {
@@ -746,56 +747,56 @@
             "integrity": "sha512-Ru7+mfzy9M1/YTEtlDS8CD45jd22ngb9tXnn64DvQK3ooyqSw9K4K9DUWmYknTTVk4TqygL9dqCrZgm1HMea/Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-                "@babel/plugin-proposal-dynamic-import": "^7.5.0",
-                "@babel/plugin-proposal-json-strings": "^7.2.0",
-                "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
-                "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-                "@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
-                "@babel/plugin-syntax-async-generators": "^7.2.0",
-                "@babel/plugin-syntax-dynamic-import": "^7.2.0",
-                "@babel/plugin-syntax-json-strings": "^7.2.0",
-                "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
-                "@babel/plugin-transform-arrow-functions": "^7.2.0",
-                "@babel/plugin-transform-async-to-generator": "^7.5.0",
-                "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-                "@babel/plugin-transform-block-scoping": "^7.6.2",
-                "@babel/plugin-transform-classes": "^7.5.5",
-                "@babel/plugin-transform-computed-properties": "^7.2.0",
-                "@babel/plugin-transform-destructuring": "^7.6.0",
-                "@babel/plugin-transform-dotall-regex": "^7.6.2",
-                "@babel/plugin-transform-duplicate-keys": "^7.5.0",
-                "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-                "@babel/plugin-transform-for-of": "^7.4.4",
-                "@babel/plugin-transform-function-name": "^7.4.4",
-                "@babel/plugin-transform-literals": "^7.2.0",
-                "@babel/plugin-transform-member-expression-literals": "^7.2.0",
-                "@babel/plugin-transform-modules-amd": "^7.5.0",
-                "@babel/plugin-transform-modules-commonjs": "^7.6.0",
-                "@babel/plugin-transform-modules-systemjs": "^7.5.0",
-                "@babel/plugin-transform-modules-umd": "^7.2.0",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.6.2",
-                "@babel/plugin-transform-new-target": "^7.4.4",
-                "@babel/plugin-transform-object-super": "^7.5.5",
-                "@babel/plugin-transform-parameters": "^7.4.4",
-                "@babel/plugin-transform-property-literals": "^7.2.0",
-                "@babel/plugin-transform-regenerator": "^7.4.5",
-                "@babel/plugin-transform-reserved-words": "^7.2.0",
-                "@babel/plugin-transform-shorthand-properties": "^7.2.0",
-                "@babel/plugin-transform-spread": "^7.6.2",
-                "@babel/plugin-transform-sticky-regex": "^7.2.0",
-                "@babel/plugin-transform-template-literals": "^7.4.4",
-                "@babel/plugin-transform-typeof-symbol": "^7.2.0",
-                "@babel/plugin-transform-unicode-regex": "^7.6.2",
-                "@babel/types": "^7.6.0",
-                "browserslist": "^4.6.0",
-                "core-js-compat": "^3.1.1",
-                "invariant": "^2.2.2",
-                "js-levenshtein": "^1.1.3",
-                "semver": "^5.5.0"
+                "@babel/helper-module-imports": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-proposal-async-generator-functions": "7.2.0",
+                "@babel/plugin-proposal-dynamic-import": "7.5.0",
+                "@babel/plugin-proposal-json-strings": "7.2.0",
+                "@babel/plugin-proposal-object-rest-spread": "7.6.2",
+                "@babel/plugin-proposal-optional-catch-binding": "7.2.0",
+                "@babel/plugin-proposal-unicode-property-regex": "7.6.2",
+                "@babel/plugin-syntax-async-generators": "7.2.0",
+                "@babel/plugin-syntax-dynamic-import": "7.2.0",
+                "@babel/plugin-syntax-json-strings": "7.2.0",
+                "@babel/plugin-syntax-object-rest-spread": "7.2.0",
+                "@babel/plugin-syntax-optional-catch-binding": "7.2.0",
+                "@babel/plugin-transform-arrow-functions": "7.2.0",
+                "@babel/plugin-transform-async-to-generator": "7.5.0",
+                "@babel/plugin-transform-block-scoped-functions": "7.2.0",
+                "@babel/plugin-transform-block-scoping": "7.6.2",
+                "@babel/plugin-transform-classes": "7.5.5",
+                "@babel/plugin-transform-computed-properties": "7.2.0",
+                "@babel/plugin-transform-destructuring": "7.6.0",
+                "@babel/plugin-transform-dotall-regex": "7.6.2",
+                "@babel/plugin-transform-duplicate-keys": "7.5.0",
+                "@babel/plugin-transform-exponentiation-operator": "7.2.0",
+                "@babel/plugin-transform-for-of": "7.4.4",
+                "@babel/plugin-transform-function-name": "7.4.4",
+                "@babel/plugin-transform-literals": "7.2.0",
+                "@babel/plugin-transform-member-expression-literals": "7.2.0",
+                "@babel/plugin-transform-modules-amd": "7.5.0",
+                "@babel/plugin-transform-modules-commonjs": "7.6.0",
+                "@babel/plugin-transform-modules-systemjs": "7.5.0",
+                "@babel/plugin-transform-modules-umd": "7.2.0",
+                "@babel/plugin-transform-named-capturing-groups-regex": "7.6.2",
+                "@babel/plugin-transform-new-target": "7.4.4",
+                "@babel/plugin-transform-object-super": "7.5.5",
+                "@babel/plugin-transform-parameters": "7.4.4",
+                "@babel/plugin-transform-property-literals": "7.2.0",
+                "@babel/plugin-transform-regenerator": "7.4.5",
+                "@babel/plugin-transform-reserved-words": "7.2.0",
+                "@babel/plugin-transform-shorthand-properties": "7.2.0",
+                "@babel/plugin-transform-spread": "7.6.2",
+                "@babel/plugin-transform-sticky-regex": "7.2.0",
+                "@babel/plugin-transform-template-literals": "7.4.4",
+                "@babel/plugin-transform-typeof-symbol": "7.2.0",
+                "@babel/plugin-transform-unicode-regex": "7.6.2",
+                "@babel/types": "7.6.1",
+                "browserslist": "4.7.0",
+                "core-js-compat": "3.2.1",
+                "invariant": "2.2.4",
+                "js-levenshtein": "1.1.6",
+                "semver": "5.7.1"
             }
         },
         "@babel/preset-react": {
@@ -804,11 +805,11 @@
             "integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-transform-react-display-name": "^7.0.0",
-                "@babel/plugin-transform-react-jsx": "^7.0.0",
-                "@babel/plugin-transform-react-jsx-self": "^7.0.0",
-                "@babel/plugin-transform-react-jsx-source": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-transform-react-display-name": "7.2.0",
+                "@babel/plugin-transform-react-jsx": "7.3.0",
+                "@babel/plugin-transform-react-jsx-self": "7.2.0",
+                "@babel/plugin-transform-react-jsx-source": "7.5.0"
             }
         },
         "@babel/runtime": {
@@ -816,7 +817,7 @@
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
             "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
             "requires": {
-                "regenerator-runtime": "^0.13.2"
+                "regenerator-runtime": "0.13.3"
             }
         },
         "@babel/template": {
@@ -825,9 +826,9 @@
             "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.6.0",
-                "@babel/types": "^7.6.0"
+                "@babel/code-frame": "7.5.5",
+                "@babel/parser": "7.6.2",
+                "@babel/types": "7.6.1"
             }
         },
         "@babel/traverse": {
@@ -836,15 +837,15 @@
             "integrity": "sha512-8fRE76xNwNttVEF2TwxJDGBLWthUkHWSldmfuBzVRmEDWOtu4XdINTgN7TDWzuLg4bbeIMLvfMFD9we5YcWkRQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.5.5",
-                "@babel/generator": "^7.6.2",
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.4.4",
-                "@babel/parser": "^7.6.2",
-                "@babel/types": "^7.6.0",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
+                "@babel/code-frame": "7.5.5",
+                "@babel/generator": "7.6.2",
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-split-export-declaration": "7.4.4",
+                "@babel/parser": "7.6.2",
+                "@babel/types": "7.6.1",
+                "debug": "4.1.1",
+                "globals": "11.12.0",
+                "lodash": "4.17.15"
             }
         },
         "@babel/types": {
@@ -853,9 +854,9 @@
             "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
             "dev": true,
             "requires": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
+                "esutils": "2.0.3",
+                "lodash": "4.17.15",
+                "to-fast-properties": "2.0.0"
             }
         },
         "@cnakazawa/watch": {
@@ -864,8 +865,8 @@
             "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
             "dev": true,
             "requires": {
-                "exec-sh": "^0.3.2",
-                "minimist": "^1.2.0"
+                "exec-sh": "0.3.2",
+                "minimist": "1.2.0"
             }
         },
         "@emotion/hash": {
@@ -879,9 +880,9 @@
             "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
             "dev": true,
             "requires": {
-                "@jest/source-map": "^24.9.0",
-                "chalk": "^2.0.1",
-                "slash": "^2.0.0"
+                "@jest/source-map": "24.9.0",
+                "chalk": "2.4.2",
+                "slash": "2.0.0"
             }
         },
         "@jest/core": {
@@ -890,34 +891,34 @@
             "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/reporters": "^24.9.0",
-                "@jest/test-result": "^24.9.0",
-                "@jest/transform": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.1",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.1.15",
-                "jest-changed-files": "^24.9.0",
-                "jest-config": "^24.9.0",
-                "jest-haste-map": "^24.9.0",
-                "jest-message-util": "^24.9.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve": "^24.9.0",
-                "jest-resolve-dependencies": "^24.9.0",
-                "jest-runner": "^24.9.0",
-                "jest-runtime": "^24.9.0",
-                "jest-snapshot": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "jest-validate": "^24.9.0",
-                "jest-watcher": "^24.9.0",
-                "micromatch": "^3.1.10",
-                "p-each-series": "^1.0.0",
-                "realpath-native": "^1.1.0",
-                "rimraf": "^2.5.4",
-                "slash": "^2.0.0",
-                "strip-ansi": "^5.0.0"
+                "@jest/console": "24.9.0",
+                "@jest/reporters": "24.9.0",
+                "@jest/test-result": "24.9.0",
+                "@jest/transform": "24.9.0",
+                "@jest/types": "24.9.0",
+                "ansi-escapes": "3.2.0",
+                "chalk": "2.4.2",
+                "exit": "0.1.2",
+                "graceful-fs": "4.2.2",
+                "jest-changed-files": "24.9.0",
+                "jest-config": "24.9.0",
+                "jest-haste-map": "24.9.0",
+                "jest-message-util": "24.9.0",
+                "jest-regex-util": "24.9.0",
+                "jest-resolve": "24.9.0",
+                "jest-resolve-dependencies": "24.9.0",
+                "jest-runner": "24.9.0",
+                "jest-runtime": "24.9.0",
+                "jest-snapshot": "24.9.0",
+                "jest-util": "24.9.0",
+                "jest-validate": "24.9.0",
+                "jest-watcher": "24.9.0",
+                "micromatch": "3.1.10",
+                "p-each-series": "1.0.0",
+                "realpath-native": "1.1.0",
+                "rimraf": "2.6.3",
+                "slash": "2.0.0",
+                "strip-ansi": "5.2.0"
             }
         },
         "@jest/environment": {
@@ -926,10 +927,10 @@
             "integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
             "dev": true,
             "requires": {
-                "@jest/fake-timers": "^24.9.0",
-                "@jest/transform": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "jest-mock": "^24.9.0"
+                "@jest/fake-timers": "24.9.0",
+                "@jest/transform": "24.9.0",
+                "@jest/types": "24.9.0",
+                "jest-mock": "24.9.0"
             }
         },
         "@jest/fake-timers": {
@@ -938,9 +939,9 @@
             "integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.9.0",
-                "jest-message-util": "^24.9.0",
-                "jest-mock": "^24.9.0"
+                "@jest/types": "24.9.0",
+                "jest-message-util": "24.9.0",
+                "jest-mock": "24.9.0"
             }
         },
         "@jest/reporters": {
@@ -949,27 +950,27 @@
             "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^24.9.0",
-                "@jest/test-result": "^24.9.0",
-                "@jest/transform": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "chalk": "^2.0.1",
-                "exit": "^0.1.2",
-                "glob": "^7.1.2",
-                "istanbul-lib-coverage": "^2.0.2",
-                "istanbul-lib-instrument": "^3.0.1",
-                "istanbul-lib-report": "^2.0.4",
-                "istanbul-lib-source-maps": "^3.0.1",
-                "istanbul-reports": "^2.2.6",
-                "jest-haste-map": "^24.9.0",
-                "jest-resolve": "^24.9.0",
-                "jest-runtime": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "jest-worker": "^24.6.0",
-                "node-notifier": "^5.4.2",
-                "slash": "^2.0.0",
-                "source-map": "^0.6.0",
-                "string-length": "^2.0.0"
+                "@jest/environment": "24.9.0",
+                "@jest/test-result": "24.9.0",
+                "@jest/transform": "24.9.0",
+                "@jest/types": "24.9.0",
+                "chalk": "2.4.2",
+                "exit": "0.1.2",
+                "glob": "7.1.4",
+                "istanbul-lib-coverage": "2.0.5",
+                "istanbul-lib-instrument": "3.3.0",
+                "istanbul-lib-report": "2.0.8",
+                "istanbul-lib-source-maps": "3.0.6",
+                "istanbul-reports": "2.2.6",
+                "jest-haste-map": "24.9.0",
+                "jest-resolve": "24.9.0",
+                "jest-runtime": "24.9.0",
+                "jest-util": "24.9.0",
+                "jest-worker": "24.9.0",
+                "node-notifier": "5.4.3",
+                "slash": "2.0.0",
+                "source-map": "0.6.1",
+                "string-length": "2.0.0"
             },
             "dependencies": {
                 "source-map": {
@@ -986,9 +987,9 @@
             "integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
             "dev": true,
             "requires": {
-                "callsites": "^3.0.0",
-                "graceful-fs": "^4.1.15",
-                "source-map": "^0.6.0"
+                "callsites": "3.1.0",
+                "graceful-fs": "4.2.2",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -1005,9 +1006,9 @@
             "integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "@types/istanbul-lib-coverage": "^2.0.0"
+                "@jest/console": "24.9.0",
+                "@jest/types": "24.9.0",
+                "@types/istanbul-lib-coverage": "2.0.1"
             }
         },
         "@jest/test-sequencer": {
@@ -1016,10 +1017,10 @@
             "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^24.9.0",
-                "jest-haste-map": "^24.9.0",
-                "jest-runner": "^24.9.0",
-                "jest-runtime": "^24.9.0"
+                "@jest/test-result": "24.9.0",
+                "jest-haste-map": "24.9.0",
+                "jest-runner": "24.9.0",
+                "jest-runtime": "24.9.0"
             }
         },
         "@jest/transform": {
@@ -1028,21 +1029,21 @@
             "integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
             "dev": true,
             "requires": {
-                "@babel/core": "^7.1.0",
-                "@jest/types": "^24.9.0",
-                "babel-plugin-istanbul": "^5.1.0",
-                "chalk": "^2.0.1",
-                "convert-source-map": "^1.4.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "graceful-fs": "^4.1.15",
-                "jest-haste-map": "^24.9.0",
-                "jest-regex-util": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "micromatch": "^3.1.10",
-                "pirates": "^4.0.1",
-                "realpath-native": "^1.1.0",
-                "slash": "^2.0.0",
-                "source-map": "^0.6.1",
+                "@babel/core": "7.6.2",
+                "@jest/types": "24.9.0",
+                "babel-plugin-istanbul": "5.2.0",
+                "chalk": "2.4.2",
+                "convert-source-map": "1.6.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "graceful-fs": "4.2.2",
+                "jest-haste-map": "24.9.0",
+                "jest-regex-util": "24.9.0",
+                "jest-util": "24.9.0",
+                "micromatch": "3.1.10",
+                "pirates": "4.0.1",
+                "realpath-native": "1.1.0",
+                "slash": "2.0.0",
+                "source-map": "0.6.1",
                 "write-file-atomic": "2.4.1"
             },
             "dependencies": {
@@ -1060,9 +1061,9 @@
             "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
             "dev": true,
             "requires": {
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^1.1.1",
-                "@types/yargs": "^13.0.0"
+                "@types/istanbul-lib-coverage": "2.0.1",
+                "@types/istanbul-reports": "1.1.1",
+                "@types/yargs": "13.0.3"
             }
         },
         "@material-ui/core": {
@@ -1070,21 +1071,21 @@
             "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.5.0.tgz",
             "integrity": "sha512-UHVAjU+1uDtA+OMBNBHb4RlCZOu514XeYPafNJv+GTdXBDr1SCPK7yqRE6TV1/bulxlDusTgu5Q6BAUgpmO4MA==",
             "requires": {
-                "@babel/runtime": "^7.4.4",
-                "@material-ui/styles": "^4.5.0",
-                "@material-ui/system": "^4.5.0",
-                "@material-ui/types": "^4.1.1",
-                "@material-ui/utils": "^4.4.0",
-                "@types/react-transition-group": "^4.2.0",
-                "clsx": "^1.0.2",
-                "convert-css-length": "^2.0.1",
-                "deepmerge": "^4.0.0",
-                "hoist-non-react-statics": "^3.2.1",
-                "is-plain-object": "^3.0.0",
-                "normalize-scroll-left": "^0.2.0",
-                "popper.js": "^1.14.1",
-                "prop-types": "^15.7.2",
-                "react-transition-group": "^4.3.0"
+                "@babel/runtime": "7.6.2",
+                "@material-ui/styles": "4.5.0",
+                "@material-ui/system": "4.5.0",
+                "@material-ui/types": "4.1.1",
+                "@material-ui/utils": "4.4.0",
+                "@types/react-transition-group": "4.2.2",
+                "clsx": "1.0.4",
+                "convert-css-length": "2.0.1",
+                "deepmerge": "4.0.0",
+                "hoist-non-react-statics": "3.3.0",
+                "is-plain-object": "3.0.0",
+                "normalize-scroll-left": "0.2.0",
+                "popper.js": "1.15.0",
+                "prop-types": "15.7.2",
+                "react-transition-group": "4.3.0"
             }
         },
         "@material-ui/styles": {
@@ -1092,23 +1093,23 @@
             "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.5.0.tgz",
             "integrity": "sha512-O0NSAECHK9f3DZK6wy56PZzp8b/7KSdfpJs8DSC7vnXUAoMPCTtchBKLzMtUsNlijiJFeJjSxNdQfjWXgyur5A==",
             "requires": {
-                "@babel/runtime": "^7.4.4",
-                "@emotion/hash": "^0.7.1",
-                "@material-ui/types": "^4.1.1",
-                "@material-ui/utils": "^4.1.0",
-                "clsx": "^1.0.2",
-                "csstype": "^2.5.2",
-                "deepmerge": "^4.0.0",
-                "hoist-non-react-statics": "^3.2.1",
-                "jss": "^10.0.0",
-                "jss-plugin-camel-case": "^10.0.0",
-                "jss-plugin-default-unit": "^10.0.0",
-                "jss-plugin-global": "^10.0.0",
-                "jss-plugin-nested": "^10.0.0",
-                "jss-plugin-props-sort": "^10.0.0",
-                "jss-plugin-rule-value-function": "^10.0.0",
-                "jss-plugin-vendor-prefixer": "^10.0.0",
-                "prop-types": "^15.7.2"
+                "@babel/runtime": "7.6.2",
+                "@emotion/hash": "0.7.3",
+                "@material-ui/types": "4.1.1",
+                "@material-ui/utils": "4.4.0",
+                "clsx": "1.0.4",
+                "csstype": "2.6.6",
+                "deepmerge": "4.0.0",
+                "hoist-non-react-statics": "3.3.0",
+                "jss": "10.0.0",
+                "jss-plugin-camel-case": "10.0.0",
+                "jss-plugin-default-unit": "10.0.0",
+                "jss-plugin-global": "10.0.0",
+                "jss-plugin-nested": "10.0.0",
+                "jss-plugin-props-sort": "10.0.0",
+                "jss-plugin-rule-value-function": "10.0.0",
+                "jss-plugin-vendor-prefixer": "10.0.0",
+                "prop-types": "15.7.2"
             }
         },
         "@material-ui/system": {
@@ -1116,9 +1117,9 @@
             "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.5.0.tgz",
             "integrity": "sha512-vR0PbMTzLnuuVCoYNQ13zyhLa/4s/UA9P9JbNuHBOOkfrHn53ShINiG0v05EgfwizfULLtc7mNvsGAgIyyp/hQ==",
             "requires": {
-                "@babel/runtime": "^7.4.4",
-                "deepmerge": "^4.0.0",
-                "prop-types": "^15.7.2"
+                "@babel/runtime": "7.6.2",
+                "deepmerge": "4.0.0",
+                "prop-types": "15.7.2"
             }
         },
         "@material-ui/types": {
@@ -1126,7 +1127,7 @@
             "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-4.1.1.tgz",
             "integrity": "sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==",
             "requires": {
-                "@types/react": "*"
+                "@types/react": "16.9.4"
             }
         },
         "@material-ui/utils": {
@@ -1134,10 +1135,16 @@
             "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.4.0.tgz",
             "integrity": "sha512-UXoQVwArQEQWXxf2FPs0iJGT+MePQpKr0Qh0CPoLc1OdF0GSMTmQczcqCzwZkeHxHAOq/NkIKM1Pb/ih1Avicg==",
             "requires": {
-                "@babel/runtime": "^7.4.4",
-                "prop-types": "^15.7.2",
-                "react-is": "^16.8.6"
+                "@babel/runtime": "7.6.2",
+                "prop-types": "15.7.2",
+                "react-is": "16.10.1"
             }
+        },
+        "@plotly/webpack-dash-dynamic-import": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@plotly/webpack-dash-dynamic-import/-/webpack-dash-dynamic-import-1.1.1.tgz",
+            "integrity": "sha512-Yrc7XZOMQuyh2TkbEMr3i6hfdAS/DMFDfvhdD3C28/G6aRWfPRTZ2Tb+IeyOhZTX41IoNmJ6YciLooME8zP5ag==",
+            "dev": true
         },
         "@shellscape/koa-send": {
             "version": "4.1.3",
@@ -1145,10 +1152,10 @@
             "integrity": "sha512-akNxJetq2ak8aj7U6ys+EYXfWY4k8keleDZJbHWvpuVDj0/PUbbOuPkeBYaie7C6d5fRNLK+0M1Puu8ywTlj3w==",
             "dev": true,
             "requires": {
-                "debug": "^2.6.3",
-                "http-errors": "^1.6.1",
-                "mz": "^2.6.0",
-                "resolve-path": "^1.3.3"
+                "debug": "2.6.9",
+                "http-errors": "1.7.3",
+                "mz": "2.7.0",
+                "resolve-path": "1.4.0"
             },
             "dependencies": {
                 "debug": {
@@ -1174,8 +1181,8 @@
             "integrity": "sha512-0T2g2NtaO2zhbqR8EBACIGtBy+haodKb8PuJ17RGDXAJwhjkgghUKLrLEnm05zuiwupfYm2APIax6D2TwLoflA==",
             "dev": true,
             "requires": {
-                "@shellscape/koa-send": "^4.1.0",
-                "debug": "^2.6.8"
+                "@shellscape/koa-send": "4.1.3",
+                "debug": "2.6.9"
             },
             "dependencies": {
                 "debug": {
@@ -1201,11 +1208,11 @@
             "integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
             "dev": true,
             "requires": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0",
-                "@types/babel__generator": "*",
-                "@types/babel__template": "*",
-                "@types/babel__traverse": "*"
+                "@babel/parser": "7.6.2",
+                "@babel/types": "7.6.1",
+                "@types/babel__generator": "7.6.0",
+                "@types/babel__template": "7.0.2",
+                "@types/babel__traverse": "7.0.7"
             }
         },
         "@types/babel__generator": {
@@ -1214,7 +1221,7 @@
             "integrity": "sha512-c1mZUu4up5cp9KROs/QAw0gTeHrw/x7m52LcnvMxxOZ03DmLwPV0MlGmlgzV3cnSdjhJOZsj7E7FHeioai+egw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.6.1"
             }
         },
         "@types/babel__template": {
@@ -1223,8 +1230,8 @@
             "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
             "dev": true,
             "requires": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/parser": "7.6.2",
+                "@babel/types": "7.6.1"
             }
         },
         "@types/babel__traverse": {
@@ -1233,7 +1240,7 @@
             "integrity": "sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.3.0"
+                "@babel/types": "7.6.1"
             }
         },
         "@types/istanbul-lib-coverage": {
@@ -1248,7 +1255,7 @@
             "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
             "dev": true,
             "requires": {
-                "@types/istanbul-lib-coverage": "*"
+                "@types/istanbul-lib-coverage": "2.0.1"
             }
         },
         "@types/istanbul-reports": {
@@ -1257,8 +1264,8 @@
             "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
             "dev": true,
             "requires": {
-                "@types/istanbul-lib-coverage": "*",
-                "@types/istanbul-lib-report": "*"
+                "@types/istanbul-lib-coverage": "2.0.1",
+                "@types/istanbul-lib-report": "1.1.1"
             }
         },
         "@types/prop-types": {
@@ -1271,8 +1278,8 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.4.tgz",
             "integrity": "sha512-ItGNmJvQ0IvWt8rbk5PLdpdQhvBVxAaXI9hDlx7UMd8Ie1iMIuwMNiKeTfmVN517CdplpyXvA22X4zm4jGGZnw==",
             "requires": {
-                "@types/prop-types": "*",
-                "csstype": "^2.2.0"
+                "@types/prop-types": "15.7.3",
+                "csstype": "2.6.6"
             }
         },
         "@types/react-transition-group": {
@@ -1280,7 +1287,7 @@
             "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.2.2.tgz",
             "integrity": "sha512-YfoaTNqBwbIqpiJ5NNfxfgg5kyFP1Hqf/jqBtSWNv0E+EkkxmN+3VD6U2fu86tlQvdAc1o0SdWhnWFwcRMTn9A==",
             "requires": {
-                "@types/react": "*"
+                "@types/react": "16.9.4"
             }
         },
         "@types/stack-utils": {
@@ -1295,7 +1302,7 @@
             "integrity": "sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==",
             "dev": true,
             "requires": {
-                "@types/yargs-parser": "*"
+                "@types/yargs-parser": "13.1.0"
             }
         },
         "@types/yargs-parser": {
@@ -1355,7 +1362,7 @@
             "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.8.5",
-                "mamacro": "^0.0.3"
+                "mamacro": "0.0.3"
             }
         },
         "@webassemblyjs/helper-wasm-bytecode": {
@@ -1382,7 +1389,7 @@
             "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
             "dev": true,
             "requires": {
-                "@xtuc/ieee754": "^1.2.0"
+                "@xtuc/ieee754": "1.2.0"
             }
         },
         "@webassemblyjs/leb128": {
@@ -1486,15 +1493,15 @@
             "integrity": "sha512-C7XsS6bXft0aRlyt7YCLg+fm97Mb3tWd+i5fVVlEl0NW5HKy8LoXVKj3mB7ECcEHNEEdHhgzg8gxP+Or8cMj8Q==",
             "dev": true,
             "requires": {
-                "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
-                "chalk": "^2.1.0",
-                "cosmiconfig": "^5.0.2",
-                "is-plain-obj": "^1.1.0",
-                "loud-rejection": "^1.6.0",
-                "merge-options": "^1.0.1",
-                "minimist": "^1.2.0",
-                "resolve": "^1.6.0",
-                "webpack-log": "^1.1.2"
+                "@webpack-contrib/schema-utils": "1.0.0-beta.0",
+                "chalk": "2.4.2",
+                "cosmiconfig": "5.2.1",
+                "is-plain-obj": "1.1.0",
+                "loud-rejection": "1.6.0",
+                "merge-options": "1.0.1",
+                "minimist": "1.2.0",
+                "resolve": "1.12.0",
+                "webpack-log": "1.2.0"
             }
         },
         "@webpack-contrib/schema-utils": {
@@ -1503,12 +1510,12 @@
             "integrity": "sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==",
             "dev": true,
             "requires": {
-                "ajv": "^6.1.0",
-                "ajv-keywords": "^3.1.0",
-                "chalk": "^2.3.2",
-                "strip-ansi": "^4.0.0",
-                "text-table": "^0.2.0",
-                "webpack-log": "^1.1.2"
+                "ajv": "6.10.2",
+                "ajv-keywords": "3.4.1",
+                "chalk": "2.4.2",
+                "strip-ansi": "4.0.0",
+                "text-table": "0.2.0",
+                "webpack-log": "1.2.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -1523,7 +1530,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -1552,7 +1559,7 @@
             "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
             "dev": true,
             "requires": {
-                "mime-types": "~2.1.24",
+                "mime-types": "2.1.24",
                 "negotiator": "0.6.2"
             }
         },
@@ -1568,8 +1575,8 @@
             "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
             "dev": true,
             "requires": {
-                "acorn": "^6.0.1",
-                "acorn-walk": "^6.0.1"
+                "acorn": "6.3.0",
+                "acorn-walk": "6.2.0"
             }
         },
         "acorn-jsx": {
@@ -1590,10 +1597,10 @@
             "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
             "dev": true,
             "requires": {
-                "fast-deep-equal": "^2.0.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
+                "fast-deep-equal": "2.0.1",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.4.1",
+                "uri-js": "4.2.2"
             }
         },
         "ajv-errors": {
@@ -1614,7 +1621,7 @@
             "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
             "dev": true,
             "requires": {
-                "string-width": "^2.0.0"
+                "string-width": "2.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -1629,8 +1636,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -1639,7 +1646,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -1668,7 +1675,7 @@
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
             "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.3"
             }
         },
         "any-promise": {
@@ -1683,8 +1690,8 @@
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "dev": true,
             "requires": {
-                "micromatch": "^3.1.4",
-                "normalize-path": "^2.1.1"
+                "micromatch": "3.1.10",
+                "normalize-path": "2.1.1"
             },
             "dependencies": {
                 "normalize-path": {
@@ -1693,7 +1700,7 @@
                     "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
                     "dev": true,
                     "requires": {
-                        "remove-trailing-separator": "^1.0.1"
+                        "remove-trailing-separator": "1.1.0"
                     }
                 }
             }
@@ -1722,7 +1729,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             }
         },
         "arr-diff": {
@@ -1761,8 +1768,8 @@
             "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.7.0"
+                "define-properties": "1.1.3",
+                "es-abstract": "1.14.2"
             }
         },
         "array-unique": {
@@ -1783,7 +1790,7 @@
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "dev": true,
             "requires": {
-                "safer-buffer": "~2.1.0"
+                "safer-buffer": "2.1.2"
             }
         },
         "asn1.js": {
@@ -1792,9 +1799,9 @@
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "bn.js": "4.11.8",
+                "inherits": "2.0.4",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "assert": {
@@ -1803,7 +1810,7 @@
             "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
             "dev": true,
             "requires": {
-                "object-assign": "^4.1.1",
+                "object-assign": "4.1.1",
                 "util": "0.10.3"
             },
             "dependencies": {
@@ -1860,7 +1867,7 @@
             "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.14"
+                "lodash": "4.17.15"
             }
         },
         "async-each": {
@@ -1905,12 +1912,12 @@
             "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.0.0",
-                "@babel/traverse": "^7.0.0",
-                "@babel/types": "^7.0.0",
+                "@babel/code-frame": "7.5.5",
+                "@babel/parser": "7.6.2",
+                "@babel/traverse": "7.6.2",
+                "@babel/types": "7.6.1",
                 "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "^1.0.0"
+                "eslint-visitor-keys": "1.1.0"
             }
         },
         "babel-jest": {
@@ -1919,13 +1926,13 @@
             "integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
             "dev": true,
             "requires": {
-                "@jest/transform": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "@types/babel__core": "^7.1.0",
-                "babel-plugin-istanbul": "^5.1.0",
-                "babel-preset-jest": "^24.9.0",
-                "chalk": "^2.4.2",
-                "slash": "^2.0.0"
+                "@jest/transform": "24.9.0",
+                "@jest/types": "24.9.0",
+                "@types/babel__core": "7.1.3",
+                "babel-plugin-istanbul": "5.2.0",
+                "babel-preset-jest": "24.9.0",
+                "chalk": "2.4.2",
+                "slash": "2.0.0"
             }
         },
         "babel-loader": {
@@ -1934,10 +1941,10 @@
             "integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
             "dev": true,
             "requires": {
-                "find-cache-dir": "^2.0.0",
-                "loader-utils": "^1.0.2",
-                "mkdirp": "^0.5.1",
-                "pify": "^4.0.1"
+                "find-cache-dir": "2.1.0",
+                "loader-utils": "1.2.3",
+                "mkdirp": "0.5.1",
+                "pify": "4.0.1"
             }
         },
         "babel-plugin-dynamic-import-node": {
@@ -1946,7 +1953,7 @@
             "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
             "dev": true,
             "requires": {
-                "object.assign": "^4.1.0"
+                "object.assign": "4.1.0"
             }
         },
         "babel-plugin-istanbul": {
@@ -1955,10 +1962,10 @@
             "integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "find-up": "^3.0.0",
-                "istanbul-lib-instrument": "^3.3.0",
-                "test-exclude": "^5.2.3"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "find-up": "3.0.0",
+                "istanbul-lib-instrument": "3.3.0",
+                "test-exclude": "5.2.3"
             }
         },
         "babel-plugin-jest-hoist": {
@@ -1967,7 +1974,7 @@
             "integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
             "dev": true,
             "requires": {
-                "@types/babel__traverse": "^7.0.6"
+                "@types/babel__traverse": "7.0.7"
             }
         },
         "babel-preset-jest": {
@@ -1976,8 +1983,8 @@
             "integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
             "dev": true,
             "requires": {
-                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-                "babel-plugin-jest-hoist": "^24.9.0"
+                "@babel/plugin-syntax-object-rest-spread": "7.2.0",
+                "babel-plugin-jest-hoist": "24.9.0"
             }
         },
         "babel-runtime": {
@@ -1986,8 +1993,8 @@
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
+                "core-js": "2.6.9",
+                "regenerator-runtime": "0.11.1"
             },
             "dependencies": {
                 "regenerator-runtime": {
@@ -2016,13 +2023,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "^1.0.1",
-                "class-utils": "^0.3.5",
-                "component-emitter": "^1.2.1",
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.1",
-                "mixin-deep": "^1.2.0",
-                "pascalcase": "^0.1.1"
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.3.0",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.2",
+                "pascalcase": "0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -2031,7 +2038,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -2040,7 +2047,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -2049,7 +2056,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -2058,9 +2065,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "isobject": {
@@ -2083,7 +2090,7 @@
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "dev": true,
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "big.js": {
@@ -2116,13 +2123,13 @@
             "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
             "dev": true,
             "requires": {
-                "ansi-align": "^2.0.0",
-                "camelcase": "^4.0.0",
-                "chalk": "^2.0.1",
-                "cli-boxes": "^1.0.0",
-                "string-width": "^2.0.0",
-                "term-size": "^1.2.0",
-                "widest-line": "^2.0.0"
+                "ansi-align": "2.0.0",
+                "camelcase": "4.1.0",
+                "chalk": "2.4.2",
+                "cli-boxes": "1.0.0",
+                "string-width": "2.1.1",
+                "term-size": "1.2.0",
+                "widest-line": "2.0.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -2143,8 +2150,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -2153,7 +2160,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -2164,7 +2171,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -2174,16 +2181,16 @@
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "dev": true,
             "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.3",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -2192,7 +2199,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "isobject": {
@@ -2238,12 +2245,12 @@
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
-                "buffer-xor": "^1.0.3",
-                "cipher-base": "^1.0.0",
-                "create-hash": "^1.1.0",
-                "evp_bytestokey": "^1.0.3",
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "buffer-xor": "1.0.3",
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "evp_bytestokey": "1.0.3",
+                "inherits": "2.0.4",
+                "safe-buffer": "5.1.2"
             }
         },
         "browserify-cipher": {
@@ -2252,9 +2259,9 @@
             "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
             "dev": true,
             "requires": {
-                "browserify-aes": "^1.0.4",
-                "browserify-des": "^1.0.0",
-                "evp_bytestokey": "^1.0.0"
+                "browserify-aes": "1.2.0",
+                "browserify-des": "1.0.2",
+                "evp_bytestokey": "1.0.3"
             }
         },
         "browserify-des": {
@@ -2263,10 +2270,10 @@
             "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
             "dev": true,
             "requires": {
-                "cipher-base": "^1.0.1",
-                "des.js": "^1.0.0",
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.1.2"
+                "cipher-base": "1.0.4",
+                "des.js": "1.0.0",
+                "inherits": "2.0.4",
+                "safe-buffer": "5.1.2"
             }
         },
         "browserify-rsa": {
@@ -2275,8 +2282,8 @@
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "randombytes": "^2.0.1"
+                "bn.js": "4.11.8",
+                "randombytes": "2.1.0"
             }
         },
         "browserify-sign": {
@@ -2285,13 +2292,13 @@
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.1",
-                "browserify-rsa": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.2",
-                "elliptic": "^6.0.0",
-                "inherits": "^2.0.1",
-                "parse-asn1": "^5.0.0"
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "elliptic": "6.5.1",
+                "inherits": "2.0.4",
+                "parse-asn1": "5.1.5"
             }
         },
         "browserify-zlib": {
@@ -2300,7 +2307,7 @@
             "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
             "dev": true,
             "requires": {
-                "pako": "~1.0.5"
+                "pako": "1.0.10"
             }
         },
         "browserslist": {
@@ -2309,9 +2316,9 @@
             "integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30000989",
-                "electron-to-chromium": "^1.3.247",
-                "node-releases": "^1.1.29"
+                "caniuse-lite": "1.0.30000998",
+                "electron-to-chromium": "1.3.273",
+                "node-releases": "1.1.33"
             }
         },
         "bser": {
@@ -2320,7 +2327,7 @@
             "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
             "dev": true,
             "requires": {
-                "node-int64": "^0.4.0"
+                "node-int64": "0.4.0"
             }
         },
         "buffer": {
@@ -2329,9 +2336,9 @@
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "dev": true,
             "requires": {
-                "base64-js": "^1.0.2",
-                "ieee754": "^1.1.4",
-                "isarray": "^1.0.0"
+                "base64-js": "1.3.1",
+                "ieee754": "1.1.13",
+                "isarray": "1.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -2366,21 +2373,21 @@
             "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
             "dev": true,
             "requires": {
-                "bluebird": "^3.5.5",
-                "chownr": "^1.1.1",
-                "figgy-pudding": "^3.5.1",
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.1.15",
-                "infer-owner": "^1.0.3",
-                "lru-cache": "^5.1.1",
-                "mississippi": "^3.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.3",
-                "ssri": "^6.0.1",
-                "unique-filename": "^1.1.1",
-                "y18n": "^4.0.0"
+                "bluebird": "3.7.0",
+                "chownr": "1.1.3",
+                "figgy-pudding": "3.5.1",
+                "glob": "7.1.4",
+                "graceful-fs": "4.2.2",
+                "infer-owner": "1.0.4",
+                "lru-cache": "5.1.1",
+                "mississippi": "3.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.3",
+                "ssri": "6.0.1",
+                "unique-filename": "1.1.1",
+                "y18n": "4.0.0"
             }
         },
         "cache-base": {
@@ -2389,15 +2396,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "^1.0.0",
-                "component-emitter": "^1.2.1",
-                "get-value": "^2.0.6",
-                "has-value": "^1.0.0",
-                "isobject": "^3.0.1",
-                "set-value": "^2.0.0",
-                "to-object-path": "^0.3.0",
-                "union-value": "^1.0.0",
-                "unset-value": "^1.0.0"
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.3.0",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.1",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.1",
+                "unset-value": "1.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -2414,8 +2421,8 @@
             "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
             "dev": true,
             "requires": {
-                "mime-types": "^2.1.18",
-                "ylru": "^1.2.0"
+                "mime-types": "2.1.24",
+                "ylru": "1.2.1"
             }
         },
         "caller-callsite": {
@@ -2424,7 +2431,7 @@
             "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
             "dev": true,
             "requires": {
-                "callsites": "^2.0.0"
+                "callsites": "2.0.0"
             },
             "dependencies": {
                 "callsites": {
@@ -2441,7 +2448,7 @@
             "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
             "dev": true,
             "requires": {
-                "caller-callsite": "^2.0.0"
+                "caller-callsite": "2.0.0"
             }
         },
         "callsites": {
@@ -2462,9 +2469,9 @@
             "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
             "dev": true,
             "requires": {
-                "camelcase": "^4.1.0",
-                "map-obj": "^2.0.0",
-                "quick-lru": "^1.0.0"
+                "camelcase": "4.1.0",
+                "map-obj": "2.0.0",
+                "quick-lru": "1.1.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -2487,7 +2494,7 @@
             "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
             "dev": true,
             "requires": {
-                "rsvp": "^4.8.4"
+                "rsvp": "4.8.5"
             }
         },
         "capture-stack-trace": {
@@ -2508,12 +2515,12 @@
             "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
             "dev": true,
             "requires": {
-                "assertion-error": "^1.1.0",
-                "check-error": "^1.0.2",
-                "deep-eql": "^3.0.1",
-                "get-func-name": "^2.0.0",
-                "pathval": "^1.1.0",
-                "type-detect": "^4.0.5"
+                "assertion-error": "1.1.0",
+                "check-error": "1.0.2",
+                "deep-eql": "3.0.1",
+                "get-func-name": "2.0.0",
+                "pathval": "1.1.0",
+                "type-detect": "4.0.8"
             }
         },
         "chalk": {
@@ -2522,9 +2529,9 @@
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.5.0"
             }
         },
         "chardet": {
@@ -2545,18 +2552,18 @@
             "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
             "dev": true,
             "requires": {
-                "anymatch": "^2.0.0",
-                "async-each": "^1.0.1",
-                "braces": "^2.3.2",
-                "fsevents": "^1.2.7",
-                "glob-parent": "^3.1.0",
-                "inherits": "^2.0.3",
-                "is-binary-path": "^1.0.0",
-                "is-glob": "^4.0.0",
-                "normalize-path": "^3.0.0",
-                "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.2.1",
-                "upath": "^1.1.1"
+                "anymatch": "2.0.0",
+                "async-each": "1.0.3",
+                "braces": "2.3.2",
+                "fsevents": "1.2.9",
+                "glob-parent": "3.1.0",
+                "inherits": "2.0.4",
+                "is-binary-path": "1.0.1",
+                "is-glob": "4.0.1",
+                "normalize-path": "3.0.0",
+                "path-is-absolute": "1.0.1",
+                "readdirp": "2.2.1",
+                "upath": "1.2.0"
             }
         },
         "chownr": {
@@ -2571,7 +2578,7 @@
             "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
             "dev": true,
             "requires": {
-                "tslib": "^1.9.0"
+                "tslib": "1.10.0"
             }
         },
         "ci-info": {
@@ -2586,8 +2593,8 @@
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.4",
+                "safe-buffer": "5.1.2"
             }
         },
         "class-utils": {
@@ -2596,10 +2603,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "^3.1.0",
-                "define-property": "^0.2.5",
-                "isobject": "^3.0.0",
-                "static-extend": "^0.1.1"
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
             },
             "dependencies": {
                 "define-property": {
@@ -2608,7 +2615,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "isobject": {
@@ -2631,7 +2638,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "^2.0.0"
+                "restore-cursor": "2.0.0"
             }
         },
         "cli-width": {
@@ -2646,8 +2653,8 @@
             "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
             "dev": true,
             "requires": {
-                "arch": "^2.1.0",
-                "execa": "^0.8.0"
+                "arch": "2.1.1",
+                "execa": "0.8.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -2656,9 +2663,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^4.0.1",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
+                        "lru-cache": "4.1.5",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.1"
                     }
                 },
                 "execa": {
@@ -2667,13 +2674,13 @@
                     "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                     }
                 },
                 "get-stream": {
@@ -2688,8 +2695,8 @@
                     "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
                     }
                 },
                 "yallist": {
@@ -2706,9 +2713,9 @@
             "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
             "dev": true,
             "requires": {
-                "string-width": "^3.1.0",
-                "strip-ansi": "^5.2.0",
-                "wrap-ansi": "^5.1.0"
+                "string-width": "3.1.0",
+                "strip-ansi": "5.2.0",
+                "wrap-ansi": "5.1.0"
             }
         },
         "clsx": {
@@ -2728,8 +2735,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "^1.0.0",
-                "object-visit": "^1.0.0"
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
             }
         },
         "color-convert": {
@@ -2753,7 +2760,7 @@
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "dev": true,
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
@@ -2785,10 +2792,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "buffer-from": "1.1.1",
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
             },
             "dependencies": {
                 "isarray": {
@@ -2803,13 +2810,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -2818,7 +2825,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -2829,12 +2836,12 @@
             "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
             "dev": true,
             "requires": {
-                "dot-prop": "^4.1.0",
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^1.0.0",
-                "unique-string": "^1.0.0",
-                "write-file-atomic": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
+                "dot-prop": "4.2.0",
+                "graceful-fs": "4.2.2",
+                "make-dir": "1.3.0",
+                "unique-string": "1.0.0",
+                "write-file-atomic": "2.4.1",
+                "xdg-basedir": "3.0.0"
             },
             "dependencies": {
                 "make-dir": {
@@ -2843,7 +2850,7 @@
                     "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
                     "dev": true,
                     "requires": {
-                        "pify": "^3.0.0"
+                        "pify": "3.0.0"
                     }
                 },
                 "pify": {
@@ -2860,7 +2867,7 @@
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
             "dev": true,
             "requires": {
-                "date-now": "^0.1.4"
+                "date-now": "0.1.4"
             }
         },
         "constants-browserify": {
@@ -2901,7 +2908,7 @@
             "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "~5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "cookies": {
@@ -2910,8 +2917,8 @@
             "integrity": "sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==",
             "dev": true,
             "requires": {
-                "depd": "~1.1.2",
-                "keygrip": "~1.0.3"
+                "depd": "1.1.2",
+                "keygrip": "1.0.3"
             }
         },
         "copy-concurrently": {
@@ -2920,12 +2927,12 @@
             "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1",
-                "fs-write-stream-atomic": "^1.0.8",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.0"
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.3",
+                "run-queue": "1.0.3"
             }
         },
         "copy-descriptor": {
@@ -2940,12 +2947,12 @@
             "integrity": "sha512-y6DZHve80whydXzBal7r70TBgKMPKesVRR1Sn/raUu7Jh/i7iSLSyGvYaq0eMJ/3Y/CKghwzjY32q1WzEnpp3Q==",
             "dev": true,
             "requires": {
-                "glob": "^7.0.5",
-                "minimatch": "^3.0.3",
-                "mkdirp": "^0.5.1",
+                "glob": "7.1.4",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
                 "noms": "0.0.0",
-                "through2": "^2.0.1",
-                "yargs": "^13.2.4"
+                "through2": "2.0.5",
+                "yargs": "13.3.0"
             }
         },
         "core-js": {
@@ -2960,8 +2967,8 @@
             "integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.6.6",
-                "semver": "^6.3.0"
+                "browserslist": "4.7.0",
+                "semver": "6.3.0"
             },
             "dependencies": {
                 "semver": {
@@ -2984,10 +2991,10 @@
             "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
             "dev": true,
             "requires": {
-                "import-fresh": "^2.0.0",
-                "is-directory": "^0.3.1",
-                "js-yaml": "^3.13.1",
-                "parse-json": "^4.0.0"
+                "import-fresh": "2.0.0",
+                "is-directory": "0.3.1",
+                "js-yaml": "3.13.1",
+                "parse-json": "4.0.0"
             },
             "dependencies": {
                 "import-fresh": {
@@ -2996,8 +3003,8 @@
                     "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
                     "dev": true,
                     "requires": {
-                        "caller-path": "^2.0.0",
-                        "resolve-from": "^3.0.0"
+                        "caller-path": "2.0.0",
+                        "resolve-from": "3.0.0"
                     }
                 },
                 "parse-json": {
@@ -3006,8 +3013,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "^1.3.1",
-                        "json-parse-better-errors": "^1.0.1"
+                        "error-ex": "1.3.2",
+                        "json-parse-better-errors": "1.0.2"
                     }
                 },
                 "resolve-from": {
@@ -3024,8 +3031,8 @@
             "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "elliptic": "^6.0.0"
+                "bn.js": "4.11.8",
+                "elliptic": "6.5.1"
             }
         },
         "create-error-class": {
@@ -3034,7 +3041,7 @@
             "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
             "dev": true,
             "requires": {
-                "capture-stack-trace": "^1.0.0"
+                "capture-stack-trace": "1.0.1"
             }
         },
         "create-hash": {
@@ -3043,11 +3050,11 @@
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
-                "cipher-base": "^1.0.1",
-                "inherits": "^2.0.1",
-                "md5.js": "^1.3.4",
-                "ripemd160": "^2.0.1",
-                "sha.js": "^2.4.0"
+                "cipher-base": "1.0.4",
+                "inherits": "2.0.4",
+                "md5.js": "1.3.5",
+                "ripemd160": "2.0.2",
+                "sha.js": "2.4.11"
             }
         },
         "create-hmac": {
@@ -3056,12 +3063,12 @@
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
-                "cipher-base": "^1.0.3",
-                "create-hash": "^1.1.0",
-                "inherits": "^2.0.1",
-                "ripemd160": "^2.0.0",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "inherits": "2.0.4",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
+                "sha.js": "2.4.11"
             }
         },
         "cross-spawn": {
@@ -3070,11 +3077,11 @@
             "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "dev": true,
             "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "nice-try": "1.0.5",
+                "path-key": "2.0.1",
+                "semver": "5.7.1",
+                "shebang-command": "1.2.0",
+                "which": "1.3.1"
             }
         },
         "crypto-browserify": {
@@ -3083,17 +3090,17 @@
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
             "requires": {
-                "browserify-cipher": "^1.0.0",
-                "browserify-sign": "^4.0.0",
-                "create-ecdh": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.0",
-                "diffie-hellman": "^5.0.0",
-                "inherits": "^2.0.1",
-                "pbkdf2": "^3.0.3",
-                "public-encrypt": "^4.0.0",
-                "randombytes": "^2.0.0",
-                "randomfill": "^1.0.3"
+                "browserify-cipher": "1.0.1",
+                "browserify-sign": "4.0.4",
+                "create-ecdh": "4.0.3",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "diffie-hellman": "5.0.3",
+                "inherits": "2.0.4",
+                "pbkdf2": "3.0.17",
+                "public-encrypt": "4.0.3",
+                "randombytes": "2.1.0",
+                "randomfill": "1.0.4"
             }
         },
         "crypto-random-string": {
@@ -3108,17 +3115,17 @@
             "integrity": "sha512-OcKJU/lt232vl1P9EEDamhoO9iKY3tIjY5GU+XDLblAykTdgs6Ux9P1hTHve8nFKy5KPpOXOsVI/hIwi3841+w==",
             "dev": true,
             "requires": {
-                "camelcase": "^5.2.0",
-                "icss-utils": "^4.1.0",
-                "loader-utils": "^1.2.3",
-                "normalize-path": "^3.0.0",
-                "postcss": "^7.0.14",
-                "postcss-modules-extract-imports": "^2.0.0",
-                "postcss-modules-local-by-default": "^2.0.6",
-                "postcss-modules-scope": "^2.1.0",
-                "postcss-modules-values": "^2.0.0",
-                "postcss-value-parser": "^3.3.0",
-                "schema-utils": "^1.0.0"
+                "camelcase": "5.3.1",
+                "icss-utils": "4.1.1",
+                "loader-utils": "1.2.3",
+                "normalize-path": "3.0.0",
+                "postcss": "7.0.18",
+                "postcss-modules-extract-imports": "2.0.0",
+                "postcss-modules-local-by-default": "2.0.6",
+                "postcss-modules-scope": "2.1.0",
+                "postcss-modules-values": "2.0.0",
+                "postcss-value-parser": "3.3.1",
+                "schema-utils": "1.0.0"
             }
         },
         "css-vendor": {
@@ -3126,8 +3133,8 @@
             "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.6.tgz",
             "integrity": "sha512-buv8FoZh84iMrtPHYGYll00/qSNV0gYO6E/GUCjUPTsSPj7uf/wot/QZwig+7qdFGxJ7HjOSJoclbhag09TVUQ==",
             "requires": {
-                "@babel/runtime": "^7.5.5",
-                "is-in-browser": "^1.0.2"
+                "@babel/runtime": "7.6.2",
+                "is-in-browser": "1.1.3"
             }
         },
         "cssesc": {
@@ -3148,7 +3155,7 @@
             "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
             "dev": true,
             "requires": {
-                "cssom": "0.3.x"
+                "cssom": "0.3.8"
             }
         },
         "csstype": {
@@ -3162,7 +3169,7 @@
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "dev": true,
             "requires": {
-                "array-find-index": "^1.0.1"
+                "array-find-index": "1.0.2"
             }
         },
         "cyclist": {
@@ -3177,8 +3184,8 @@
             "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
             "dev": true,
             "requires": {
-                "es5-ext": "^0.10.50",
-                "type": "^1.0.1"
+                "es5-ext": "0.10.51",
+                "type": "1.2.0"
             }
         },
         "d3": {
@@ -3186,37 +3193,37 @@
             "resolved": "https://registry.npmjs.org/d3/-/d3-5.12.0.tgz",
             "integrity": "sha512-flYVMoVuhPFHd9zVCe2BxIszUWqBcd5fvQGMNRmSiBrgdnh6Vlruh60RJQTouAK9xPbOB0plxMvBm4MoyODXNg==",
             "requires": {
-                "d3-array": "1",
-                "d3-axis": "1",
-                "d3-brush": "1",
-                "d3-chord": "1",
-                "d3-collection": "1",
-                "d3-color": "1",
-                "d3-contour": "1",
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-dsv": "1",
-                "d3-ease": "1",
-                "d3-fetch": "1",
-                "d3-force": "1",
-                "d3-format": "1",
-                "d3-geo": "1",
-                "d3-hierarchy": "1",
-                "d3-interpolate": "1",
-                "d3-path": "1",
-                "d3-polygon": "1",
-                "d3-quadtree": "1",
-                "d3-random": "1",
-                "d3-scale": "2",
-                "d3-scale-chromatic": "1",
-                "d3-selection": "1",
-                "d3-shape": "1",
-                "d3-time": "1",
-                "d3-time-format": "2",
-                "d3-timer": "1",
-                "d3-transition": "1",
-                "d3-voronoi": "1",
-                "d3-zoom": "1"
+                "d3-array": "1.2.4",
+                "d3-axis": "1.0.12",
+                "d3-brush": "1.1.3",
+                "d3-chord": "1.0.6",
+                "d3-collection": "1.0.7",
+                "d3-color": "1.4.0",
+                "d3-contour": "1.3.2",
+                "d3-dispatch": "1.0.5",
+                "d3-drag": "1.2.4",
+                "d3-dsv": "1.1.1",
+                "d3-ease": "1.0.5",
+                "d3-fetch": "1.1.2",
+                "d3-force": "1.2.1",
+                "d3-format": "1.4.1",
+                "d3-geo": "1.11.6",
+                "d3-hierarchy": "1.1.8",
+                "d3-interpolate": "1.3.2",
+                "d3-path": "1.0.8",
+                "d3-polygon": "1.0.5",
+                "d3-quadtree": "1.0.6",
+                "d3-random": "1.1.2",
+                "d3-scale": "2.2.2",
+                "d3-scale-chromatic": "1.5.0",
+                "d3-selection": "1.4.0",
+                "d3-shape": "1.3.5",
+                "d3-time": "1.1.0",
+                "d3-time-format": "2.1.3",
+                "d3-timer": "1.0.9",
+                "d3-transition": "1.2.0",
+                "d3-voronoi": "1.1.4",
+                "d3-zoom": "1.8.3"
             }
         },
         "d3-array": {
@@ -3234,11 +3241,11 @@
             "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.3.tgz",
             "integrity": "sha512-v8bbYyCFKjyCzFk/tdWqXwDykY8YWqhXYjcYxfILIit085VZOpj4XJKOMccTsvWxgzSLMJQg5SiqHjslsipEDg==",
             "requires": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
+                "d3-dispatch": "1.0.5",
+                "d3-drag": "1.2.4",
+                "d3-interpolate": "1.3.2",
+                "d3-selection": "1.4.0",
+                "d3-transition": "1.2.0"
             }
         },
         "d3-chord": {
@@ -3246,8 +3253,8 @@
             "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.6.tgz",
             "integrity": "sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==",
             "requires": {
-                "d3-array": "1",
-                "d3-path": "1"
+                "d3-array": "1.2.4",
+                "d3-path": "1.0.8"
             }
         },
         "d3-collection": {
@@ -3265,7 +3272,7 @@
             "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-1.3.2.tgz",
             "integrity": "sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==",
             "requires": {
-                "d3-array": "^1.1.1"
+                "d3-array": "1.2.4"
             }
         },
         "d3-dispatch": {
@@ -3278,8 +3285,8 @@
             "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.4.tgz",
             "integrity": "sha512-ICPurDETFAelF1CTHdIyiUM4PsyZLaM+7oIBhmyP+cuVjze5vDZ8V//LdOFjg0jGnFIZD/Sfmk0r95PSiu78rw==",
             "requires": {
-                "d3-dispatch": "1",
-                "d3-selection": "1"
+                "d3-dispatch": "1.0.5",
+                "d3-selection": "1.4.0"
             }
         },
         "d3-dsv": {
@@ -3287,9 +3294,9 @@
             "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.1.1.tgz",
             "integrity": "sha512-1EH1oRGSkeDUlDRbhsFytAXU6cAmXFzc52YUe6MRlPClmWb85MP1J5x+YJRzya4ynZWnbELdSAvATFW/MbxaXw==",
             "requires": {
-                "commander": "2",
-                "iconv-lite": "0.4",
-                "rw": "1"
+                "commander": "2.20.1",
+                "iconv-lite": "0.4.24",
+                "rw": "1.3.3"
             }
         },
         "d3-ease": {
@@ -3302,7 +3309,7 @@
             "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-1.1.2.tgz",
             "integrity": "sha512-S2loaQCV/ZeyTyIF2oP8D1K9Z4QizUzW7cWeAOAS4U88qOt3Ucf6GsmgthuYSdyB2HyEm4CeGvkQxWsmInsIVA==",
             "requires": {
-                "d3-dsv": "1"
+                "d3-dsv": "1.1.1"
             }
         },
         "d3-force": {
@@ -3310,10 +3317,10 @@
             "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
             "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
             "requires": {
-                "d3-collection": "1",
-                "d3-dispatch": "1",
-                "d3-quadtree": "1",
-                "d3-timer": "1"
+                "d3-collection": "1.0.7",
+                "d3-dispatch": "1.0.5",
+                "d3-quadtree": "1.0.6",
+                "d3-timer": "1.0.9"
             }
         },
         "d3-format": {
@@ -3326,7 +3333,7 @@
             "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.11.6.tgz",
             "integrity": "sha512-z0J8InXR9e9wcgNtmVnPTj0TU8nhYT6lD/ak9may2PdKqXIeHUr8UbFLoCtrPYNsjv6YaLvSDQVl578k6nm7GA==",
             "requires": {
-                "d3-array": "1"
+                "d3-array": "1.2.4"
             }
         },
         "d3-hierarchy": {
@@ -3339,7 +3346,7 @@
             "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.3.2.tgz",
             "integrity": "sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==",
             "requires": {
-                "d3-color": "1"
+                "d3-color": "1.4.0"
             }
         },
         "d3-path": {
@@ -3367,12 +3374,12 @@
             "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
             "integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
             "requires": {
-                "d3-array": "^1.2.0",
-                "d3-collection": "1",
-                "d3-format": "1",
-                "d3-interpolate": "1",
-                "d3-time": "1",
-                "d3-time-format": "2"
+                "d3-array": "1.2.4",
+                "d3-collection": "1.0.7",
+                "d3-format": "1.4.1",
+                "d3-interpolate": "1.3.2",
+                "d3-time": "1.1.0",
+                "d3-time-format": "2.1.3"
             }
         },
         "d3-scale-chromatic": {
@@ -3380,8 +3387,8 @@
             "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz",
             "integrity": "sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==",
             "requires": {
-                "d3-color": "1",
-                "d3-interpolate": "1"
+                "d3-color": "1.4.0",
+                "d3-interpolate": "1.3.2"
             }
         },
         "d3-selection": {
@@ -3394,7 +3401,7 @@
             "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.5.tgz",
             "integrity": "sha512-VKazVR3phgD+MUCldapHD7P9kcrvPcexeX/PkMJmkUov4JM8IxsSg1DvbYoYich9AtdTsa5nNk2++ImPiDiSxg==",
             "requires": {
-                "d3-path": "1"
+                "d3-path": "1.0.8"
             }
         },
         "d3-time": {
@@ -3407,7 +3414,7 @@
             "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.3.tgz",
             "integrity": "sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==",
             "requires": {
-                "d3-time": "1"
+                "d3-time": "1.1.0"
             }
         },
         "d3-timer": {
@@ -3420,12 +3427,12 @@
             "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.2.0.tgz",
             "integrity": "sha512-VJ7cmX/FPIPJYuaL2r1o1EMHLttvoIuZhhuAlRoOxDzogV8iQS6jYulDm3xEU3TqL80IZIhI551/ebmCMrkvhw==",
             "requires": {
-                "d3-color": "1",
-                "d3-dispatch": "1",
-                "d3-ease": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "^1.1.0",
-                "d3-timer": "1"
+                "d3-color": "1.4.0",
+                "d3-dispatch": "1.0.5",
+                "d3-ease": "1.0.5",
+                "d3-interpolate": "1.3.2",
+                "d3-selection": "1.4.0",
+                "d3-timer": "1.0.9"
             }
         },
         "d3-voronoi": {
@@ -3438,11 +3445,11 @@
             "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.8.3.tgz",
             "integrity": "sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==",
             "requires": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
+                "d3-dispatch": "1.0.5",
+                "d3-drag": "1.2.4",
+                "d3-interpolate": "1.3.2",
+                "d3-selection": "1.4.0",
+                "d3-transition": "1.2.0"
             }
         },
         "dashdash": {
@@ -3451,7 +3458,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "data-urls": {
@@ -3460,9 +3467,9 @@
             "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
             "dev": true,
             "requires": {
-                "abab": "^2.0.0",
-                "whatwg-mimetype": "^2.2.0",
-                "whatwg-url": "^7.0.0"
+                "abab": "2.0.2",
+                "whatwg-mimetype": "2.3.0",
+                "whatwg-url": "7.0.0"
             },
             "dependencies": {
                 "whatwg-url": {
@@ -3471,9 +3478,9 @@
                     "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
                     "dev": true,
                     "requires": {
-                        "lodash.sortby": "^4.7.0",
-                        "tr46": "^1.0.1",
-                        "webidl-conversions": "^4.0.2"
+                        "lodash.sortby": "4.7.0",
+                        "tr46": "1.0.1",
+                        "webidl-conversions": "4.0.2"
                     }
                 }
             }
@@ -3490,7 +3497,7 @@
             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
             "dev": true,
             "requires": {
-                "ms": "^2.1.1"
+                "ms": "2.1.2"
             }
         },
         "decamelize": {
@@ -3505,8 +3512,8 @@
             "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
             "dev": true,
             "requires": {
-                "decamelize": "^1.1.0",
-                "map-obj": "^1.0.0"
+                "decamelize": "1.2.0",
+                "map-obj": "1.0.1"
             },
             "dependencies": {
                 "map-obj": {
@@ -3529,7 +3536,7 @@
             "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
             "dev": true,
             "requires": {
-                "type-detect": "^4.0.0"
+                "type-detect": "4.0.8"
             }
         },
         "deep-equal": {
@@ -3561,7 +3568,7 @@
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "dev": true,
             "requires": {
-                "object-keys": "^1.0.12"
+                "object-keys": "1.1.1"
             }
         },
         "define-property": {
@@ -3570,8 +3577,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "^1.0.2",
-                "isobject": "^3.0.1"
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -3580,7 +3587,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -3589,7 +3596,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -3598,9 +3605,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "isobject": {
@@ -3635,8 +3642,8 @@
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "inherits": "2.0.4",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "destroy": {
@@ -3669,9 +3676,9 @@
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "miller-rabin": "^4.0.0",
-                "randombytes": "^2.0.0"
+                "bn.js": "4.11.8",
+                "miller-rabin": "4.0.1",
+                "randombytes": "2.1.0"
             }
         },
         "doctrine": {
@@ -3680,7 +3687,7 @@
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
             "requires": {
-                "esutils": "^2.0.2"
+                "esutils": "2.0.3"
             }
         },
         "dom-helpers": {
@@ -3688,8 +3695,8 @@
             "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.0.tgz",
             "integrity": "sha512-zRRYDhpiKuAJHasOqCm7lBnsd22nrM4+OYI4ASWCxen+ocTMl7BIAKgGag97TlLiTl6rrau5aPe1VGUm9jQBng==",
             "requires": {
-                "@babel/runtime": "^7.5.5",
-                "csstype": "^2.6.6"
+                "@babel/runtime": "7.6.2",
+                "csstype": "2.6.6"
             }
         },
         "domain-browser": {
@@ -3704,7 +3711,7 @@
             "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
             "dev": true,
             "requires": {
-                "webidl-conversions": "^4.0.2"
+                "webidl-conversions": "4.0.2"
             }
         },
         "dot-prop": {
@@ -3713,7 +3720,7 @@
             "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
             "dev": true,
             "requires": {
-                "is-obj": "^1.0.0"
+                "is-obj": "1.0.1"
             }
         },
         "duplexer3": {
@@ -3728,10 +3735,10 @@
             "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.4",
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -3746,13 +3753,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -3761,7 +3768,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -3772,8 +3779,8 @@
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "dev": true,
             "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2"
             }
         },
         "ee-first": {
@@ -3794,13 +3801,13 @@
             "integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.7",
+                "hmac-drbg": "1.0.1",
+                "inherits": "2.0.4",
+                "minimalistic-assert": "1.0.1",
+                "minimalistic-crypto-utils": "1.0.1"
             }
         },
         "emoji-regex": {
@@ -3827,7 +3834,7 @@
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "dev": true,
             "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
             }
         },
         "enhanced-resolve": {
@@ -3836,9 +3843,9 @@
             "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "memory-fs": "^0.4.0",
-                "tapable": "^1.0.0"
+                "graceful-fs": "4.2.2",
+                "memory-fs": "0.4.1",
+                "tapable": "1.1.3"
             }
         },
         "errno": {
@@ -3847,7 +3854,7 @@
             "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
             "dev": true,
             "requires": {
-                "prr": "~1.0.1"
+                "prr": "1.0.1"
             }
         },
         "error-ex": {
@@ -3856,7 +3863,7 @@
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "dev": true,
             "requires": {
-                "is-arrayish": "^0.2.1"
+                "is-arrayish": "0.2.1"
             }
         },
         "error-inject": {
@@ -3871,16 +3878,16 @@
             "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
             "dev": true,
             "requires": {
-                "es-to-primitive": "^1.2.0",
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.0",
-                "is-callable": "^1.1.4",
-                "is-regex": "^1.0.4",
-                "object-inspect": "^1.6.0",
-                "object-keys": "^1.1.1",
-                "string.prototype.trimleft": "^2.0.0",
-                "string.prototype.trimright": "^2.0.0"
+                "es-to-primitive": "1.2.0",
+                "function-bind": "1.1.1",
+                "has": "1.0.3",
+                "has-symbols": "1.0.0",
+                "is-callable": "1.1.4",
+                "is-regex": "1.0.4",
+                "object-inspect": "1.6.0",
+                "object-keys": "1.1.1",
+                "string.prototype.trimleft": "2.1.0",
+                "string.prototype.trimright": "2.1.0"
             }
         },
         "es-to-primitive": {
@@ -3889,9 +3896,9 @@
             "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
             "dev": true,
             "requires": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
+                "is-callable": "1.1.4",
+                "is-date-object": "1.0.1",
+                "is-symbol": "1.0.2"
             }
         },
         "es5-ext": {
@@ -3900,9 +3907,9 @@
             "integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
             "dev": true,
             "requires": {
-                "es6-iterator": "~2.0.3",
-                "es6-symbol": "~3.1.1",
-                "next-tick": "^1.0.0"
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.2",
+                "next-tick": "1.0.0"
             }
         },
         "es6-iterator": {
@@ -3911,9 +3918,9 @@
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.35",
-                "es6-symbol": "^3.1.1"
+                "d": "1.0.1",
+                "es5-ext": "0.10.51",
+                "es6-symbol": "3.1.2"
             }
         },
         "es6-symbol": {
@@ -3922,8 +3929,8 @@
             "integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
             "dev": true,
             "requires": {
-                "d": "^1.0.1",
-                "es5-ext": "^0.10.51"
+                "d": "1.0.1",
+                "es5-ext": "0.10.51"
             }
         },
         "escape-html": {
@@ -3944,11 +3951,11 @@
             "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
             "dev": true,
             "requires": {
-                "esprima": "^3.1.3",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
+                "esprima": "3.1.3",
+                "estraverse": "4.3.0",
+                "esutils": "2.0.3",
+                "optionator": "0.8.2",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "esprima": {
@@ -3972,42 +3979,42 @@
             "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "ajv": "^6.9.1",
-                "chalk": "^2.1.0",
-                "cross-spawn": "^6.0.5",
-                "debug": "^4.0.1",
-                "doctrine": "^3.0.0",
-                "eslint-scope": "^4.0.3",
-                "eslint-utils": "^1.3.1",
-                "eslint-visitor-keys": "^1.0.0",
-                "espree": "^5.0.1",
-                "esquery": "^1.0.1",
-                "esutils": "^2.0.2",
-                "file-entry-cache": "^5.0.1",
-                "functional-red-black-tree": "^1.0.1",
-                "glob": "^7.1.2",
-                "globals": "^11.7.0",
-                "ignore": "^4.0.6",
-                "import-fresh": "^3.0.0",
-                "imurmurhash": "^0.1.4",
-                "inquirer": "^6.2.2",
-                "js-yaml": "^3.13.0",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.3.0",
-                "lodash": "^4.17.11",
-                "minimatch": "^3.0.4",
-                "mkdirp": "^0.5.1",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.8.2",
-                "path-is-inside": "^1.0.2",
-                "progress": "^2.0.0",
-                "regexpp": "^2.0.1",
-                "semver": "^5.5.1",
-                "strip-ansi": "^4.0.0",
-                "strip-json-comments": "^2.0.1",
-                "table": "^5.2.3",
-                "text-table": "^0.2.0"
+                "@babel/code-frame": "7.5.5",
+                "ajv": "6.10.2",
+                "chalk": "2.4.2",
+                "cross-spawn": "6.0.5",
+                "debug": "4.1.1",
+                "doctrine": "3.0.0",
+                "eslint-scope": "4.0.3",
+                "eslint-utils": "1.4.2",
+                "eslint-visitor-keys": "1.1.0",
+                "espree": "5.0.1",
+                "esquery": "1.0.1",
+                "esutils": "2.0.3",
+                "file-entry-cache": "5.0.1",
+                "functional-red-black-tree": "1.0.1",
+                "glob": "7.1.4",
+                "globals": "11.12.0",
+                "ignore": "4.0.6",
+                "import-fresh": "3.1.0",
+                "imurmurhash": "0.1.4",
+                "inquirer": "6.5.2",
+                "js-yaml": "3.13.1",
+                "json-stable-stringify-without-jsonify": "1.0.1",
+                "levn": "0.3.0",
+                "lodash": "4.17.15",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "optionator": "0.8.2",
+                "path-is-inside": "1.0.2",
+                "progress": "2.0.3",
+                "regexpp": "2.0.1",
+                "semver": "5.7.1",
+                "strip-ansi": "4.0.0",
+                "strip-json-comments": "2.0.1",
+                "table": "5.4.6",
+                "text-table": "0.2.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -4022,8 +4029,8 @@
                     "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
                     "dev": true,
                     "requires": {
-                        "esrecurse": "^4.1.0",
-                        "estraverse": "^4.1.1"
+                        "esrecurse": "4.2.1",
+                        "estraverse": "4.3.0"
                     }
                 },
                 "strip-ansi": {
@@ -4032,7 +4039,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -4043,7 +4050,7 @@
             "integrity": "sha512-sZwhSTHVVz78+kYD3t5pCWSYEdVSBR0PXnwjDRsUs8ytIrK8PLXw+6FKp8r3Z7rx4ZszdetWlXYKOHoUrrwPlA==",
             "dev": true,
             "requires": {
-                "get-stdin": "^6.0.0"
+                "get-stdin": "6.0.0"
             }
         },
         "eslint-import-resolver-node": {
@@ -4052,8 +4059,8 @@
             "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
             "dev": true,
             "requires": {
-                "debug": "^2.6.9",
-                "resolve": "^1.5.0"
+                "debug": "2.6.9",
+                "resolve": "1.12.0"
             },
             "dependencies": {
                 "debug": {
@@ -4079,8 +4086,8 @@
             "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
             "dev": true,
             "requires": {
-                "debug": "^2.6.8",
-                "pkg-dir": "^2.0.0"
+                "debug": "2.6.9",
+                "pkg-dir": "2.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -4098,7 +4105,7 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "2.0.0"
                     }
                 },
                 "locate-path": {
@@ -4107,8 +4114,8 @@
                     "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                     "dev": true,
                     "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
                     }
                 },
                 "ms": {
@@ -4123,7 +4130,7 @@
                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
                     "dev": true,
                     "requires": {
-                        "p-try": "^1.0.0"
+                        "p-try": "1.0.0"
                     }
                 },
                 "p-locate": {
@@ -4132,7 +4139,7 @@
                     "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                     "dev": true,
                     "requires": {
-                        "p-limit": "^1.1.0"
+                        "p-limit": "1.3.0"
                     }
                 },
                 "p-try": {
@@ -4147,7 +4154,7 @@
                     "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
                     "dev": true,
                     "requires": {
-                        "find-up": "^2.1.0"
+                        "find-up": "2.1.0"
                     }
                 }
             }
@@ -4158,17 +4165,17 @@
             "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
             "dev": true,
             "requires": {
-                "array-includes": "^3.0.3",
-                "contains-path": "^0.1.0",
-                "debug": "^2.6.9",
+                "array-includes": "3.0.3",
+                "contains-path": "0.1.0",
+                "debug": "2.6.9",
                 "doctrine": "1.5.0",
-                "eslint-import-resolver-node": "^0.3.2",
-                "eslint-module-utils": "^2.4.0",
-                "has": "^1.0.3",
-                "minimatch": "^3.0.4",
-                "object.values": "^1.1.0",
-                "read-pkg-up": "^2.0.0",
-                "resolve": "^1.11.0"
+                "eslint-import-resolver-node": "0.3.2",
+                "eslint-module-utils": "2.4.1",
+                "has": "1.0.3",
+                "minimatch": "3.0.4",
+                "object.values": "1.1.0",
+                "read-pkg-up": "2.0.0",
+                "resolve": "1.12.0"
             },
             "dependencies": {
                 "debug": {
@@ -4186,8 +4193,8 @@
                     "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
                     "dev": true,
                     "requires": {
-                        "esutils": "^2.0.2",
-                        "isarray": "^1.0.0"
+                        "esutils": "2.0.3",
+                        "isarray": "1.0.0"
                     }
                 },
                 "isarray": {
@@ -4210,15 +4217,15 @@
             "integrity": "sha512-YotSItgMPwLGlr3df44MGVyXnHkmKcpkHTzpte3QwJtocr3nFqCXCuoxFZeBtnT8RHdj038NlTvam3dcAFrMcA==",
             "dev": true,
             "requires": {
-                "array-includes": "^3.0.3",
-                "doctrine": "^2.1.0",
-                "has": "^1.0.3",
-                "jsx-ast-utils": "^2.2.1",
-                "object.entries": "^1.1.0",
-                "object.fromentries": "^2.0.0",
-                "object.values": "^1.1.0",
-                "prop-types": "^15.7.2",
-                "resolve": "^1.12.0"
+                "array-includes": "3.0.3",
+                "doctrine": "2.1.0",
+                "has": "1.0.3",
+                "jsx-ast-utils": "2.2.1",
+                "object.entries": "1.1.0",
+                "object.fromentries": "2.0.0",
+                "object.values": "1.1.0",
+                "prop-types": "15.7.2",
+                "resolve": "1.12.0"
             },
             "dependencies": {
                 "doctrine": {
@@ -4227,7 +4234,7 @@
                     "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
                     "dev": true,
                     "requires": {
-                        "esutils": "^2.0.2"
+                        "esutils": "2.0.3"
                     }
                 }
             }
@@ -4238,8 +4245,8 @@
             "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
             "dev": true,
             "requires": {
-                "esrecurse": "^4.1.0",
-                "estraverse": "^4.1.1"
+                "esrecurse": "4.2.1",
+                "estraverse": "4.3.0"
             }
         },
         "eslint-utils": {
@@ -4248,7 +4255,7 @@
             "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
             "dev": true,
             "requires": {
-                "eslint-visitor-keys": "^1.0.0"
+                "eslint-visitor-keys": "1.1.0"
             }
         },
         "eslint-visitor-keys": {
@@ -4263,9 +4270,9 @@
             "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
             "dev": true,
             "requires": {
-                "acorn": "^6.0.7",
-                "acorn-jsx": "^5.0.0",
-                "eslint-visitor-keys": "^1.0.0"
+                "acorn": "6.3.0",
+                "acorn-jsx": "5.0.2",
+                "eslint-visitor-keys": "1.1.0"
             }
         },
         "esprima": {
@@ -4280,7 +4287,7 @@
             "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.0.0"
+                "estraverse": "4.3.0"
             }
         },
         "esrecurse": {
@@ -4289,7 +4296,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "4.3.0"
             }
         },
         "estraverse": {
@@ -4316,8 +4323,8 @@
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "dev": true,
             "requires": {
-                "md5.js": "^1.3.4",
-                "safe-buffer": "^5.1.1"
+                "md5.js": "1.3.5",
+                "safe-buffer": "5.1.2"
             }
         },
         "exec-sh": {
@@ -4332,13 +4339,13 @@
             "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
             "dev": true,
             "requires": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^4.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
+                "cross-spawn": "6.0.5",
+                "get-stream": "4.1.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
             }
         },
         "exit": {
@@ -4353,13 +4360,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "debug": {
@@ -4377,7 +4384,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -4386,7 +4393,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "ms": {
@@ -4403,7 +4410,7 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "^1.0.1"
+                "homedir-polyfill": "1.0.3"
             }
         },
         "expect": {
@@ -4412,12 +4419,12 @@
             "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.9.0",
-                "ansi-styles": "^3.2.0",
-                "jest-get-type": "^24.9.0",
-                "jest-matcher-utils": "^24.9.0",
-                "jest-message-util": "^24.9.0",
-                "jest-regex-util": "^24.9.0"
+                "@jest/types": "24.9.0",
+                "ansi-styles": "3.2.1",
+                "jest-get-type": "24.9.0",
+                "jest-matcher-utils": "24.9.0",
+                "jest-message-util": "24.9.0",
+                "jest-regex-util": "24.9.0"
             }
         },
         "extend": {
@@ -4432,8 +4439,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -4442,7 +4449,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 },
                 "is-plain-object": {
@@ -4451,7 +4458,7 @@
                     "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
                     "dev": true,
                     "requires": {
-                        "isobject": "^3.0.1"
+                        "isobject": "3.0.1"
                     }
                 },
                 "isobject": {
@@ -4468,9 +4475,9 @@
             "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
             "dev": true,
             "requires": {
-                "chardet": "^0.7.0",
-                "iconv-lite": "^0.4.24",
-                "tmp": "^0.0.33"
+                "chardet": "0.7.0",
+                "iconv-lite": "0.4.24",
+                "tmp": "0.0.33"
             }
         },
         "extglob": {
@@ -4479,14 +4486,14 @@
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -4495,7 +4502,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "extend-shallow": {
@@ -4504,7 +4511,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -4513,7 +4520,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -4522,7 +4529,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -4531,9 +4538,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -4567,7 +4574,7 @@
             "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
             "dev": true,
             "requires": {
-                "bser": "^2.0.0"
+                "bser": "2.1.0"
             }
         },
         "figgy-pudding": {
@@ -4582,7 +4589,7 @@
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "^1.0.5"
+                "escape-string-regexp": "1.0.5"
             }
         },
         "file-entry-cache": {
@@ -4591,7 +4598,7 @@
             "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
             "dev": true,
             "requires": {
-                "flat-cache": "^2.0.1"
+                "flat-cache": "2.0.1"
             }
         },
         "fill-range": {
@@ -4600,10 +4607,10 @@
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -4612,7 +4619,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -4623,9 +4630,9 @@
             "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
             "dev": true,
             "requires": {
-                "commondir": "^1.0.1",
-                "make-dir": "^2.0.0",
-                "pkg-dir": "^3.0.0"
+                "commondir": "1.0.1",
+                "make-dir": "2.1.0",
+                "pkg-dir": "3.0.0"
             }
         },
         "find-up": {
@@ -4634,7 +4641,7 @@
             "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
             "dev": true,
             "requires": {
-                "locate-path": "^3.0.0"
+                "locate-path": "3.0.0"
             }
         },
         "findup-sync": {
@@ -4643,10 +4650,10 @@
             "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
             "dev": true,
             "requires": {
-                "detect-file": "^1.0.0",
-                "is-glob": "^4.0.0",
-                "micromatch": "^3.0.4",
-                "resolve-dir": "^1.0.1"
+                "detect-file": "1.0.0",
+                "is-glob": "4.0.1",
+                "micromatch": "3.1.10",
+                "resolve-dir": "1.0.1"
             }
         },
         "flat-cache": {
@@ -4655,7 +4662,7 @@
             "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
             "dev": true,
             "requires": {
-                "flatted": "^2.0.0",
+                "flatted": "2.0.1",
                 "rimraf": "2.6.3",
                 "write": "1.0.3"
             }
@@ -4672,8 +4679,8 @@
             "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.3.6"
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.6"
             },
             "dependencies": {
                 "isarray": {
@@ -4688,13 +4695,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -4703,7 +4710,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -4726,9 +4733,9 @@
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "dev": true,
             "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.8",
+                "mime-types": "2.1.24"
             }
         },
         "fragment-cache": {
@@ -4737,7 +4744,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "^0.2.2"
+                "map-cache": "0.2.2"
             }
         },
         "fresh": {
@@ -4752,8 +4759,8 @@
             "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0"
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.6"
             },
             "dependencies": {
                 "isarray": {
@@ -4768,13 +4775,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -4783,7 +4790,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -4794,10 +4801,10 @@
             "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "iferr": "^0.1.5",
-                "imurmurhash": "^0.1.4",
-                "readable-stream": "1 || 2"
+                "graceful-fs": "4.2.2",
+                "iferr": "0.1.5",
+                "imurmurhash": "0.1.4",
+                "readable-stream": "1.0.34"
             }
         },
         "fs.realpath": {
@@ -4813,8 +4820,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "^2.12.1",
-                "node-pre-gyp": "^0.12.0"
+                "nan": "2.14.0",
+                "node-pre-gyp": "0.12.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -5377,7 +5384,7 @@
             "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
             "dev": true,
             "requires": {
-                "pump": "^3.0.0"
+                "pump": "3.0.0"
             }
         },
         "get-value": {
@@ -5392,7 +5399,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "glob": {
@@ -5401,12 +5408,12 @@
             "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
             "dev": true,
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.4",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "glob-parent": {
@@ -5415,8 +5422,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
             },
             "dependencies": {
                 "is-glob": {
@@ -5425,7 +5432,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^2.1.0"
+                        "is-extglob": "2.1.1"
                     }
                 }
             }
@@ -5436,7 +5443,7 @@
             "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
             "dev": true,
             "requires": {
-                "ini": "^1.3.4"
+                "ini": "1.3.5"
             }
         },
         "global-modules": {
@@ -5445,7 +5452,7 @@
             "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
             "dev": true,
             "requires": {
-                "global-prefix": "^3.0.0"
+                "global-prefix": "3.0.0"
             },
             "dependencies": {
                 "global-prefix": {
@@ -5454,9 +5461,9 @@
                     "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
                     "dev": true,
                     "requires": {
-                        "ini": "^1.3.5",
-                        "kind-of": "^6.0.2",
-                        "which": "^1.3.1"
+                        "ini": "1.3.5",
+                        "kind-of": "6.0.2",
+                        "which": "1.3.1"
                     }
                 }
             }
@@ -5467,11 +5474,11 @@
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "^2.0.2",
-                "homedir-polyfill": "^1.0.1",
-                "ini": "^1.3.4",
-                "is-windows": "^1.0.1",
-                "which": "^1.2.14"
+                "expand-tilde": "2.0.2",
+                "homedir-polyfill": "1.0.3",
+                "ini": "1.3.5",
+                "is-windows": "1.0.2",
+                "which": "1.3.1"
             }
         },
         "globals": {
@@ -5486,17 +5493,17 @@
             "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
             "dev": true,
             "requires": {
-                "create-error-class": "^3.0.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^3.0.0",
-                "is-redirect": "^1.0.0",
-                "is-retry-allowed": "^1.0.0",
-                "is-stream": "^1.0.0",
-                "lowercase-keys": "^1.0.0",
-                "safe-buffer": "^5.0.1",
-                "timed-out": "^4.0.0",
-                "unzip-response": "^2.0.1",
-                "url-parse-lax": "^1.0.0"
+                "create-error-class": "3.0.2",
+                "duplexer3": "0.1.4",
+                "get-stream": "3.0.0",
+                "is-redirect": "1.0.0",
+                "is-retry-allowed": "1.2.0",
+                "is-stream": "1.1.0",
+                "lowercase-keys": "1.0.1",
+                "safe-buffer": "5.1.2",
+                "timed-out": "4.0.1",
+                "unzip-response": "2.0.1",
+                "url-parse-lax": "1.0.0"
             },
             "dependencies": {
                 "get-stream": {
@@ -5525,10 +5532,10 @@
             "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
             "dev": true,
             "requires": {
-                "neo-async": "^2.6.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
+                "neo-async": "2.6.1",
+                "optimist": "0.6.1",
+                "source-map": "0.6.1",
+                "uglify-js": "3.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -5551,8 +5558,8 @@
             "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "dev": true,
             "requires": {
-                "ajv": "^6.5.5",
-                "har-schema": "^2.0.0"
+                "ajv": "6.10.2",
+                "har-schema": "2.0.0"
             }
         },
         "has": {
@@ -5561,7 +5568,7 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
-                "function-bind": "^1.1.1"
+                "function-bind": "1.1.1"
             }
         },
         "has-flag": {
@@ -5582,9 +5589,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "^2.0.6",
-                "has-values": "^1.0.0",
-                "isobject": "^3.0.0"
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -5601,8 +5608,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "kind-of": "^4.0.0"
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -5611,7 +5618,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -5622,8 +5629,8 @@
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.4",
+                "safe-buffer": "5.1.2"
             }
         },
         "hash.js": {
@@ -5632,8 +5639,8 @@
             "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.3",
-                "minimalistic-assert": "^1.0.1"
+                "inherits": "2.0.4",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "hmac-drbg": {
@@ -5642,9 +5649,9 @@
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "requires": {
-                "hash.js": "^1.0.3",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.1"
+                "hash.js": "1.1.7",
+                "minimalistic-assert": "1.0.1",
+                "minimalistic-crypto-utils": "1.0.1"
             }
         },
         "hoist-non-react-statics": {
@@ -5652,7 +5659,7 @@
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
             "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
             "requires": {
-                "react-is": "^16.7.0"
+                "react-is": "16.10.1"
             }
         },
         "homedir-polyfill": {
@@ -5661,7 +5668,7 @@
             "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
             "dev": true,
             "requires": {
-                "parse-passwd": "^1.0.0"
+                "parse-passwd": "1.0.0"
             }
         },
         "hosted-git-info": {
@@ -5676,7 +5683,7 @@
             "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
             "dev": true,
             "requires": {
-                "whatwg-encoding": "^1.0.1"
+                "whatwg-encoding": "1.0.5"
             }
         },
         "http-assert": {
@@ -5685,8 +5692,8 @@
             "integrity": "sha512-rdw7q6GTlibqVVbXr0CKelfV5iY8G2HqEUkhSk297BMbSpSL8crXC+9rjKoMcZZEsksX30le6f/4ul4E28gegw==",
             "dev": true,
             "requires": {
-                "deep-equal": "~1.0.1",
-                "http-errors": "~1.7.2"
+                "deep-equal": "1.0.1",
+                "http-errors": "1.7.3"
             }
         },
         "http-errors": {
@@ -5695,10 +5702,10 @@
             "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
             "dev": true,
             "requires": {
-                "depd": "~1.1.2",
+                "depd": "1.1.2",
                 "inherits": "2.0.4",
                 "setprototypeof": "1.1.1",
-                "statuses": ">= 1.5.0 < 2",
+                "statuses": "1.5.0",
                 "toidentifier": "1.0.0"
             }
         },
@@ -5708,9 +5715,9 @@
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.16.1"
             }
         },
         "https-browserify": {
@@ -5729,7 +5736,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": "2.1.2"
             }
         },
         "icss-replace-symbols": {
@@ -5744,7 +5751,7 @@
             "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
             "dev": true,
             "requires": {
-                "postcss": "^7.0.14"
+                "postcss": "7.0.18"
             }
         },
         "ieee754": {
@@ -5771,8 +5778,8 @@
             "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
             "dev": true,
             "requires": {
-                "parent-module": "^1.0.0",
-                "resolve-from": "^4.0.0"
+                "parent-module": "1.0.1",
+                "resolve-from": "4.0.0"
             }
         },
         "import-lazy": {
@@ -5787,8 +5794,8 @@
             "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
             "dev": true,
             "requires": {
-                "pkg-dir": "^3.0.0",
-                "resolve-cwd": "^2.0.0"
+                "pkg-dir": "3.0.0",
+                "resolve-cwd": "2.0.0"
             }
         },
         "imurmurhash": {
@@ -5821,8 +5828,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -5843,19 +5850,19 @@
             "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^3.2.0",
-                "chalk": "^2.4.2",
-                "cli-cursor": "^2.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^3.0.3",
-                "figures": "^2.0.0",
-                "lodash": "^4.17.12",
+                "ansi-escapes": "3.2.0",
+                "chalk": "2.4.2",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "3.1.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.15",
                 "mute-stream": "0.0.7",
-                "run-async": "^2.2.0",
-                "rxjs": "^6.4.0",
-                "string-width": "^2.1.0",
-                "strip-ansi": "^5.1.0",
-                "through": "^2.3.6"
+                "run-async": "2.3.0",
+                "rxjs": "6.5.3",
+                "string-width": "2.1.1",
+                "strip-ansi": "5.2.0",
+                "through": "2.3.8"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -5870,8 +5877,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     },
                     "dependencies": {
                         "strip-ansi": {
@@ -5880,7 +5887,7 @@
                             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "^3.0.0"
+                                "ansi-regex": "3.0.0"
                             }
                         }
                     }
@@ -5899,7 +5906,7 @@
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "dev": true,
             "requires": {
-                "loose-envify": "^1.0.0"
+                "loose-envify": "1.4.0"
             }
         },
         "invert-kv": {
@@ -5914,7 +5921,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -5923,7 +5930,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -5940,7 +5947,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "^1.0.0"
+                "binary-extensions": "1.13.1"
             }
         },
         "is-buffer": {
@@ -5961,7 +5968,7 @@
             "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
             "dev": true,
             "requires": {
-                "ci-info": "^2.0.0"
+                "ci-info": "2.0.0"
             }
         },
         "is-data-descriptor": {
@@ -5970,7 +5977,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -5979,7 +5986,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -5996,9 +6003,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -6051,7 +6058,7 @@
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
             "dev": true,
             "requires": {
-                "is-extglob": "^2.1.1"
+                "is-extglob": "2.1.1"
             }
         },
         "is-in-browser": {
@@ -6065,8 +6072,8 @@
             "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
             "dev": true,
             "requires": {
-                "global-dirs": "^0.1.0",
-                "is-path-inside": "^1.0.0"
+                "global-dirs": "0.1.1",
+                "is-path-inside": "1.0.1"
             }
         },
         "is-npm": {
@@ -6081,7 +6088,7 @@
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -6090,7 +6097,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -6107,7 +6114,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "^1.0.1"
+                "path-is-inside": "1.0.2"
             }
         },
         "is-plain-obj": {
@@ -6121,7 +6128,7 @@
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
             "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
             "requires": {
-                "isobject": "^4.0.0"
+                "isobject": "4.0.0"
             }
         },
         "is-promise": {
@@ -6142,7 +6149,7 @@
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "dev": true,
             "requires": {
-                "has": "^1.0.1"
+                "has": "1.0.3"
             }
         },
         "is-retry-allowed": {
@@ -6163,7 +6170,7 @@
             "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
             "dev": true,
             "requires": {
-                "has-symbols": "^1.0.0"
+                "has-symbols": "1.0.0"
             }
         },
         "is-typedarray": {
@@ -6219,13 +6226,13 @@
             "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
             "dev": true,
             "requires": {
-                "@babel/generator": "^7.4.0",
-                "@babel/parser": "^7.4.3",
-                "@babel/template": "^7.4.0",
-                "@babel/traverse": "^7.4.3",
-                "@babel/types": "^7.4.0",
-                "istanbul-lib-coverage": "^2.0.5",
-                "semver": "^6.0.0"
+                "@babel/generator": "7.6.2",
+                "@babel/parser": "7.6.2",
+                "@babel/template": "7.6.0",
+                "@babel/traverse": "7.6.2",
+                "@babel/types": "7.6.1",
+                "istanbul-lib-coverage": "2.0.5",
+                "semver": "6.3.0"
             },
             "dependencies": {
                 "semver": {
@@ -6242,9 +6249,9 @@
             "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
             "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "^2.0.5",
-                "make-dir": "^2.1.0",
-                "supports-color": "^6.1.0"
+                "istanbul-lib-coverage": "2.0.5",
+                "make-dir": "2.1.0",
+                "supports-color": "6.1.0"
             },
             "dependencies": {
                 "supports-color": {
@@ -6253,7 +6260,7 @@
                     "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -6264,11 +6271,11 @@
             "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
             "dev": true,
             "requires": {
-                "debug": "^4.1.1",
-                "istanbul-lib-coverage": "^2.0.5",
-                "make-dir": "^2.1.0",
-                "rimraf": "^2.6.3",
-                "source-map": "^0.6.1"
+                "debug": "4.1.1",
+                "istanbul-lib-coverage": "2.0.5",
+                "make-dir": "2.1.0",
+                "rimraf": "2.6.3",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -6285,7 +6292,7 @@
             "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
             "dev": true,
             "requires": {
-                "handlebars": "^4.1.2"
+                "handlebars": "4.4.0"
             }
         },
         "jest": {
@@ -6294,8 +6301,8 @@
             "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
             "dev": true,
             "requires": {
-                "import-local": "^2.0.0",
-                "jest-cli": "^24.9.0"
+                "import-local": "2.0.0",
+                "jest-cli": "24.9.0"
             },
             "dependencies": {
                 "jest-cli": {
@@ -6304,19 +6311,19 @@
                     "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
                     "dev": true,
                     "requires": {
-                        "@jest/core": "^24.9.0",
-                        "@jest/test-result": "^24.9.0",
-                        "@jest/types": "^24.9.0",
-                        "chalk": "^2.0.1",
-                        "exit": "^0.1.2",
-                        "import-local": "^2.0.0",
-                        "is-ci": "^2.0.0",
-                        "jest-config": "^24.9.0",
-                        "jest-util": "^24.9.0",
-                        "jest-validate": "^24.9.0",
-                        "prompts": "^2.0.1",
-                        "realpath-native": "^1.1.0",
-                        "yargs": "^13.3.0"
+                        "@jest/core": "24.9.0",
+                        "@jest/test-result": "24.9.0",
+                        "@jest/types": "24.9.0",
+                        "chalk": "2.4.2",
+                        "exit": "0.1.2",
+                        "import-local": "2.0.0",
+                        "is-ci": "2.0.0",
+                        "jest-config": "24.9.0",
+                        "jest-util": "24.9.0",
+                        "jest-validate": "24.9.0",
+                        "prompts": "2.2.1",
+                        "realpath-native": "1.1.0",
+                        "yargs": "13.3.0"
                     }
                 }
             }
@@ -6327,9 +6334,9 @@
             "integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.9.0",
-                "execa": "^1.0.0",
-                "throat": "^4.0.0"
+                "@jest/types": "24.9.0",
+                "execa": "1.0.0",
+                "throat": "4.1.0"
             }
         },
         "jest-config": {
@@ -6338,23 +6345,23 @@
             "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
             "dev": true,
             "requires": {
-                "@babel/core": "^7.1.0",
-                "@jest/test-sequencer": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "babel-jest": "^24.9.0",
-                "chalk": "^2.0.1",
-                "glob": "^7.1.1",
-                "jest-environment-jsdom": "^24.9.0",
-                "jest-environment-node": "^24.9.0",
-                "jest-get-type": "^24.9.0",
-                "jest-jasmine2": "^24.9.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "jest-validate": "^24.9.0",
-                "micromatch": "^3.1.10",
-                "pretty-format": "^24.9.0",
-                "realpath-native": "^1.1.0"
+                "@babel/core": "7.6.2",
+                "@jest/test-sequencer": "24.9.0",
+                "@jest/types": "24.9.0",
+                "babel-jest": "24.9.0",
+                "chalk": "2.4.2",
+                "glob": "7.1.4",
+                "jest-environment-jsdom": "24.9.0",
+                "jest-environment-node": "24.9.0",
+                "jest-get-type": "24.9.0",
+                "jest-jasmine2": "24.9.0",
+                "jest-regex-util": "24.9.0",
+                "jest-resolve": "24.9.0",
+                "jest-util": "24.9.0",
+                "jest-validate": "24.9.0",
+                "micromatch": "3.1.10",
+                "pretty-format": "24.9.0",
+                "realpath-native": "1.1.0"
             }
         },
         "jest-diff": {
@@ -6363,10 +6370,10 @@
             "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1",
-                "diff-sequences": "^24.9.0",
-                "jest-get-type": "^24.9.0",
-                "pretty-format": "^24.9.0"
+                "chalk": "2.4.2",
+                "diff-sequences": "24.9.0",
+                "jest-get-type": "24.9.0",
+                "pretty-format": "24.9.0"
             }
         },
         "jest-docblock": {
@@ -6375,7 +6382,7 @@
             "integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
             "dev": true,
             "requires": {
-                "detect-newline": "^2.1.0"
+                "detect-newline": "2.1.0"
             }
         },
         "jest-each": {
@@ -6384,11 +6391,11 @@
             "integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.9.0",
-                "chalk": "^2.0.1",
-                "jest-get-type": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "pretty-format": "^24.9.0"
+                "@jest/types": "24.9.0",
+                "chalk": "2.4.2",
+                "jest-get-type": "24.9.0",
+                "jest-util": "24.9.0",
+                "pretty-format": "24.9.0"
             }
         },
         "jest-environment-jsdom": {
@@ -6397,12 +6404,12 @@
             "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^24.9.0",
-                "@jest/fake-timers": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "jest-mock": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "jsdom": "^11.5.1"
+                "@jest/environment": "24.9.0",
+                "@jest/fake-timers": "24.9.0",
+                "@jest/types": "24.9.0",
+                "jest-mock": "24.9.0",
+                "jest-util": "24.9.0",
+                "jsdom": "11.12.0"
             }
         },
         "jest-environment-node": {
@@ -6411,11 +6418,11 @@
             "integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^24.9.0",
-                "@jest/fake-timers": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "jest-mock": "^24.9.0",
-                "jest-util": "^24.9.0"
+                "@jest/environment": "24.9.0",
+                "@jest/fake-timers": "24.9.0",
+                "@jest/types": "24.9.0",
+                "jest-mock": "24.9.0",
+                "jest-util": "24.9.0"
             }
         },
         "jest-get-type": {
@@ -6430,18 +6437,18 @@
             "integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.9.0",
-                "anymatch": "^2.0.0",
-                "fb-watchman": "^2.0.0",
-                "fsevents": "^1.2.7",
-                "graceful-fs": "^4.1.15",
-                "invariant": "^2.2.4",
-                "jest-serializer": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "jest-worker": "^24.9.0",
-                "micromatch": "^3.1.10",
-                "sane": "^4.0.3",
-                "walker": "^1.0.7"
+                "@jest/types": "24.9.0",
+                "anymatch": "2.0.0",
+                "fb-watchman": "2.0.0",
+                "fsevents": "1.2.9",
+                "graceful-fs": "4.2.2",
+                "invariant": "2.2.4",
+                "jest-serializer": "24.9.0",
+                "jest-util": "24.9.0",
+                "jest-worker": "24.9.0",
+                "micromatch": "3.1.10",
+                "sane": "4.1.0",
+                "walker": "1.0.7"
             }
         },
         "jest-jasmine2": {
@@ -6450,22 +6457,22 @@
             "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.1.0",
-                "@jest/environment": "^24.9.0",
-                "@jest/test-result": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "chalk": "^2.0.1",
-                "co": "^4.6.0",
-                "expect": "^24.9.0",
-                "is-generator-fn": "^2.0.0",
-                "jest-each": "^24.9.0",
-                "jest-matcher-utils": "^24.9.0",
-                "jest-message-util": "^24.9.0",
-                "jest-runtime": "^24.9.0",
-                "jest-snapshot": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "pretty-format": "^24.9.0",
-                "throat": "^4.0.0"
+                "@babel/traverse": "7.6.2",
+                "@jest/environment": "24.9.0",
+                "@jest/test-result": "24.9.0",
+                "@jest/types": "24.9.0",
+                "chalk": "2.4.2",
+                "co": "4.6.0",
+                "expect": "24.9.0",
+                "is-generator-fn": "2.1.0",
+                "jest-each": "24.9.0",
+                "jest-matcher-utils": "24.9.0",
+                "jest-message-util": "24.9.0",
+                "jest-runtime": "24.9.0",
+                "jest-snapshot": "24.9.0",
+                "jest-util": "24.9.0",
+                "pretty-format": "24.9.0",
+                "throat": "4.1.0"
             }
         },
         "jest-leak-detector": {
@@ -6474,8 +6481,8 @@
             "integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
             "dev": true,
             "requires": {
-                "jest-get-type": "^24.9.0",
-                "pretty-format": "^24.9.0"
+                "jest-get-type": "24.9.0",
+                "pretty-format": "24.9.0"
             }
         },
         "jest-matcher-utils": {
@@ -6484,10 +6491,10 @@
             "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1",
-                "jest-diff": "^24.9.0",
-                "jest-get-type": "^24.9.0",
-                "pretty-format": "^24.9.0"
+                "chalk": "2.4.2",
+                "jest-diff": "24.9.0",
+                "jest-get-type": "24.9.0",
+                "pretty-format": "24.9.0"
             }
         },
         "jest-message-util": {
@@ -6496,14 +6503,14 @@
             "integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@jest/test-result": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "@types/stack-utils": "^1.0.1",
-                "chalk": "^2.0.1",
-                "micromatch": "^3.1.10",
-                "slash": "^2.0.0",
-                "stack-utils": "^1.0.1"
+                "@babel/code-frame": "7.5.5",
+                "@jest/test-result": "24.9.0",
+                "@jest/types": "24.9.0",
+                "@types/stack-utils": "1.0.1",
+                "chalk": "2.4.2",
+                "micromatch": "3.1.10",
+                "slash": "2.0.0",
+                "stack-utils": "1.0.2"
             }
         },
         "jest-mock": {
@@ -6512,7 +6519,7 @@
             "integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.9.0"
+                "@jest/types": "24.9.0"
             }
         },
         "jest-pnp-resolver": {
@@ -6533,11 +6540,11 @@
             "integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.9.0",
-                "browser-resolve": "^1.11.3",
-                "chalk": "^2.0.1",
-                "jest-pnp-resolver": "^1.2.1",
-                "realpath-native": "^1.1.0"
+                "@jest/types": "24.9.0",
+                "browser-resolve": "1.11.3",
+                "chalk": "2.4.2",
+                "jest-pnp-resolver": "1.2.1",
+                "realpath-native": "1.1.0"
             }
         },
         "jest-resolve-dependencies": {
@@ -6546,9 +6553,9 @@
             "integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.9.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-snapshot": "^24.9.0"
+                "@jest/types": "24.9.0",
+                "jest-regex-util": "24.9.0",
+                "jest-snapshot": "24.9.0"
             }
         },
         "jest-runner": {
@@ -6557,25 +6564,25 @@
             "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/environment": "^24.9.0",
-                "@jest/test-result": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "chalk": "^2.4.2",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.1.15",
-                "jest-config": "^24.9.0",
-                "jest-docblock": "^24.3.0",
-                "jest-haste-map": "^24.9.0",
-                "jest-jasmine2": "^24.9.0",
-                "jest-leak-detector": "^24.9.0",
-                "jest-message-util": "^24.9.0",
-                "jest-resolve": "^24.9.0",
-                "jest-runtime": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "jest-worker": "^24.6.0",
-                "source-map-support": "^0.5.6",
-                "throat": "^4.0.0"
+                "@jest/console": "24.9.0",
+                "@jest/environment": "24.9.0",
+                "@jest/test-result": "24.9.0",
+                "@jest/types": "24.9.0",
+                "chalk": "2.4.2",
+                "exit": "0.1.2",
+                "graceful-fs": "4.2.2",
+                "jest-config": "24.9.0",
+                "jest-docblock": "24.9.0",
+                "jest-haste-map": "24.9.0",
+                "jest-jasmine2": "24.9.0",
+                "jest-leak-detector": "24.9.0",
+                "jest-message-util": "24.9.0",
+                "jest-resolve": "24.9.0",
+                "jest-runtime": "24.9.0",
+                "jest-util": "24.9.0",
+                "jest-worker": "24.9.0",
+                "source-map-support": "0.5.13",
+                "throat": "4.1.0"
             }
         },
         "jest-runtime": {
@@ -6584,29 +6591,29 @@
             "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/environment": "^24.9.0",
-                "@jest/source-map": "^24.3.0",
-                "@jest/transform": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "@types/yargs": "^13.0.0",
-                "chalk": "^2.0.1",
-                "exit": "^0.1.2",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.1.15",
-                "jest-config": "^24.9.0",
-                "jest-haste-map": "^24.9.0",
-                "jest-message-util": "^24.9.0",
-                "jest-mock": "^24.9.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve": "^24.9.0",
-                "jest-snapshot": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "jest-validate": "^24.9.0",
-                "realpath-native": "^1.1.0",
-                "slash": "^2.0.0",
-                "strip-bom": "^3.0.0",
-                "yargs": "^13.3.0"
+                "@jest/console": "24.9.0",
+                "@jest/environment": "24.9.0",
+                "@jest/source-map": "24.9.0",
+                "@jest/transform": "24.9.0",
+                "@jest/types": "24.9.0",
+                "@types/yargs": "13.0.3",
+                "chalk": "2.4.2",
+                "exit": "0.1.2",
+                "glob": "7.1.4",
+                "graceful-fs": "4.2.2",
+                "jest-config": "24.9.0",
+                "jest-haste-map": "24.9.0",
+                "jest-message-util": "24.9.0",
+                "jest-mock": "24.9.0",
+                "jest-regex-util": "24.9.0",
+                "jest-resolve": "24.9.0",
+                "jest-snapshot": "24.9.0",
+                "jest-util": "24.9.0",
+                "jest-validate": "24.9.0",
+                "realpath-native": "1.1.0",
+                "slash": "2.0.0",
+                "strip-bom": "3.0.0",
+                "yargs": "13.3.0"
             }
         },
         "jest-serializer": {
@@ -6621,19 +6628,19 @@
             "integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0",
-                "@jest/types": "^24.9.0",
-                "chalk": "^2.0.1",
-                "expect": "^24.9.0",
-                "jest-diff": "^24.9.0",
-                "jest-get-type": "^24.9.0",
-                "jest-matcher-utils": "^24.9.0",
-                "jest-message-util": "^24.9.0",
-                "jest-resolve": "^24.9.0",
-                "mkdirp": "^0.5.1",
-                "natural-compare": "^1.4.0",
-                "pretty-format": "^24.9.0",
-                "semver": "^6.2.0"
+                "@babel/types": "7.6.1",
+                "@jest/types": "24.9.0",
+                "chalk": "2.4.2",
+                "expect": "24.9.0",
+                "jest-diff": "24.9.0",
+                "jest-get-type": "24.9.0",
+                "jest-matcher-utils": "24.9.0",
+                "jest-message-util": "24.9.0",
+                "jest-resolve": "24.9.0",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "pretty-format": "24.9.0",
+                "semver": "6.3.0"
             },
             "dependencies": {
                 "semver": {
@@ -6650,18 +6657,18 @@
             "integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.9.0",
-                "@jest/fake-timers": "^24.9.0",
-                "@jest/source-map": "^24.9.0",
-                "@jest/test-result": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "callsites": "^3.0.0",
-                "chalk": "^2.0.1",
-                "graceful-fs": "^4.1.15",
-                "is-ci": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "slash": "^2.0.0",
-                "source-map": "^0.6.0"
+                "@jest/console": "24.9.0",
+                "@jest/fake-timers": "24.9.0",
+                "@jest/source-map": "24.9.0",
+                "@jest/test-result": "24.9.0",
+                "@jest/types": "24.9.0",
+                "callsites": "3.1.0",
+                "chalk": "2.4.2",
+                "graceful-fs": "4.2.2",
+                "is-ci": "2.0.0",
+                "mkdirp": "0.5.1",
+                "slash": "2.0.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -6678,12 +6685,12 @@
             "integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.9.0",
-                "camelcase": "^5.3.1",
-                "chalk": "^2.0.1",
-                "jest-get-type": "^24.9.0",
-                "leven": "^3.1.0",
-                "pretty-format": "^24.9.0"
+                "@jest/types": "24.9.0",
+                "camelcase": "5.3.1",
+                "chalk": "2.4.2",
+                "jest-get-type": "24.9.0",
+                "leven": "3.1.0",
+                "pretty-format": "24.9.0"
             }
         },
         "jest-watcher": {
@@ -6692,13 +6699,13 @@
             "integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "@types/yargs": "^13.0.0",
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.1",
-                "jest-util": "^24.9.0",
-                "string-length": "^2.0.0"
+                "@jest/test-result": "24.9.0",
+                "@jest/types": "24.9.0",
+                "@types/yargs": "13.0.3",
+                "ansi-escapes": "3.2.0",
+                "chalk": "2.4.2",
+                "jest-util": "24.9.0",
+                "string-length": "2.0.0"
             }
         },
         "jest-worker": {
@@ -6707,8 +6714,8 @@
             "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
             "dev": true,
             "requires": {
-                "merge-stream": "^2.0.0",
-                "supports-color": "^6.1.0"
+                "merge-stream": "2.0.0",
+                "supports-color": "6.1.0"
             },
             "dependencies": {
                 "supports-color": {
@@ -6717,7 +6724,7 @@
                     "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -6739,8 +6746,8 @@
             "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "1.0.10",
+                "esprima": "4.0.1"
             }
         },
         "jsbn": {
@@ -6755,32 +6762,32 @@
             "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
             "dev": true,
             "requires": {
-                "abab": "^2.0.0",
-                "acorn": "^5.5.3",
-                "acorn-globals": "^4.1.0",
-                "array-equal": "^1.0.0",
-                "cssom": ">= 0.3.2 < 0.4.0",
-                "cssstyle": "^1.0.0",
-                "data-urls": "^1.0.0",
-                "domexception": "^1.0.1",
-                "escodegen": "^1.9.1",
-                "html-encoding-sniffer": "^1.0.2",
-                "left-pad": "^1.3.0",
-                "nwsapi": "^2.0.7",
+                "abab": "2.0.2",
+                "acorn": "5.7.3",
+                "acorn-globals": "4.3.4",
+                "array-equal": "1.0.0",
+                "cssom": "0.3.8",
+                "cssstyle": "1.4.0",
+                "data-urls": "1.1.0",
+                "domexception": "1.0.1",
+                "escodegen": "1.12.0",
+                "html-encoding-sniffer": "1.0.2",
+                "left-pad": "1.3.0",
+                "nwsapi": "2.1.4",
                 "parse5": "4.0.0",
-                "pn": "^1.1.0",
-                "request": "^2.87.0",
-                "request-promise-native": "^1.0.5",
-                "sax": "^1.2.4",
-                "symbol-tree": "^3.2.2",
-                "tough-cookie": "^2.3.4",
-                "w3c-hr-time": "^1.0.1",
-                "webidl-conversions": "^4.0.2",
-                "whatwg-encoding": "^1.0.3",
-                "whatwg-mimetype": "^2.1.0",
-                "whatwg-url": "^6.4.1",
-                "ws": "^5.2.0",
-                "xml-name-validator": "^3.0.0"
+                "pn": "1.1.0",
+                "request": "2.88.0",
+                "request-promise-native": "1.0.7",
+                "sax": "1.2.4",
+                "symbol-tree": "3.2.4",
+                "tough-cookie": "2.5.0",
+                "w3c-hr-time": "1.0.1",
+                "webidl-conversions": "4.0.2",
+                "whatwg-encoding": "1.0.5",
+                "whatwg-mimetype": "2.3.0",
+                "whatwg-url": "6.5.0",
+                "ws": "5.2.2",
+                "xml-name-validator": "3.0.0"
             },
             "dependencies": {
                 "acorn": {
@@ -6833,7 +6840,7 @@
             "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
             "dev": true,
             "requires": {
-                "minimist": "^1.2.0"
+                "minimist": "1.2.0"
             }
         },
         "jsprim": {
@@ -6853,10 +6860,10 @@
             "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0.tgz",
             "integrity": "sha512-TPpDFsiBjuERiL+dFDq8QCdiF9oDasPcNqCKLGCo/qED3fNYOQ8PX2lZhknyTiAt3tZrfOFbb0lbQ9lTjPZxsQ==",
             "requires": {
-                "@babel/runtime": "^7.3.1",
-                "csstype": "^2.6.5",
-                "is-in-browser": "^1.1.3",
-                "tiny-warning": "^1.0.2"
+                "@babel/runtime": "7.6.2",
+                "csstype": "2.6.6",
+                "is-in-browser": "1.1.3",
+                "tiny-warning": "1.0.3"
             }
         },
         "jss-plugin-camel-case": {
@@ -6864,8 +6871,8 @@
             "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0.tgz",
             "integrity": "sha512-yALDL00+pPR4FJh+k07A8FeDvfoPPuXU48HLy63enAubcVd3DnS+2rgqPXglHDGixIDVkCSXecl/l5GAMjzIbA==",
             "requires": {
-                "@babel/runtime": "^7.3.1",
-                "hyphenate-style-name": "^1.0.3",
+                "@babel/runtime": "7.6.2",
+                "hyphenate-style-name": "1.0.3",
                 "jss": "10.0.0"
             }
         },
@@ -6874,7 +6881,7 @@
             "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0.tgz",
             "integrity": "sha512-sURozIOdCtGg9ap18erQ+ijndAfEGtTaetxfU3H4qwC18Bi+fdvjlY/ahKbuu0ASs7R/+WKCP7UaRZOjUDMcdQ==",
             "requires": {
-                "@babel/runtime": "^7.3.1",
+                "@babel/runtime": "7.6.2",
                 "jss": "10.0.0"
             }
         },
@@ -6883,7 +6890,7 @@
             "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.0.0.tgz",
             "integrity": "sha512-80ofWKSQUo62bxLtRoTNe0kFPtHgUbAJeOeR36WEGgWIBEsXLyXOnD5KNnjPqG4heuEkz9eSLccjYST50JnI7Q==",
             "requires": {
-                "@babel/runtime": "^7.3.1",
+                "@babel/runtime": "7.6.2",
                 "jss": "10.0.0"
             }
         },
@@ -6892,9 +6899,9 @@
             "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.0.0.tgz",
             "integrity": "sha512-waxxwl/po1hN3azTyixKnr8ReEqUv5WK7WsO+5AWB0bFndML5Yqnt8ARZ90HEg8/P6WlqE/AB2413TkCRZE8bA==",
             "requires": {
-                "@babel/runtime": "^7.3.1",
+                "@babel/runtime": "7.6.2",
                 "jss": "10.0.0",
-                "tiny-warning": "^1.0.2"
+                "tiny-warning": "1.0.3"
             }
         },
         "jss-plugin-props-sort": {
@@ -6902,7 +6909,7 @@
             "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0.tgz",
             "integrity": "sha512-41mf22CImjwNdtOG3r+cdC8+RhwNm616sjHx5YlqTwtSJLyLFinbQC/a4PIFk8xqf1qpFH1kEAIw+yx9HaqZ3g==",
             "requires": {
-                "@babel/runtime": "^7.3.1",
+                "@babel/runtime": "7.6.2",
                 "jss": "10.0.0"
             }
         },
@@ -6911,7 +6918,7 @@
             "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0.tgz",
             "integrity": "sha512-Jw+BZ8JIw1f12V0SERqGlBT1JEPWax3vuZpMym54NAXpPb7R1LYHiCTIlaJUyqvIfEy3kiHMtgI+r2whGgRIxQ==",
             "requires": {
-                "@babel/runtime": "^7.3.1",
+                "@babel/runtime": "7.6.2",
                 "jss": "10.0.0"
             }
         },
@@ -6920,8 +6927,8 @@
             "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0.tgz",
             "integrity": "sha512-qslqvL0MUbWuzXJWdUxpj6mdNUX8jr4FFTo3aZnAT65nmzWL7g8oTr9ZxmTXXgdp7ANhS1QWE7036/Q2isFBpw==",
             "requires": {
-                "@babel/runtime": "^7.3.1",
-                "css-vendor": "^2.0.6",
+                "@babel/runtime": "7.6.2",
+                "css-vendor": "2.0.6",
                 "jss": "10.0.0"
             }
         },
@@ -6931,10 +6938,10 @@
             "integrity": "sha512-nUG73Sfi8L4eOkc7pv9sflgAm43v+z6XMuePGVdRoBUxBLJiVcMcf3Xgc4h19eHHF3JwsaagOkUu825UnPBLJw==",
             "dev": true,
             "requires": {
-                "lazy-seq": "^1.0.0",
-                "rc4": "~0.1.5",
-                "trampa": "^1.0.0",
-                "typify-parser": "^1.1.0"
+                "lazy-seq": "1.0.0",
+                "rc4": "0.1.5",
+                "trampa": "1.0.1",
+                "typify-parser": "1.1.0"
             }
         },
         "jsx-ast-utils": {
@@ -6943,8 +6950,8 @@
             "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
             "dev": true,
             "requires": {
-                "array-includes": "^3.0.3",
-                "object.assign": "^4.1.0"
+                "array-includes": "3.0.3",
+                "object.assign": "4.1.0"
             }
         },
         "keygrip": {
@@ -6977,31 +6984,31 @@
             "integrity": "sha512-q1uZOgpl3wjr5FS/tjbABJ8lA5+NeKa9eq7QyBP5xxgOBwJN4iBrMEgO3LroE51lrIw3BsO0WZZ0Yi6giSiMDw==",
             "dev": true,
             "requires": {
-                "accepts": "^1.3.5",
-                "cache-content-type": "^1.0.0",
-                "content-disposition": "~0.5.2",
-                "content-type": "^1.0.4",
-                "cookies": "~0.7.1",
-                "debug": "~3.1.0",
-                "delegates": "^1.0.0",
-                "depd": "^1.1.2",
-                "destroy": "^1.0.4",
-                "encodeurl": "^1.0.2",
-                "error-inject": "^1.0.0",
-                "escape-html": "^1.0.3",
-                "fresh": "~0.5.2",
-                "http-assert": "^1.3.0",
-                "http-errors": "^1.6.3",
-                "is-generator-function": "^1.0.7",
-                "koa-compose": "^4.1.0",
-                "koa-convert": "^1.2.0",
-                "koa-is-json": "^1.0.0",
-                "on-finished": "^2.3.0",
-                "only": "~0.0.2",
-                "parseurl": "^1.3.2",
-                "statuses": "^1.5.0",
-                "type-is": "^1.6.16",
-                "vary": "^1.1.2"
+                "accepts": "1.3.7",
+                "cache-content-type": "1.0.1",
+                "content-disposition": "0.5.3",
+                "content-type": "1.0.4",
+                "cookies": "0.7.3",
+                "debug": "3.1.0",
+                "delegates": "1.0.0",
+                "depd": "1.1.2",
+                "destroy": "1.0.4",
+                "encodeurl": "1.0.2",
+                "error-inject": "1.0.0",
+                "escape-html": "1.0.3",
+                "fresh": "0.5.2",
+                "http-assert": "1.4.1",
+                "http-errors": "1.7.3",
+                "is-generator-function": "1.0.7",
+                "koa-compose": "4.1.0",
+                "koa-convert": "1.2.0",
+                "koa-is-json": "1.0.0",
+                "on-finished": "2.3.0",
+                "only": "0.0.2",
+                "parseurl": "1.3.3",
+                "statuses": "1.5.0",
+                "type-is": "1.6.18",
+                "vary": "1.1.2"
             },
             "dependencies": {
                 "debug": {
@@ -7033,8 +7040,8 @@
             "integrity": "sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=",
             "dev": true,
             "requires": {
-                "co": "^4.6.0",
-                "koa-compose": "^3.0.0"
+                "co": "4.6.0",
+                "koa-compose": "3.2.1"
             },
             "dependencies": {
                 "koa-compose": {
@@ -7043,7 +7050,7 @@
                     "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
                     "dev": true,
                     "requires": {
-                        "any-promise": "^1.1.0"
+                        "any-promise": "1.3.0"
                     }
                 }
             }
@@ -7060,11 +7067,11 @@
             "integrity": "sha512-P+j2TzeZAqFwscd/dlLykk/sxwr6wQ5Tp3FYDhqv1+y9aRIffTPnu2zK+1BhfM+Kyh8bepU1jFR420maE+Vajw==",
             "dev": true,
             "requires": {
-                "app-root-path": "^2.0.1",
-                "merge-options": "^1.0.0",
-                "webpack-dev-middleware": "^3.0.0",
-                "webpack-hot-client": "^3.0.0",
-                "webpack-log": "^1.1.1"
+                "app-root-path": "2.2.1",
+                "merge-options": "1.0.1",
+                "webpack-dev-middleware": "3.7.2",
+                "webpack-hot-client": "3.0.0",
+                "webpack-log": "1.2.0"
             }
         },
         "latest-version": {
@@ -7073,7 +7080,7 @@
             "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
             "dev": true,
             "requires": {
-                "package-json": "^4.0.0"
+                "package-json": "4.0.1"
             }
         },
         "lazy-seq": {
@@ -7088,7 +7095,7 @@
             "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
             "dev": true,
             "requires": {
-                "invert-kv": "^2.0.0"
+                "invert-kv": "2.0.0"
             }
         },
         "leaflet": {
@@ -7119,8 +7126,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
             }
         },
         "load-json-file": {
@@ -7129,10 +7136,10 @@
             "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "strip-bom": "^3.0.0"
+                "graceful-fs": "4.2.2",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "strip-bom": "3.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -7155,9 +7162,9 @@
             "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
             "dev": true,
             "requires": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^2.0.0",
-                "json5": "^1.0.1"
+                "big.js": "5.2.2",
+                "emojis-list": "2.1.0",
+                "json5": "1.0.1"
             },
             "dependencies": {
                 "json5": {
@@ -7166,7 +7173,7 @@
                     "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
                     "dev": true,
                     "requires": {
-                        "minimist": "^1.2.0"
+                        "minimist": "1.2.0"
                     }
                 }
             }
@@ -7177,8 +7184,8 @@
             "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
             "dev": true,
             "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
+                "p-locate": "3.0.0",
+                "path-exists": "3.0.0"
             }
         },
         "lodash": {
@@ -7204,7 +7211,7 @@
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1"
+                "chalk": "2.4.2"
             }
         },
         "loglevelnext": {
@@ -7213,8 +7220,8 @@
             "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
             "dev": true,
             "requires": {
-                "es6-symbol": "^3.1.1",
-                "object.assign": "^4.1.0"
+                "es6-symbol": "3.1.2",
+                "object.assign": "4.1.0"
             }
         },
         "loose-envify": {
@@ -7222,7 +7229,7 @@
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
+                "js-tokens": "4.0.0"
             }
         },
         "loud-rejection": {
@@ -7231,8 +7238,8 @@
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "dev": true,
             "requires": {
-                "currently-unhandled": "^0.4.1",
-                "signal-exit": "^3.0.0"
+                "currently-unhandled": "0.4.1",
+                "signal-exit": "3.0.2"
             }
         },
         "lowercase-keys": {
@@ -7247,7 +7254,7 @@
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
             "requires": {
-                "yallist": "^3.0.2"
+                "yallist": "3.1.1"
             }
         },
         "make-dir": {
@@ -7256,8 +7263,8 @@
             "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
             "dev": true,
             "requires": {
-                "pify": "^4.0.1",
-                "semver": "^5.6.0"
+                "pify": "4.0.1",
+                "semver": "5.7.1"
             }
         },
         "makeerror": {
@@ -7266,7 +7273,7 @@
             "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
             "dev": true,
             "requires": {
-                "tmpl": "1.0.x"
+                "tmpl": "1.0.4"
             }
         },
         "mamacro": {
@@ -7281,7 +7288,7 @@
             "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
             "dev": true,
             "requires": {
-                "p-defer": "^1.0.0"
+                "p-defer": "1.0.0"
             }
         },
         "map-cache": {
@@ -7302,7 +7309,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "^1.0.0"
+                "object-visit": "1.0.1"
             }
         },
         "md5.js": {
@@ -7311,9 +7318,9 @@
             "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
             "dev": true,
             "requires": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.1.2"
+                "hash-base": "3.0.4",
+                "inherits": "2.0.4",
+                "safe-buffer": "5.1.2"
             }
         },
         "media-typer": {
@@ -7328,9 +7335,9 @@
             "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
             "dev": true,
             "requires": {
-                "map-age-cleaner": "^0.1.1",
-                "mimic-fn": "^2.0.0",
-                "p-is-promise": "^2.0.0"
+                "map-age-cleaner": "0.1.3",
+                "mimic-fn": "2.1.0",
+                "p-is-promise": "2.1.0"
             },
             "dependencies": {
                 "mimic-fn": {
@@ -7347,8 +7354,8 @@
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
             "dev": true,
             "requires": {
-                "errno": "^0.1.3",
-                "readable-stream": "^2.0.1"
+                "errno": "0.1.7",
+                "readable-stream": "2.3.6"
             },
             "dependencies": {
                 "isarray": {
@@ -7363,13 +7370,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -7378,7 +7385,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -7389,15 +7396,15 @@
             "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
             "dev": true,
             "requires": {
-                "camelcase-keys": "^4.0.0",
-                "decamelize-keys": "^1.0.0",
-                "loud-rejection": "^1.0.0",
-                "minimist-options": "^3.0.1",
-                "normalize-package-data": "^2.3.4",
-                "read-pkg-up": "^3.0.0",
-                "redent": "^2.0.0",
-                "trim-newlines": "^2.0.0",
-                "yargs-parser": "^10.0.0"
+                "camelcase-keys": "4.2.0",
+                "decamelize-keys": "1.1.0",
+                "loud-rejection": "1.6.0",
+                "minimist-options": "3.0.2",
+                "normalize-package-data": "2.5.0",
+                "read-pkg-up": "3.0.0",
+                "redent": "2.0.0",
+                "trim-newlines": "2.0.0",
+                "yargs-parser": "10.1.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -7412,7 +7419,7 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "2.0.0"
                     }
                 },
                 "load-json-file": {
@@ -7421,10 +7428,10 @@
                     "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^4.0.0",
-                        "pify": "^3.0.0",
-                        "strip-bom": "^3.0.0"
+                        "graceful-fs": "4.2.2",
+                        "parse-json": "4.0.0",
+                        "pify": "3.0.0",
+                        "strip-bom": "3.0.0"
                     }
                 },
                 "locate-path": {
@@ -7433,8 +7440,8 @@
                     "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                     "dev": true,
                     "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
                     }
                 },
                 "p-limit": {
@@ -7443,7 +7450,7 @@
                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
                     "dev": true,
                     "requires": {
-                        "p-try": "^1.0.0"
+                        "p-try": "1.0.0"
                     }
                 },
                 "p-locate": {
@@ -7452,7 +7459,7 @@
                     "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                     "dev": true,
                     "requires": {
-                        "p-limit": "^1.1.0"
+                        "p-limit": "1.3.0"
                     }
                 },
                 "p-try": {
@@ -7467,8 +7474,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "^1.3.1",
-                        "json-parse-better-errors": "^1.0.1"
+                        "error-ex": "1.3.2",
+                        "json-parse-better-errors": "1.0.2"
                     }
                 },
                 "path-type": {
@@ -7477,7 +7484,7 @@
                     "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
                     "dev": true,
                     "requires": {
-                        "pify": "^3.0.0"
+                        "pify": "3.0.0"
                     }
                 },
                 "pify": {
@@ -7492,9 +7499,9 @@
                     "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "^4.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^3.0.0"
+                        "load-json-file": "4.0.0",
+                        "normalize-package-data": "2.5.0",
+                        "path-type": "3.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -7503,8 +7510,8 @@
                     "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
                     "dev": true,
                     "requires": {
-                        "find-up": "^2.0.0",
-                        "read-pkg": "^3.0.0"
+                        "find-up": "2.1.0",
+                        "read-pkg": "3.0.0"
                     }
                 },
                 "yargs-parser": {
@@ -7513,7 +7520,7 @@
                     "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0"
+                        "camelcase": "4.1.0"
                     }
                 }
             }
@@ -7524,7 +7531,7 @@
             "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
             "dev": true,
             "requires": {
-                "is-plain-obj": "^1.1"
+                "is-plain-obj": "1.1.0"
             }
         },
         "merge-stream": {
@@ -7539,19 +7546,19 @@
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "dev": true,
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.13",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             }
         },
         "miller-rabin": {
@@ -7560,8 +7567,8 @@
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.0.0",
-                "brorand": "^1.0.1"
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0"
             }
         },
         "mime": {
@@ -7609,7 +7616,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -7624,8 +7631,8 @@
             "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
             "dev": true,
             "requires": {
-                "arrify": "^1.0.1",
-                "is-plain-obj": "^1.1.0"
+                "arrify": "1.0.1",
+                "is-plain-obj": "1.1.0"
             }
         },
         "mississippi": {
@@ -7634,16 +7641,16 @@
             "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
             "dev": true,
             "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^3.0.0",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
+                "concat-stream": "1.6.2",
+                "duplexify": "3.7.1",
+                "end-of-stream": "1.4.4",
+                "flush-write-stream": "1.1.1",
+                "from2": "2.3.0",
+                "parallel-transform": "1.2.0",
+                "pump": "3.0.0",
+                "pumpify": "1.5.1",
+                "stream-each": "1.2.3",
+                "through2": "2.0.5"
             }
         },
         "mixin-deep": {
@@ -7652,8 +7659,8 @@
             "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
             "dev": true,
             "requires": {
-                "for-in": "^1.0.2",
-                "is-extendable": "^1.0.1"
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -7662,7 +7669,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 },
                 "is-plain-object": {
@@ -7671,7 +7678,7 @@
                     "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
                     "dev": true,
                     "requires": {
-                        "isobject": "^3.0.1"
+                        "isobject": "3.0.1"
                     }
                 },
                 "isobject": {
@@ -7705,12 +7712,12 @@
             "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1",
-                "copy-concurrently": "^1.0.0",
-                "fs-write-stream-atomic": "^1.0.8",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.3"
+                "aproba": "1.2.0",
+                "copy-concurrently": "1.0.5",
+                "fs-write-stream-atomic": "1.0.10",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.3",
+                "run-queue": "1.0.3"
             }
         },
         "ms": {
@@ -7731,9 +7738,9 @@
             "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
             "dev": true,
             "requires": {
-                "any-promise": "^1.0.0",
-                "object-assign": "^4.0.1",
-                "thenify-all": "^1.0.0"
+                "any-promise": "1.3.0",
+                "object-assign": "4.1.1",
+                "thenify-all": "1.6.0"
             }
         },
         "nan": {
@@ -7755,9 +7762,9 @@
             "integrity": "sha512-Hv9USGyH8EsPy0o8pPWE7x3YRIfuZDgMBirzjU6XLebhiSK2g53JlfqgolD0c39ne6wXAfaBNcIAvYe22Bav+Q==",
             "dev": true,
             "requires": {
-                "nanoassert": "^1.1.0",
-                "nanotiming": "^7.2.0",
-                "remove-array-items": "^1.0.0"
+                "nanoassert": "1.1.0",
+                "nanotiming": "7.3.1",
+                "remove-array-items": "1.1.1"
             }
         },
         "nanomatch": {
@@ -7766,17 +7773,17 @@
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "dev": true,
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "fragment-cache": "^0.2.1",
-                "is-windows": "^1.0.2",
-                "kind-of": "^6.0.2",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             }
         },
         "nanoscheduler": {
@@ -7785,7 +7792,7 @@
             "integrity": "sha512-jBbrF3qdU9321r8n9X7yu18DjP31Do2ItJm3mWrt90wJTrnDO+HXpoV7ftaUglAtjgj9s+OaCxGufbvx6pvbEQ==",
             "dev": true,
             "requires": {
-                "nanoassert": "^1.1.0"
+                "nanoassert": "1.1.0"
             }
         },
         "nanotiming": {
@@ -7794,8 +7801,8 @@
             "integrity": "sha512-l3lC7v/PfOuRWQa8vV29Jo6TG10wHtnthLElFXs4Te4Aas57Fo4n1Q8LH9n+NDh9riOzTVvb2QNBhTS4JUKNjw==",
             "dev": true,
             "requires": {
-                "nanoassert": "^1.1.0",
-                "nanoscheduler": "^1.0.2"
+                "nanoassert": "1.1.0",
+                "nanoscheduler": "1.0.3"
             }
         },
         "natural-compare": {
@@ -7834,7 +7841,7 @@
             "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
             "dev": true,
             "requires": {
-                "minimatch": "^3.0.2"
+                "minimatch": "3.0.4"
             }
         },
         "node-int64": {
@@ -7849,29 +7856,29 @@
             "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
             "dev": true,
             "requires": {
-                "assert": "^1.1.1",
-                "browserify-zlib": "^0.2.0",
-                "buffer": "^4.3.0",
-                "console-browserify": "^1.1.0",
-                "constants-browserify": "^1.0.0",
-                "crypto-browserify": "^3.11.0",
-                "domain-browser": "^1.1.1",
-                "events": "^3.0.0",
-                "https-browserify": "^1.0.0",
-                "os-browserify": "^0.3.0",
+                "assert": "1.5.0",
+                "browserify-zlib": "0.2.0",
+                "buffer": "4.9.1",
+                "console-browserify": "1.1.0",
+                "constants-browserify": "1.0.0",
+                "crypto-browserify": "3.12.0",
+                "domain-browser": "1.2.0",
+                "events": "3.0.0",
+                "https-browserify": "1.0.0",
+                "os-browserify": "0.3.0",
                 "path-browserify": "0.0.1",
-                "process": "^0.11.10",
-                "punycode": "^1.2.4",
-                "querystring-es3": "^0.2.0",
-                "readable-stream": "^2.3.3",
-                "stream-browserify": "^2.0.1",
-                "stream-http": "^2.7.2",
-                "string_decoder": "^1.0.0",
-                "timers-browserify": "^2.0.4",
+                "process": "0.11.10",
+                "punycode": "1.4.1",
+                "querystring-es3": "0.2.1",
+                "readable-stream": "2.3.6",
+                "stream-browserify": "2.0.2",
+                "stream-http": "2.8.3",
+                "string_decoder": "1.3.0",
+                "timers-browserify": "2.0.11",
                 "tty-browserify": "0.0.0",
-                "url": "^0.11.0",
-                "util": "^0.11.0",
-                "vm-browserify": "^1.0.1"
+                "url": "0.11.0",
+                "util": "0.11.1",
+                "vm-browserify": "1.1.0"
             },
             "dependencies": {
                 "isarray": {
@@ -7892,13 +7899,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     },
                     "dependencies": {
                         "string_decoder": {
@@ -7907,7 +7914,7 @@
                             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "5.1.2"
                             }
                         }
                     }
@@ -7918,7 +7925,7 @@
                     "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.2.0"
+                        "safe-buffer": "5.2.0"
                     },
                     "dependencies": {
                         "safe-buffer": {
@@ -7943,11 +7950,11 @@
             "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
             "dev": true,
             "requires": {
-                "growly": "^1.3.0",
-                "is-wsl": "^1.1.0",
-                "semver": "^5.5.0",
-                "shellwords": "^0.1.1",
-                "which": "^1.3.0"
+                "growly": "1.3.0",
+                "is-wsl": "1.1.0",
+                "semver": "5.7.1",
+                "shellwords": "0.1.1",
+                "which": "1.3.1"
             }
         },
         "node-releases": {
@@ -7956,7 +7963,7 @@
             "integrity": "sha512-I0V30bWQEoHb+10W8oedVoUrdjW5wIkYm0w7vvcrPO95pZY738m1k77GF5sO0vKg5eXYg9oGtrMAETbgZGm11A==",
             "dev": true,
             "requires": {
-                "semver": "^5.3.0"
+                "semver": "5.7.1"
             }
         },
         "noms": {
@@ -7965,8 +7972,8 @@
             "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "~1.0.31"
+                "inherits": "2.0.4",
+                "readable-stream": "1.0.34"
             }
         },
         "normalize-package-data": {
@@ -7975,10 +7982,10 @@
             "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "^2.1.4",
-                "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
+                "hosted-git-info": "2.8.4",
+                "resolve": "1.12.0",
+                "semver": "5.7.1",
+                "validate-npm-package-license": "3.0.4"
             }
         },
         "normalize-path": {
@@ -7998,129 +8005,129 @@
             "integrity": "sha512-K2h+MPzZiY39Xf6eHEdECe/LKoJXam4UCflz5kIxoskN3LQFeYs5fqBGT5i4TtM/aBk+86Mcf+jgXs/WuWAutQ==",
             "dev": true,
             "requires": {
-                "JSONStream": "^1.3.5",
-                "abbrev": "~1.1.1",
-                "ansicolors": "~0.3.2",
-                "ansistyles": "~0.1.3",
-                "aproba": "^2.0.0",
-                "archy": "~1.0.0",
-                "bin-links": "^1.1.3",
-                "bluebird": "^3.5.5",
-                "byte-size": "^5.0.1",
-                "cacache": "^12.0.3",
-                "call-limit": "^1.1.1",
-                "chownr": "^1.1.2",
-                "ci-info": "^2.0.0",
-                "cli-columns": "^3.1.2",
-                "cli-table3": "^0.5.1",
-                "cmd-shim": "^3.0.3",
-                "columnify": "~1.5.4",
-                "config-chain": "^1.1.12",
-                "debuglog": "*",
-                "detect-indent": "~5.0.0",
-                "detect-newline": "^2.1.0",
-                "dezalgo": "~1.0.3",
-                "editor": "~1.0.0",
-                "figgy-pudding": "^3.5.1",
-                "find-npm-prefix": "^1.0.2",
-                "fs-vacuum": "~1.2.10",
-                "fs-write-stream-atomic": "~1.0.10",
-                "gentle-fs": "^2.2.1",
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.2.2",
-                "has-unicode": "~2.0.1",
-                "hosted-git-info": "^2.8.2",
-                "iferr": "^1.0.2",
-                "imurmurhash": "*",
-                "infer-owner": "^1.0.4",
-                "inflight": "~1.0.6",
-                "inherits": "^2.0.4",
-                "ini": "^1.3.5",
-                "init-package-json": "^1.10.3",
-                "is-cidr": "^3.0.0",
-                "json-parse-better-errors": "^1.0.2",
-                "lazy-property": "~1.0.0",
-                "libcipm": "^4.0.3",
-                "libnpm": "^3.0.1",
-                "libnpmaccess": "^3.0.2",
-                "libnpmhook": "^5.0.3",
-                "libnpmorg": "^1.0.1",
-                "libnpmsearch": "^2.0.2",
-                "libnpmteam": "^1.0.2",
-                "libnpx": "^10.2.0",
-                "lock-verify": "^2.1.0",
-                "lockfile": "^1.0.4",
-                "lodash._baseindexof": "*",
-                "lodash._baseuniq": "~4.6.0",
-                "lodash._bindcallback": "*",
-                "lodash._cacheindexof": "*",
-                "lodash._createcache": "*",
-                "lodash._getnative": "*",
-                "lodash.clonedeep": "~4.5.0",
-                "lodash.restparam": "*",
-                "lodash.union": "~4.6.0",
-                "lodash.uniq": "~4.5.0",
-                "lodash.without": "~4.4.0",
-                "lru-cache": "^5.1.1",
-                "meant": "~1.0.1",
-                "mississippi": "^3.0.0",
-                "mkdirp": "~0.5.1",
-                "move-concurrently": "^1.0.1",
-                "node-gyp": "^5.0.3",
-                "nopt": "~4.0.1",
-                "normalize-package-data": "^2.5.0",
-                "npm-audit-report": "^1.3.2",
-                "npm-cache-filename": "~1.0.2",
-                "npm-install-checks": "~3.0.0",
-                "npm-lifecycle": "^3.1.3",
-                "npm-package-arg": "^6.1.1",
-                "npm-packlist": "^1.4.4",
-                "npm-pick-manifest": "^3.0.2",
-                "npm-profile": "^4.0.2",
-                "npm-registry-fetch": "^4.0.0",
-                "npm-user-validate": "~1.0.0",
-                "npmlog": "~4.1.2",
-                "once": "~1.4.0",
-                "opener": "^1.5.1",
-                "osenv": "^0.1.5",
-                "pacote": "^9.5.8",
-                "path-is-inside": "~1.0.2",
-                "promise-inflight": "~1.0.1",
-                "qrcode-terminal": "^0.12.0",
-                "query-string": "^6.8.2",
-                "qw": "~1.0.1",
-                "read": "~1.0.7",
-                "read-cmd-shim": "^1.0.4",
-                "read-installed": "~4.0.3",
-                "read-package-json": "^2.1.0",
-                "read-package-tree": "^5.3.1",
-                "readable-stream": "^3.4.0",
-                "readdir-scoped-modules": "^1.1.0",
-                "request": "^2.88.0",
-                "retry": "^0.12.0",
-                "rimraf": "^2.6.3",
-                "safe-buffer": "^5.1.2",
-                "semver": "^5.7.1",
-                "sha": "^3.0.0",
-                "slide": "~1.1.6",
-                "sorted-object": "~2.0.1",
-                "sorted-union-stream": "~2.1.3",
-                "ssri": "^6.0.1",
-                "stringify-package": "^1.0.0",
-                "tar": "^4.4.10",
-                "text-table": "~0.2.0",
-                "tiny-relative-date": "^1.3.0",
+                "JSONStream": "1.3.5",
+                "abbrev": "1.1.1",
+                "ansicolors": "0.3.2",
+                "ansistyles": "0.1.3",
+                "aproba": "2.0.0",
+                "archy": "1.0.0",
+                "bin-links": "1.1.3",
+                "bluebird": "3.5.5",
+                "byte-size": "5.0.1",
+                "cacache": "12.0.3",
+                "call-limit": "1.1.1",
+                "chownr": "1.1.2",
+                "ci-info": "2.0.0",
+                "cli-columns": "3.1.2",
+                "cli-table3": "0.5.1",
+                "cmd-shim": "3.0.3",
+                "columnify": "1.5.4",
+                "config-chain": "1.1.12",
+                "debuglog": "1.0.1",
+                "detect-indent": "5.0.0",
+                "detect-newline": "2.1.0",
+                "dezalgo": "1.0.3",
+                "editor": "1.0.0",
+                "figgy-pudding": "3.5.1",
+                "find-npm-prefix": "1.0.2",
+                "fs-vacuum": "1.2.10",
+                "fs-write-stream-atomic": "1.0.10",
+                "gentle-fs": "2.2.1",
+                "glob": "7.1.4",
+                "graceful-fs": "4.2.2",
+                "has-unicode": "2.0.1",
+                "hosted-git-info": "2.8.2",
+                "iferr": "1.0.2",
+                "imurmurhash": "0.1.4",
+                "infer-owner": "1.0.4",
+                "inflight": "1.0.6",
+                "inherits": "2.0.4",
+                "ini": "1.3.5",
+                "init-package-json": "1.10.3",
+                "is-cidr": "3.0.0",
+                "json-parse-better-errors": "1.0.2",
+                "lazy-property": "1.0.0",
+                "libcipm": "4.0.3",
+                "libnpm": "3.0.1",
+                "libnpmaccess": "3.0.2",
+                "libnpmhook": "5.0.3",
+                "libnpmorg": "1.0.1",
+                "libnpmsearch": "2.0.2",
+                "libnpmteam": "1.0.2",
+                "libnpx": "10.2.0",
+                "lock-verify": "2.1.0",
+                "lockfile": "1.0.4",
+                "lodash._baseindexof": "3.1.0",
+                "lodash._baseuniq": "4.6.0",
+                "lodash._bindcallback": "3.0.1",
+                "lodash._cacheindexof": "3.0.2",
+                "lodash._createcache": "3.1.2",
+                "lodash._getnative": "3.9.1",
+                "lodash.clonedeep": "4.5.0",
+                "lodash.restparam": "3.6.1",
+                "lodash.union": "4.6.0",
+                "lodash.uniq": "4.5.0",
+                "lodash.without": "4.4.0",
+                "lru-cache": "5.1.1",
+                "meant": "1.0.1",
+                "mississippi": "3.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "node-gyp": "5.0.3",
+                "nopt": "4.0.1",
+                "normalize-package-data": "2.5.0",
+                "npm-audit-report": "1.3.2",
+                "npm-cache-filename": "1.0.2",
+                "npm-install-checks": "3.0.0",
+                "npm-lifecycle": "3.1.3",
+                "npm-package-arg": "6.1.1",
+                "npm-packlist": "1.4.4",
+                "npm-pick-manifest": "3.0.2",
+                "npm-profile": "4.0.2",
+                "npm-registry-fetch": "4.0.0",
+                "npm-user-validate": "1.0.0",
+                "npmlog": "4.1.2",
+                "once": "1.4.0",
+                "opener": "1.5.1",
+                "osenv": "0.1.5",
+                "pacote": "9.5.8",
+                "path-is-inside": "1.0.2",
+                "promise-inflight": "1.0.1",
+                "qrcode-terminal": "0.12.0",
+                "query-string": "6.8.2",
+                "qw": "1.0.1",
+                "read": "1.0.7",
+                "read-cmd-shim": "1.0.4",
+                "read-installed": "4.0.3",
+                "read-package-json": "2.1.0",
+                "read-package-tree": "5.3.1",
+                "readable-stream": "3.4.0",
+                "readdir-scoped-modules": "1.1.0",
+                "request": "2.88.0",
+                "retry": "0.12.0",
+                "rimraf": "2.6.3",
+                "safe-buffer": "5.1.2",
+                "semver": "5.7.1",
+                "sha": "3.0.0",
+                "slide": "1.1.6",
+                "sorted-object": "2.0.1",
+                "sorted-union-stream": "2.1.3",
+                "ssri": "6.0.1",
+                "stringify-package": "1.0.0",
+                "tar": "4.4.10",
+                "text-table": "0.2.0",
+                "tiny-relative-date": "1.3.0",
                 "uid-number": "0.0.6",
-                "umask": "~1.1.0",
-                "unique-filename": "^1.1.1",
-                "unpipe": "~1.0.0",
-                "update-notifier": "^2.5.0",
-                "uuid": "^3.3.2",
-                "validate-npm-package-license": "^3.0.4",
-                "validate-npm-package-name": "~3.0.0",
-                "which": "^1.3.1",
-                "worker-farm": "^1.7.0",
-                "write-file-atomic": "^2.4.3"
+                "umask": "1.1.0",
+                "unique-filename": "1.1.1",
+                "unpipe": "1.0.0",
+                "update-notifier": "2.5.0",
+                "uuid": "3.3.2",
+                "validate-npm-package-license": "3.0.4",
+                "validate-npm-package-name": "3.0.0",
+                "which": "1.3.1",
+                "worker-farm": "1.7.0",
+                "write-file-atomic": "2.4.3"
             },
             "dependencies": {
                 "JSONStream": {
@@ -8128,8 +8135,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "jsonparse": "^1.2.0",
-                        "through": ">=2.2.7 <3"
+                        "jsonparse": "1.3.1",
+                        "through": "2.3.8"
                     }
                 },
                 "abbrev": {
@@ -8142,7 +8149,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                     }
                 },
                 "agentkeepalive": {
@@ -8150,7 +8157,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "humanize-ms": "^1.2.1"
+                        "humanize-ms": "1.2.1"
                     }
                 },
                 "ajv": {
@@ -8158,10 +8165,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "co": "^4.6.0",
-                        "fast-deep-equal": "^1.0.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.3.0"
+                        "co": "4.6.0",
+                        "fast-deep-equal": "1.1.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1"
                     }
                 },
                 "ansi-align": {
@@ -8169,7 +8176,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "string-width": "^2.0.0"
+                        "string-width": "2.1.1"
                     }
                 },
                 "ansi-regex": {
@@ -8182,7 +8189,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "ansicolors": {
@@ -8210,8 +8217,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.3.6"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -8219,13 +8226,13 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.4",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "2.0.0",
+                                "safe-buffer": "5.1.2",
+                                "string_decoder": "1.1.1",
+                                "util-deprecate": "1.0.2"
                             }
                         },
                         "string_decoder": {
@@ -8233,7 +8240,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "5.1.2"
                             }
                         }
                     }
@@ -8248,7 +8255,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safer-buffer": "~2.1.0"
+                        "safer-buffer": "2.1.2"
                     }
                 },
                 "assert-plus": {
@@ -8282,7 +8289,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "tweetnacl": "^0.14.3"
+                        "tweetnacl": "0.14.5"
                     }
                 },
                 "bin-links": {
@@ -8290,11 +8297,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "bluebird": "^3.5.3",
-                        "cmd-shim": "^3.0.0",
-                        "gentle-fs": "^2.0.1",
-                        "graceful-fs": "^4.1.15",
-                        "write-file-atomic": "^2.3.0"
+                        "bluebird": "3.5.5",
+                        "cmd-shim": "3.0.3",
+                        "gentle-fs": "2.2.1",
+                        "graceful-fs": "4.2.2",
+                        "write-file-atomic": "2.4.3"
                     }
                 },
                 "bluebird": {
@@ -8307,13 +8314,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-align": "^2.0.0",
-                        "camelcase": "^4.0.0",
-                        "chalk": "^2.0.1",
-                        "cli-boxes": "^1.0.0",
-                        "string-width": "^2.0.0",
-                        "term-size": "^1.2.0",
-                        "widest-line": "^2.0.0"
+                        "ansi-align": "2.0.0",
+                        "camelcase": "4.1.0",
+                        "chalk": "2.4.1",
+                        "cli-boxes": "1.0.0",
+                        "string-width": "2.1.1",
+                        "term-size": "1.2.0",
+                        "widest-line": "2.0.0"
                     }
                 },
                 "brace-expansion": {
@@ -8321,7 +8328,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -8350,21 +8357,21 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "bluebird": "^3.5.5",
-                        "chownr": "^1.1.1",
-                        "figgy-pudding": "^3.5.1",
-                        "glob": "^7.1.4",
-                        "graceful-fs": "^4.1.15",
-                        "infer-owner": "^1.0.3",
-                        "lru-cache": "^5.1.1",
-                        "mississippi": "^3.0.0",
-                        "mkdirp": "^0.5.1",
-                        "move-concurrently": "^1.0.1",
-                        "promise-inflight": "^1.0.1",
-                        "rimraf": "^2.6.3",
-                        "ssri": "^6.0.1",
-                        "unique-filename": "^1.1.1",
-                        "y18n": "^4.0.0"
+                        "bluebird": "3.5.5",
+                        "chownr": "1.1.2",
+                        "figgy-pudding": "3.5.1",
+                        "glob": "7.1.4",
+                        "graceful-fs": "4.2.2",
+                        "infer-owner": "1.0.4",
+                        "lru-cache": "5.1.1",
+                        "mississippi": "3.0.0",
+                        "mkdirp": "0.5.1",
+                        "move-concurrently": "1.0.1",
+                        "promise-inflight": "1.0.1",
+                        "rimraf": "2.6.3",
+                        "ssri": "6.0.1",
+                        "unique-filename": "1.1.1",
+                        "y18n": "4.0.0"
                     }
                 },
                 "call-limit": {
@@ -8392,9 +8399,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
                     }
                 },
                 "chownr": {
@@ -8412,7 +8419,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ip-regex": "^2.1.0"
+                        "ip-regex": "2.1.0"
                     }
                 },
                 "cli-boxes": {
@@ -8425,8 +8432,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "string-width": "^2.0.0",
-                        "strip-ansi": "^3.0.1"
+                        "string-width": "2.1.1",
+                        "strip-ansi": "3.0.1"
                     }
                 },
                 "cli-table3": {
@@ -8434,9 +8441,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "colors": "^1.1.2",
-                        "object-assign": "^4.1.0",
-                        "string-width": "^2.1.1"
+                        "colors": "1.3.3",
+                        "object-assign": "4.1.1",
+                        "string-width": "2.1.1"
                     }
                 },
                 "cliui": {
@@ -8444,9 +8451,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "string-width": "^2.1.1",
-                        "strip-ansi": "^4.0.0",
-                        "wrap-ansi": "^2.0.0"
+                        "string-width": "2.1.1",
+                        "strip-ansi": "4.0.0",
+                        "wrap-ansi": "2.1.0"
                     },
                     "dependencies": {
                         "ansi-regex": {
@@ -8459,7 +8466,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "^3.0.0"
+                                "ansi-regex": "3.0.0"
                             }
                         }
                     }
@@ -8474,8 +8481,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "mkdirp": "~0.5.0"
+                        "graceful-fs": "4.2.2",
+                        "mkdirp": "0.5.1"
                     }
                 },
                 "co": {
@@ -8493,7 +8500,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "color-name": "^1.1.1"
+                        "color-name": "1.1.3"
                     }
                 },
                 "color-name": {
@@ -8512,8 +8519,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "strip-ansi": "^3.0.0",
-                        "wcwidth": "^1.0.0"
+                        "strip-ansi": "3.0.1",
+                        "wcwidth": "1.0.1"
                     }
                 },
                 "combined-stream": {
@@ -8521,7 +8528,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "delayed-stream": "~1.0.0"
+                        "delayed-stream": "1.0.0"
                     }
                 },
                 "concat-map": {
@@ -8534,10 +8541,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "buffer-from": "^1.0.0",
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.2.2",
-                        "typedarray": "^0.0.6"
+                        "buffer-from": "1.0.0",
+                        "inherits": "2.0.4",
+                        "readable-stream": "2.3.6",
+                        "typedarray": "0.0.6"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -8545,13 +8552,13 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.4",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "2.0.0",
+                                "safe-buffer": "5.1.2",
+                                "string_decoder": "1.1.1",
+                                "util-deprecate": "1.0.2"
                             }
                         },
                         "string_decoder": {
@@ -8559,7 +8566,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "5.1.2"
                             }
                         }
                     }
@@ -8569,8 +8576,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ini": "^1.3.4",
-                        "proto-list": "~1.2.1"
+                        "ini": "1.3.5",
+                        "proto-list": "1.2.4"
                     }
                 },
                 "configstore": {
@@ -8578,12 +8585,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "dot-prop": "^4.1.0",
-                        "graceful-fs": "^4.1.2",
-                        "make-dir": "^1.0.0",
-                        "unique-string": "^1.0.0",
-                        "write-file-atomic": "^2.0.0",
-                        "xdg-basedir": "^3.0.0"
+                        "dot-prop": "4.2.0",
+                        "graceful-fs": "4.2.2",
+                        "make-dir": "1.3.0",
+                        "unique-string": "1.0.0",
+                        "write-file-atomic": "2.4.3",
+                        "xdg-basedir": "3.0.0"
                     }
                 },
                 "console-control-strings": {
@@ -8596,12 +8603,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "aproba": "^1.1.1",
-                        "fs-write-stream-atomic": "^1.0.8",
-                        "iferr": "^0.1.5",
-                        "mkdirp": "^0.5.1",
-                        "rimraf": "^2.5.4",
-                        "run-queue": "^1.0.0"
+                        "aproba": "1.2.0",
+                        "fs-write-stream-atomic": "1.0.10",
+                        "iferr": "0.1.5",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.3",
+                        "run-queue": "1.0.3"
                     },
                     "dependencies": {
                         "aproba": {
@@ -8626,7 +8633,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "capture-stack-trace": "^1.0.0"
+                        "capture-stack-trace": "1.0.0"
                     }
                 },
                 "cross-spawn": {
@@ -8634,9 +8641,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^4.0.1",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
+                        "lru-cache": "4.1.5",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.1"
                     },
                     "dependencies": {
                         "lru-cache": {
@@ -8644,8 +8651,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "pseudomap": "^1.0.2",
-                                "yallist": "^2.1.2"
+                                "pseudomap": "1.0.2",
+                                "yallist": "2.1.2"
                             }
                         },
                         "yallist": {
@@ -8670,7 +8677,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "assert-plus": "^1.0.0"
+                        "assert-plus": "1.0.0"
                     }
                 },
                 "debug": {
@@ -8713,7 +8720,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "clone": "^1.0.2"
+                        "clone": "1.0.4"
                     }
                 },
                 "define-properties": {
@@ -8721,7 +8728,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "object-keys": "^1.0.12"
+                        "object-keys": "1.0.12"
                     }
                 },
                 "delayed-stream": {
@@ -8749,8 +8756,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "asap": "^2.0.0",
-                        "wrappy": "1"
+                        "asap": "2.0.6",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "dot-prop": {
@@ -8758,7 +8765,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-obj": "^1.0.0"
+                        "is-obj": "1.0.1"
                     }
                 },
                 "dotenv": {
@@ -8776,10 +8783,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "end-of-stream": "^1.0.0",
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0",
-                        "stream-shift": "^1.0.0"
+                        "end-of-stream": "1.4.1",
+                        "inherits": "2.0.4",
+                        "readable-stream": "2.3.6",
+                        "stream-shift": "1.0.0"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -8787,13 +8794,13 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.4",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "2.0.0",
+                                "safe-buffer": "5.1.2",
+                                "string_decoder": "1.1.1",
+                                "util-deprecate": "1.0.2"
                             }
                         },
                         "string_decoder": {
@@ -8801,7 +8808,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "5.1.2"
                             }
                         }
                     }
@@ -8812,8 +8819,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "~0.1.0",
-                        "safer-buffer": "^2.1.0"
+                        "jsbn": "0.1.1",
+                        "safer-buffer": "2.1.2"
                     }
                 },
                 "editor": {
@@ -8826,7 +8833,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "iconv-lite": "~0.4.13"
+                        "iconv-lite": "0.4.23"
                     }
                 },
                 "end-of-stream": {
@@ -8834,7 +8841,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "once": "^1.4.0"
+                        "once": "1.4.0"
                     }
                 },
                 "env-paths": {
@@ -8852,7 +8859,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "prr": "~1.0.1"
+                        "prr": "1.0.1"
                     }
                 },
                 "es-abstract": {
@@ -8860,11 +8867,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "es-to-primitive": "^1.1.1",
-                        "function-bind": "^1.1.1",
-                        "has": "^1.0.1",
-                        "is-callable": "^1.1.3",
-                        "is-regex": "^1.0.4"
+                        "es-to-primitive": "1.2.0",
+                        "function-bind": "1.1.1",
+                        "has": "1.0.3",
+                        "is-callable": "1.1.4",
+                        "is-regex": "1.0.4"
                     }
                 },
                 "es-to-primitive": {
@@ -8872,9 +8879,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-callable": "^1.1.4",
-                        "is-date-object": "^1.0.1",
-                        "is-symbol": "^1.0.2"
+                        "is-callable": "1.1.4",
+                        "is-date-object": "1.0.1",
+                        "is-symbol": "1.0.2"
                     }
                 },
                 "es6-promise": {
@@ -8887,7 +8894,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "es6-promise": "^4.0.3"
+                        "es6-promise": "4.2.8"
                     }
                 },
                 "escape-string-regexp": {
@@ -8900,13 +8907,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                     },
                     "dependencies": {
                         "get-stream": {
@@ -8951,7 +8958,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "2.0.0"
                     }
                 },
                 "flush-write-stream": {
@@ -8959,8 +8966,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.4"
+                        "inherits": "2.0.4",
+                        "readable-stream": "2.3.6"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -8968,13 +8975,13 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.4",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "2.0.0",
+                                "safe-buffer": "5.1.2",
+                                "string_decoder": "1.1.1",
+                                "util-deprecate": "1.0.2"
                             }
                         },
                         "string_decoder": {
@@ -8982,7 +8989,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "5.1.2"
                             }
                         }
                     }
@@ -8997,9 +9004,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "asynckit": "^0.4.0",
+                        "asynckit": "0.4.0",
                         "combined-stream": "1.0.6",
-                        "mime-types": "^2.1.12"
+                        "mime-types": "2.1.19"
                     }
                 },
                 "from2": {
@@ -9007,8 +9014,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0"
+                        "inherits": "2.0.4",
+                        "readable-stream": "2.3.6"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -9016,13 +9023,13 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.4",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "2.0.0",
+                                "safe-buffer": "5.1.2",
+                                "string_decoder": "1.1.1",
+                                "util-deprecate": "1.0.2"
                             }
                         },
                         "string_decoder": {
@@ -9030,7 +9037,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "5.1.2"
                             }
                         }
                     }
@@ -9040,7 +9047,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "2.3.3"
                     }
                 },
                 "fs-vacuum": {
@@ -9048,9 +9055,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "path-is-inside": "^1.0.1",
-                        "rimraf": "^2.5.2"
+                        "graceful-fs": "4.2.2",
+                        "path-is-inside": "1.0.2",
+                        "rimraf": "2.6.3"
                     }
                 },
                 "fs-write-stream-atomic": {
@@ -9058,10 +9065,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "iferr": "^0.1.5",
-                        "imurmurhash": "^0.1.4",
-                        "readable-stream": "1 || 2"
+                        "graceful-fs": "4.2.2",
+                        "iferr": "0.1.5",
+                        "imurmurhash": "0.1.4",
+                        "readable-stream": "2.3.6"
                     },
                     "dependencies": {
                         "iferr": {
@@ -9074,13 +9081,13 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.4",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "2.0.0",
+                                "safe-buffer": "5.1.2",
+                                "string_decoder": "1.1.1",
+                                "util-deprecate": "1.0.2"
                             }
                         },
                         "string_decoder": {
@@ -9088,7 +9095,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "5.1.2"
                             }
                         }
                     }
@@ -9108,14 +9115,14 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
+                        "aproba": "1.2.0",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
                     },
                     "dependencies": {
                         "aproba": {
@@ -9128,9 +9135,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
                             }
                         }
                     }
@@ -9145,16 +9152,16 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "aproba": "^1.1.2",
-                        "chownr": "^1.1.2",
-                        "fs-vacuum": "^1.2.10",
-                        "graceful-fs": "^4.1.11",
-                        "iferr": "^0.1.5",
-                        "infer-owner": "^1.0.4",
-                        "mkdirp": "^0.5.1",
-                        "path-is-inside": "^1.0.2",
-                        "read-cmd-shim": "^1.0.1",
-                        "slide": "^1.1.6"
+                        "aproba": "1.2.0",
+                        "chownr": "1.1.2",
+                        "fs-vacuum": "1.2.10",
+                        "graceful-fs": "4.2.2",
+                        "iferr": "0.1.5",
+                        "infer-owner": "1.0.4",
+                        "mkdirp": "0.5.1",
+                        "path-is-inside": "1.0.2",
+                        "read-cmd-shim": "1.0.4",
+                        "slide": "1.1.6"
                     },
                     "dependencies": {
                         "aproba": {
@@ -9179,7 +9186,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pump": "^3.0.0"
+                        "pump": "3.0.0"
                     }
                 },
                 "getpass": {
@@ -9187,7 +9194,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "assert-plus": "^1.0.0"
+                        "assert-plus": "1.0.0"
                     }
                 },
                 "glob": {
@@ -9195,12 +9202,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.4",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "global-dirs": {
@@ -9208,7 +9215,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ini": "^1.3.4"
+                        "ini": "1.3.5"
                     }
                 },
                 "got": {
@@ -9216,17 +9223,17 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "create-error-class": "^3.0.0",
-                        "duplexer3": "^0.1.4",
-                        "get-stream": "^3.0.0",
-                        "is-redirect": "^1.0.0",
-                        "is-retry-allowed": "^1.0.0",
-                        "is-stream": "^1.0.0",
-                        "lowercase-keys": "^1.0.0",
-                        "safe-buffer": "^5.0.1",
-                        "timed-out": "^4.0.0",
-                        "unzip-response": "^2.0.1",
-                        "url-parse-lax": "^1.0.0"
+                        "create-error-class": "3.0.2",
+                        "duplexer3": "0.1.4",
+                        "get-stream": "3.0.0",
+                        "is-redirect": "1.0.0",
+                        "is-retry-allowed": "1.1.0",
+                        "is-stream": "1.1.0",
+                        "lowercase-keys": "1.0.1",
+                        "safe-buffer": "5.1.2",
+                        "timed-out": "4.0.1",
+                        "unzip-response": "2.0.1",
+                        "url-parse-lax": "1.0.0"
                     },
                     "dependencies": {
                         "get-stream": {
@@ -9251,8 +9258,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ajv": "^5.3.0",
-                        "har-schema": "^2.0.0"
+                        "ajv": "5.5.2",
+                        "har-schema": "2.0.0"
                     }
                 },
                 "has": {
@@ -9260,7 +9267,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "function-bind": "^1.1.1"
+                        "function-bind": "1.1.1"
                     }
                 },
                 "has-flag": {
@@ -9283,7 +9290,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^5.1.1"
+                        "lru-cache": "5.1.1"
                     }
                 },
                 "http-cache-semantics": {
@@ -9296,7 +9303,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "agent-base": "4",
+                        "agent-base": "4.3.0",
                         "debug": "3.1.0"
                     }
                 },
@@ -9305,9 +9312,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "assert-plus": "^1.0.0",
-                        "jsprim": "^1.2.2",
-                        "sshpk": "^1.7.0"
+                        "assert-plus": "1.0.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.14.2"
                     }
                 },
                 "https-proxy-agent": {
@@ -9315,8 +9322,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "agent-base": "^4.3.0",
-                        "debug": "^3.1.0"
+                        "agent-base": "4.3.0",
+                        "debug": "3.1.0"
                     }
                 },
                 "humanize-ms": {
@@ -9324,7 +9331,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ms": "^2.0.0"
+                        "ms": "2.1.1"
                     }
                 },
                 "iconv-lite": {
@@ -9332,7 +9339,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
+                        "safer-buffer": "2.1.2"
                     }
                 },
                 "iferr": {
@@ -9345,7 +9352,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "minimatch": "^3.0.4"
+                        "minimatch": "3.0.4"
                     }
                 },
                 "import-lazy": {
@@ -9368,8 +9375,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -9387,14 +9394,14 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "^7.1.1",
-                        "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
-                        "promzard": "^0.3.0",
-                        "read": "~1.0.1",
-                        "read-package-json": "1 || 2",
-                        "semver": "2.x || 3.x || 4 || 5",
-                        "validate-npm-package-license": "^3.0.1",
-                        "validate-npm-package-name": "^3.0.0"
+                        "glob": "7.1.4",
+                        "npm-package-arg": "6.1.1",
+                        "promzard": "0.3.0",
+                        "read": "1.0.7",
+                        "read-package-json": "2.1.0",
+                        "semver": "5.7.1",
+                        "validate-npm-package-license": "3.0.4",
+                        "validate-npm-package-name": "3.0.0"
                     }
                 },
                 "invert-kv": {
@@ -9422,7 +9429,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ci-info": "^1.0.0"
+                        "ci-info": "1.6.0"
                     },
                     "dependencies": {
                         "ci-info": {
@@ -9437,7 +9444,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cidr-regex": "^2.0.10"
+                        "cidr-regex": "2.0.10"
                     }
                 },
                 "is-date-object": {
@@ -9450,7 +9457,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "is-installed-globally": {
@@ -9458,8 +9465,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "global-dirs": "^0.1.0",
-                        "is-path-inside": "^1.0.0"
+                        "global-dirs": "0.1.1",
+                        "is-path-inside": "1.0.1"
                     }
                 },
                 "is-npm": {
@@ -9477,7 +9484,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "path-is-inside": "^1.0.1"
+                        "path-is-inside": "1.0.2"
                     }
                 },
                 "is-redirect": {
@@ -9490,7 +9497,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "has": "^1.0.1"
+                        "has": "1.0.3"
                     }
                 },
                 "is-retry-allowed": {
@@ -9508,7 +9515,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "has-symbols": "^1.0.0"
+                        "has-symbols": "1.0.0"
                     }
                 },
                 "is-typedarray": {
@@ -9578,7 +9585,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "package-json": "^4.0.0"
+                        "package-json": "4.0.1"
                     }
                 },
                 "lazy-property": {
@@ -9591,7 +9598,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "invert-kv": "^1.0.0"
+                        "invert-kv": "1.0.0"
                     }
                 },
                 "libcipm": {
@@ -9599,21 +9606,21 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "bin-links": "^1.1.2",
-                        "bluebird": "^3.5.1",
-                        "figgy-pudding": "^3.5.1",
-                        "find-npm-prefix": "^1.0.2",
-                        "graceful-fs": "^4.1.11",
-                        "ini": "^1.3.5",
-                        "lock-verify": "^2.0.2",
-                        "mkdirp": "^0.5.1",
-                        "npm-lifecycle": "^3.0.0",
-                        "npm-logical-tree": "^1.2.1",
-                        "npm-package-arg": "^6.1.0",
-                        "pacote": "^9.1.0",
-                        "read-package-json": "^2.0.13",
-                        "rimraf": "^2.6.2",
-                        "worker-farm": "^1.6.0"
+                        "bin-links": "1.1.3",
+                        "bluebird": "3.5.5",
+                        "figgy-pudding": "3.5.1",
+                        "find-npm-prefix": "1.0.2",
+                        "graceful-fs": "4.2.2",
+                        "ini": "1.3.5",
+                        "lock-verify": "2.1.0",
+                        "mkdirp": "0.5.1",
+                        "npm-lifecycle": "3.1.3",
+                        "npm-logical-tree": "1.2.1",
+                        "npm-package-arg": "6.1.1",
+                        "pacote": "9.5.8",
+                        "read-package-json": "2.1.0",
+                        "rimraf": "2.6.3",
+                        "worker-farm": "1.7.0"
                     }
                 },
                 "libnpm": {
@@ -9621,26 +9628,26 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "bin-links": "^1.1.2",
-                        "bluebird": "^3.5.3",
-                        "find-npm-prefix": "^1.0.2",
-                        "libnpmaccess": "^3.0.2",
-                        "libnpmconfig": "^1.2.1",
-                        "libnpmhook": "^5.0.3",
-                        "libnpmorg": "^1.0.1",
-                        "libnpmpublish": "^1.1.2",
-                        "libnpmsearch": "^2.0.2",
-                        "libnpmteam": "^1.0.2",
-                        "lock-verify": "^2.0.2",
-                        "npm-lifecycle": "^3.0.0",
-                        "npm-logical-tree": "^1.2.1",
-                        "npm-package-arg": "^6.1.0",
-                        "npm-profile": "^4.0.2",
-                        "npm-registry-fetch": "^4.0.0",
-                        "npmlog": "^4.1.2",
-                        "pacote": "^9.5.3",
-                        "read-package-json": "^2.0.13",
-                        "stringify-package": "^1.0.0"
+                        "bin-links": "1.1.3",
+                        "bluebird": "3.5.5",
+                        "find-npm-prefix": "1.0.2",
+                        "libnpmaccess": "3.0.2",
+                        "libnpmconfig": "1.2.1",
+                        "libnpmhook": "5.0.3",
+                        "libnpmorg": "1.0.1",
+                        "libnpmpublish": "1.1.2",
+                        "libnpmsearch": "2.0.2",
+                        "libnpmteam": "1.0.2",
+                        "lock-verify": "2.1.0",
+                        "npm-lifecycle": "3.1.3",
+                        "npm-logical-tree": "1.2.1",
+                        "npm-package-arg": "6.1.1",
+                        "npm-profile": "4.0.2",
+                        "npm-registry-fetch": "4.0.0",
+                        "npmlog": "4.1.2",
+                        "pacote": "9.5.8",
+                        "read-package-json": "2.1.0",
+                        "stringify-package": "1.0.0"
                     }
                 },
                 "libnpmaccess": {
@@ -9648,10 +9655,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "aproba": "^2.0.0",
-                        "get-stream": "^4.0.0",
-                        "npm-package-arg": "^6.1.0",
-                        "npm-registry-fetch": "^4.0.0"
+                        "aproba": "2.0.0",
+                        "get-stream": "4.1.0",
+                        "npm-package-arg": "6.1.1",
+                        "npm-registry-fetch": "4.0.0"
                     }
                 },
                 "libnpmconfig": {
@@ -9659,9 +9666,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "figgy-pudding": "^3.5.1",
-                        "find-up": "^3.0.0",
-                        "ini": "^1.3.5"
+                        "figgy-pudding": "3.5.1",
+                        "find-up": "3.0.0",
+                        "ini": "1.3.5"
                     },
                     "dependencies": {
                         "find-up": {
@@ -9669,7 +9676,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "locate-path": "^3.0.0"
+                                "locate-path": "3.0.0"
                             }
                         },
                         "locate-path": {
@@ -9677,8 +9684,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "p-locate": "^3.0.0",
-                                "path-exists": "^3.0.0"
+                                "p-locate": "3.0.0",
+                                "path-exists": "3.0.0"
                             }
                         },
                         "p-limit": {
@@ -9686,7 +9693,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "p-try": "^2.0.0"
+                                "p-try": "2.2.0"
                             }
                         },
                         "p-locate": {
@@ -9694,7 +9701,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "p-limit": "^2.0.0"
+                                "p-limit": "2.2.0"
                             }
                         },
                         "p-try": {
@@ -9709,10 +9716,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "aproba": "^2.0.0",
-                        "figgy-pudding": "^3.4.1",
-                        "get-stream": "^4.0.0",
-                        "npm-registry-fetch": "^4.0.0"
+                        "aproba": "2.0.0",
+                        "figgy-pudding": "3.5.1",
+                        "get-stream": "4.1.0",
+                        "npm-registry-fetch": "4.0.0"
                     }
                 },
                 "libnpmorg": {
@@ -9720,10 +9727,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "aproba": "^2.0.0",
-                        "figgy-pudding": "^3.4.1",
-                        "get-stream": "^4.0.0",
-                        "npm-registry-fetch": "^4.0.0"
+                        "aproba": "2.0.0",
+                        "figgy-pudding": "3.5.1",
+                        "get-stream": "4.1.0",
+                        "npm-registry-fetch": "4.0.0"
                     }
                 },
                 "libnpmpublish": {
@@ -9731,15 +9738,15 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "aproba": "^2.0.0",
-                        "figgy-pudding": "^3.5.1",
-                        "get-stream": "^4.0.0",
-                        "lodash.clonedeep": "^4.5.0",
-                        "normalize-package-data": "^2.4.0",
-                        "npm-package-arg": "^6.1.0",
-                        "npm-registry-fetch": "^4.0.0",
-                        "semver": "^5.5.1",
-                        "ssri": "^6.0.1"
+                        "aproba": "2.0.0",
+                        "figgy-pudding": "3.5.1",
+                        "get-stream": "4.1.0",
+                        "lodash.clonedeep": "4.5.0",
+                        "normalize-package-data": "2.5.0",
+                        "npm-package-arg": "6.1.1",
+                        "npm-registry-fetch": "4.0.0",
+                        "semver": "5.7.1",
+                        "ssri": "6.0.1"
                     }
                 },
                 "libnpmsearch": {
@@ -9747,9 +9754,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "figgy-pudding": "^3.5.1",
-                        "get-stream": "^4.0.0",
-                        "npm-registry-fetch": "^4.0.0"
+                        "figgy-pudding": "3.5.1",
+                        "get-stream": "4.1.0",
+                        "npm-registry-fetch": "4.0.0"
                     }
                 },
                 "libnpmteam": {
@@ -9757,10 +9764,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "aproba": "^2.0.0",
-                        "figgy-pudding": "^3.4.1",
-                        "get-stream": "^4.0.0",
-                        "npm-registry-fetch": "^4.0.0"
+                        "aproba": "2.0.0",
+                        "figgy-pudding": "3.5.1",
+                        "get-stream": "4.1.0",
+                        "npm-registry-fetch": "4.0.0"
                     }
                 },
                 "libnpx": {
@@ -9768,14 +9775,14 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "dotenv": "^5.0.1",
-                        "npm-package-arg": "^6.0.0",
-                        "rimraf": "^2.6.2",
-                        "safe-buffer": "^5.1.0",
-                        "update-notifier": "^2.3.0",
-                        "which": "^1.3.0",
-                        "y18n": "^4.0.0",
-                        "yargs": "^11.0.0"
+                        "dotenv": "5.0.1",
+                        "npm-package-arg": "6.1.1",
+                        "rimraf": "2.6.3",
+                        "safe-buffer": "5.1.2",
+                        "update-notifier": "2.5.0",
+                        "which": "1.3.1",
+                        "y18n": "4.0.0",
+                        "yargs": "11.0.0"
                     }
                 },
                 "locate-path": {
@@ -9783,8 +9790,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
                     }
                 },
                 "lock-verify": {
@@ -9792,8 +9799,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "npm-package-arg": "^6.1.0",
-                        "semver": "^5.4.1"
+                        "npm-package-arg": "6.1.1",
+                        "semver": "5.7.1"
                     }
                 },
                 "lockfile": {
@@ -9801,7 +9808,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "signal-exit": "^3.0.2"
+                        "signal-exit": "3.0.2"
                     }
                 },
                 "lodash._baseindexof": {
@@ -9814,8 +9821,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "lodash._createset": "~4.0.0",
-                        "lodash._root": "~3.0.0"
+                        "lodash._createset": "4.0.3",
+                        "lodash._root": "3.0.1"
                     }
                 },
                 "lodash._bindcallback": {
@@ -9833,7 +9840,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "lodash._getnative": "^3.0.0"
+                        "lodash._getnative": "3.9.1"
                     }
                 },
                 "lodash._createset": {
@@ -9886,7 +9893,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "yallist": "^3.0.2"
+                        "yallist": "3.0.3"
                     }
                 },
                 "make-dir": {
@@ -9894,7 +9901,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pify": "^3.0.0"
+                        "pify": "3.0.0"
                     }
                 },
                 "make-fetch-happen": {
@@ -9902,17 +9909,17 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "agentkeepalive": "^3.4.1",
-                        "cacache": "^12.0.0",
-                        "http-cache-semantics": "^3.8.1",
-                        "http-proxy-agent": "^2.1.0",
-                        "https-proxy-agent": "^2.2.1",
-                        "lru-cache": "^5.1.1",
-                        "mississippi": "^3.0.0",
-                        "node-fetch-npm": "^2.0.2",
-                        "promise-retry": "^1.1.1",
-                        "socks-proxy-agent": "^4.0.0",
-                        "ssri": "^6.0.0"
+                        "agentkeepalive": "3.5.2",
+                        "cacache": "12.0.3",
+                        "http-cache-semantics": "3.8.1",
+                        "http-proxy-agent": "2.1.0",
+                        "https-proxy-agent": "2.2.2",
+                        "lru-cache": "5.1.1",
+                        "mississippi": "3.0.0",
+                        "node-fetch-npm": "2.0.2",
+                        "promise-retry": "1.1.1",
+                        "socks-proxy-agent": "4.0.2",
+                        "ssri": "6.0.1"
                     }
                 },
                 "meant": {
@@ -9925,7 +9932,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "^1.0.0"
+                        "mimic-fn": "1.2.0"
                     }
                 },
                 "mime-db": {
@@ -9938,7 +9945,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mime-db": "~1.35.0"
+                        "mime-db": "1.35.0"
                     }
                 },
                 "mimic-fn": {
@@ -9951,7 +9958,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "minimist": {
@@ -9964,8 +9971,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.0"
+                        "safe-buffer": "5.1.2",
+                        "yallist": "3.0.2"
                     },
                     "dependencies": {
                         "yallist": {
@@ -9980,7 +9987,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "2.3.3"
                     }
                 },
                 "mississippi": {
@@ -9988,16 +9995,16 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^3.0.0",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.6.0",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "3.0.0",
+                        "pumpify": "1.5.1",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
                     }
                 },
                 "mkdirp": {
@@ -10013,12 +10020,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "aproba": "^1.1.1",
-                        "copy-concurrently": "^1.0.0",
-                        "fs-write-stream-atomic": "^1.0.8",
-                        "mkdirp": "^0.5.1",
-                        "rimraf": "^2.5.4",
-                        "run-queue": "^1.0.3"
+                        "aproba": "1.2.0",
+                        "copy-concurrently": "1.0.5",
+                        "fs-write-stream-atomic": "1.0.10",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.3",
+                        "run-queue": "1.0.3"
                     },
                     "dependencies": {
                         "aproba": {
@@ -10043,9 +10050,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "encoding": "^0.1.11",
-                        "json-parse-better-errors": "^1.0.0",
-                        "safe-buffer": "^5.1.1"
+                        "encoding": "0.1.12",
+                        "json-parse-better-errors": "1.0.2",
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "node-gyp": {
@@ -10053,17 +10060,17 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "env-paths": "^1.0.0",
-                        "glob": "^7.0.3",
-                        "graceful-fs": "^4.1.2",
-                        "mkdirp": "^0.5.0",
-                        "nopt": "2 || 3",
-                        "npmlog": "0 || 1 || 2 || 3 || 4",
-                        "request": "^2.87.0",
-                        "rimraf": "2",
-                        "semver": "~5.3.0",
-                        "tar": "^4.4.8",
-                        "which": "1"
+                        "env-paths": "1.0.0",
+                        "glob": "7.1.4",
+                        "graceful-fs": "4.2.2",
+                        "mkdirp": "0.5.1",
+                        "nopt": "3.0.6",
+                        "npmlog": "4.1.2",
+                        "request": "2.88.0",
+                        "rimraf": "2.6.3",
+                        "semver": "5.3.0",
+                        "tar": "4.4.10",
+                        "which": "1.3.1"
                     },
                     "dependencies": {
                         "nopt": {
@@ -10071,7 +10078,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "abbrev": "1"
+                                "abbrev": "1.1.1"
                             }
                         },
                         "semver": {
@@ -10086,8 +10093,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
+                        "abbrev": "1.1.1",
+                        "osenv": "0.1.5"
                     }
                 },
                 "normalize-package-data": {
@@ -10095,10 +10102,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hosted-git-info": "^2.1.4",
-                        "resolve": "^1.10.0",
-                        "semver": "2 || 3 || 4 || 5",
-                        "validate-npm-package-license": "^3.0.1"
+                        "hosted-git-info": "2.8.2",
+                        "resolve": "1.10.0",
+                        "semver": "5.7.1",
+                        "validate-npm-package-license": "3.0.4"
                     },
                     "dependencies": {
                         "resolve": {
@@ -10106,7 +10113,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "path-parse": "^1.0.6"
+                                "path-parse": "1.0.6"
                             }
                         }
                     }
@@ -10116,8 +10123,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cli-table3": "^0.5.0",
-                        "console-control-strings": "^1.1.0"
+                        "cli-table3": "0.5.1",
+                        "console-control-strings": "1.1.0"
                     }
                 },
                 "npm-bundled": {
@@ -10135,7 +10142,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "semver": "^2.3.0 || 3.x || 4 || 5"
+                        "semver": "5.7.1"
                     }
                 },
                 "npm-lifecycle": {
@@ -10143,14 +10150,14 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "byline": "^5.0.0",
-                        "graceful-fs": "^4.1.15",
-                        "node-gyp": "^5.0.2",
-                        "resolve-from": "^4.0.0",
-                        "slide": "^1.1.6",
+                        "byline": "5.0.0",
+                        "graceful-fs": "4.2.2",
+                        "node-gyp": "5.0.3",
+                        "resolve-from": "4.0.0",
+                        "slide": "1.1.6",
                         "uid-number": "0.0.6",
-                        "umask": "^1.1.0",
-                        "which": "^1.3.1"
+                        "umask": "1.1.0",
+                        "which": "1.3.1"
                     }
                 },
                 "npm-logical-tree": {
@@ -10163,10 +10170,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hosted-git-info": "^2.7.1",
-                        "osenv": "^0.1.5",
-                        "semver": "^5.6.0",
-                        "validate-npm-package-name": "^3.0.0"
+                        "hosted-git-info": "2.8.2",
+                        "osenv": "0.1.5",
+                        "semver": "5.7.1",
+                        "validate-npm-package-name": "3.0.0"
                     }
                 },
                 "npm-packlist": {
@@ -10174,8 +10181,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1"
+                        "ignore-walk": "3.0.1",
+                        "npm-bundled": "1.0.6"
                     }
                 },
                 "npm-pick-manifest": {
@@ -10183,9 +10190,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "figgy-pudding": "^3.5.1",
-                        "npm-package-arg": "^6.0.0",
-                        "semver": "^5.4.1"
+                        "figgy-pudding": "3.5.1",
+                        "npm-package-arg": "6.1.1",
+                        "semver": "5.7.1"
                     }
                 },
                 "npm-profile": {
@@ -10193,9 +10200,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "aproba": "^1.1.2 || 2",
-                        "figgy-pudding": "^3.4.1",
-                        "npm-registry-fetch": "^4.0.0"
+                        "aproba": "2.0.0",
+                        "figgy-pudding": "3.5.1",
+                        "npm-registry-fetch": "4.0.0"
                     }
                 },
                 "npm-registry-fetch": {
@@ -10203,12 +10210,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "JSONStream": "^1.3.4",
-                        "bluebird": "^3.5.1",
-                        "figgy-pudding": "^3.4.1",
-                        "lru-cache": "^5.1.1",
-                        "make-fetch-happen": "^5.0.0",
-                        "npm-package-arg": "^6.1.0"
+                        "JSONStream": "1.3.5",
+                        "bluebird": "3.5.5",
+                        "figgy-pudding": "3.5.1",
+                        "lru-cache": "5.1.1",
+                        "make-fetch-happen": "5.0.0",
+                        "npm-package-arg": "6.1.1"
                     }
                 },
                 "npm-run-path": {
@@ -10216,7 +10223,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "path-key": "^2.0.0"
+                        "path-key": "2.0.1"
                     }
                 },
                 "npm-user-validate": {
@@ -10229,10 +10236,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -10260,8 +10267,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "define-properties": "^1.1.2",
-                        "es-abstract": "^1.5.1"
+                        "define-properties": "1.1.3",
+                        "es-abstract": "1.12.0"
                     }
                 },
                 "once": {
@@ -10269,7 +10276,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "opener": {
@@ -10287,9 +10294,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "execa": "^0.7.0",
-                        "lcid": "^1.0.0",
-                        "mem": "^1.1.0"
+                        "execa": "0.7.0",
+                        "lcid": "1.0.0",
+                        "mem": "1.1.0"
                     }
                 },
                 "os-tmpdir": {
@@ -10302,8 +10309,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "os-homedir": "^1.0.0",
-                        "os-tmpdir": "^1.0.0"
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
                     }
                 },
                 "p-finally": {
@@ -10316,7 +10323,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-try": "^1.0.0"
+                        "p-try": "1.0.0"
                     }
                 },
                 "p-locate": {
@@ -10324,7 +10331,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-limit": "^1.1.0"
+                        "p-limit": "1.2.0"
                     }
                 },
                 "p-try": {
@@ -10337,10 +10344,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "got": "^6.7.1",
-                        "registry-auth-token": "^3.0.1",
-                        "registry-url": "^3.0.3",
-                        "semver": "^5.1.0"
+                        "got": "6.7.1",
+                        "registry-auth-token": "3.3.2",
+                        "registry-url": "3.1.0",
+                        "semver": "5.7.1"
                     }
                 },
                 "pacote": {
@@ -10348,35 +10355,35 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "bluebird": "^3.5.3",
-                        "cacache": "^12.0.2",
-                        "chownr": "^1.1.2",
-                        "figgy-pudding": "^3.5.1",
-                        "get-stream": "^4.1.0",
-                        "glob": "^7.1.3",
-                        "infer-owner": "^1.0.4",
-                        "lru-cache": "^5.1.1",
-                        "make-fetch-happen": "^5.0.0",
-                        "minimatch": "^3.0.4",
-                        "minipass": "^2.3.5",
-                        "mississippi": "^3.0.0",
-                        "mkdirp": "^0.5.1",
-                        "normalize-package-data": "^2.4.0",
-                        "npm-package-arg": "^6.1.0",
-                        "npm-packlist": "^1.1.12",
-                        "npm-pick-manifest": "^3.0.0",
-                        "npm-registry-fetch": "^4.0.0",
-                        "osenv": "^0.1.5",
-                        "promise-inflight": "^1.0.1",
-                        "promise-retry": "^1.1.1",
-                        "protoduck": "^5.0.1",
-                        "rimraf": "^2.6.2",
-                        "safe-buffer": "^5.1.2",
-                        "semver": "^5.6.0",
-                        "ssri": "^6.0.1",
-                        "tar": "^4.4.10",
-                        "unique-filename": "^1.1.1",
-                        "which": "^1.3.1"
+                        "bluebird": "3.5.5",
+                        "cacache": "12.0.3",
+                        "chownr": "1.1.2",
+                        "figgy-pudding": "3.5.1",
+                        "get-stream": "4.1.0",
+                        "glob": "7.1.4",
+                        "infer-owner": "1.0.4",
+                        "lru-cache": "5.1.1",
+                        "make-fetch-happen": "5.0.0",
+                        "minimatch": "3.0.4",
+                        "minipass": "2.3.5",
+                        "mississippi": "3.0.0",
+                        "mkdirp": "0.5.1",
+                        "normalize-package-data": "2.5.0",
+                        "npm-package-arg": "6.1.1",
+                        "npm-packlist": "1.4.4",
+                        "npm-pick-manifest": "3.0.2",
+                        "npm-registry-fetch": "4.0.0",
+                        "osenv": "0.1.5",
+                        "promise-inflight": "1.0.1",
+                        "promise-retry": "1.1.1",
+                        "protoduck": "5.0.1",
+                        "rimraf": "2.6.3",
+                        "safe-buffer": "5.1.2",
+                        "semver": "5.7.1",
+                        "ssri": "6.0.1",
+                        "tar": "4.4.10",
+                        "unique-filename": "1.1.1",
+                        "which": "1.3.1"
                     },
                     "dependencies": {
                         "minipass": {
@@ -10384,8 +10391,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "^5.1.2",
-                                "yallist": "^3.0.0"
+                                "safe-buffer": "5.1.2",
+                                "yallist": "3.0.3"
                             }
                         }
                     }
@@ -10395,9 +10402,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cyclist": "~0.2.2",
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.1.5"
+                        "cyclist": "0.2.2",
+                        "inherits": "2.0.4",
+                        "readable-stream": "2.3.6"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -10405,13 +10412,13 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.4",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "2.0.0",
+                                "safe-buffer": "5.1.2",
+                                "string_decoder": "1.1.1",
+                                "util-deprecate": "1.0.2"
                             }
                         },
                         "string_decoder": {
@@ -10419,7 +10426,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "5.1.2"
                             }
                         }
                     }
@@ -10479,8 +10486,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "err-code": "^1.0.0",
-                        "retry": "^0.10.0"
+                        "err-code": "1.1.2",
+                        "retry": "0.10.1"
                     },
                     "dependencies": {
                         "retry": {
@@ -10495,7 +10502,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "read": "1"
+                        "read": "1.0.7"
                     }
                 },
                 "proto-list": {
@@ -10508,7 +10515,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "genfun": "^5.0.0"
+                        "genfun": "5.0.0"
                     }
                 },
                 "prr": {
@@ -10531,8 +10538,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
                     }
                 },
                 "pumpify": {
@@ -10540,9 +10547,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "duplexify": "^3.6.0",
-                        "inherits": "^2.0.3",
-                        "pump": "^2.0.0"
+                        "duplexify": "3.6.0",
+                        "inherits": "2.0.4",
+                        "pump": "2.0.1"
                     },
                     "dependencies": {
                         "pump": {
@@ -10550,8 +10557,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "end-of-stream": "^1.1.0",
-                                "once": "^1.3.1"
+                                "end-of-stream": "1.4.1",
+                                "once": "1.4.0"
                             }
                         }
                     }
@@ -10576,9 +10583,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "decode-uri-component": "^0.2.0",
-                        "split-on-first": "^1.0.0",
-                        "strict-uri-encode": "^2.0.0"
+                        "decode-uri-component": "0.2.0",
+                        "split-on-first": "1.1.0",
+                        "strict-uri-encode": "2.0.0"
                     }
                 },
                 "qw": {
@@ -10591,10 +10598,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "deep-extend": "^0.5.1",
-                        "ini": "~1.3.0",
-                        "minimist": "^1.2.0",
-                        "strip-json-comments": "~2.0.1"
+                        "deep-extend": "0.5.1",
+                        "ini": "1.3.5",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -10609,7 +10616,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mute-stream": "~0.0.4"
+                        "mute-stream": "0.0.7"
                     }
                 },
                 "read-cmd-shim": {
@@ -10617,7 +10624,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2"
+                        "graceful-fs": "4.2.2"
                     }
                 },
                 "read-installed": {
@@ -10625,13 +10632,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debuglog": "^1.0.1",
-                        "graceful-fs": "^4.1.2",
-                        "read-package-json": "^2.0.0",
-                        "readdir-scoped-modules": "^1.0.0",
-                        "semver": "2 || 3 || 4 || 5",
-                        "slide": "~1.1.3",
-                        "util-extend": "^1.0.1"
+                        "debuglog": "1.0.1",
+                        "graceful-fs": "4.2.2",
+                        "read-package-json": "2.1.0",
+                        "readdir-scoped-modules": "1.1.0",
+                        "semver": "5.7.1",
+                        "slide": "1.1.6",
+                        "util-extend": "1.0.3"
                     }
                 },
                 "read-package-json": {
@@ -10639,11 +10646,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "^7.1.1",
-                        "graceful-fs": "^4.1.2",
-                        "json-parse-better-errors": "^1.0.1",
-                        "normalize-package-data": "^2.0.0",
-                        "slash": "^1.0.0"
+                        "glob": "7.1.4",
+                        "graceful-fs": "4.2.2",
+                        "json-parse-better-errors": "1.0.2",
+                        "normalize-package-data": "2.5.0",
+                        "slash": "1.0.0"
                     }
                 },
                 "read-package-tree": {
@@ -10651,9 +10658,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "read-package-json": "^2.0.0",
-                        "readdir-scoped-modules": "^1.0.0",
-                        "util-promisify": "^2.1.0"
+                        "read-package-json": "2.1.0",
+                        "readdir-scoped-modules": "1.1.0",
+                        "util-promisify": "2.1.0"
                     }
                 },
                 "readable-stream": {
@@ -10661,9 +10668,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "inherits": "^2.0.3",
-                        "string_decoder": "^1.1.1",
-                        "util-deprecate": "^1.0.1"
+                        "inherits": "2.0.4",
+                        "string_decoder": "1.2.0",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "readdir-scoped-modules": {
@@ -10671,10 +10678,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debuglog": "^1.0.1",
-                        "dezalgo": "^1.0.0",
-                        "graceful-fs": "^4.1.2",
-                        "once": "^1.3.0"
+                        "debuglog": "1.0.1",
+                        "dezalgo": "1.0.3",
+                        "graceful-fs": "4.2.2",
+                        "once": "1.4.0"
                     }
                 },
                 "registry-auth-token": {
@@ -10682,8 +10689,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "rc": "^1.1.6",
-                        "safe-buffer": "^5.0.1"
+                        "rc": "1.2.7",
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "registry-url": {
@@ -10691,7 +10698,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "rc": "^1.0.1"
+                        "rc": "1.2.7"
                     }
                 },
                 "request": {
@@ -10699,26 +10706,26 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "~0.7.0",
-                        "aws4": "^1.8.0",
-                        "caseless": "~0.12.0",
-                        "combined-stream": "~1.0.6",
-                        "extend": "~3.0.2",
-                        "forever-agent": "~0.6.1",
-                        "form-data": "~2.3.2",
-                        "har-validator": "~5.1.0",
-                        "http-signature": "~1.2.0",
-                        "is-typedarray": "~1.0.0",
-                        "isstream": "~0.1.2",
-                        "json-stringify-safe": "~5.0.1",
-                        "mime-types": "~2.1.19",
-                        "oauth-sign": "~0.9.0",
-                        "performance-now": "^2.1.0",
-                        "qs": "~6.5.2",
-                        "safe-buffer": "^5.1.2",
-                        "tough-cookie": "~2.4.3",
-                        "tunnel-agent": "^0.6.0",
-                        "uuid": "^3.3.2"
+                        "aws-sign2": "0.7.0",
+                        "aws4": "1.8.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.6",
+                        "extend": "3.0.2",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.3.2",
+                        "har-validator": "5.1.0",
+                        "http-signature": "1.2.0",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.19",
+                        "oauth-sign": "0.9.0",
+                        "performance-now": "2.1.0",
+                        "qs": "6.5.2",
+                        "safe-buffer": "5.1.2",
+                        "tough-cookie": "2.4.3",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.3.2"
                     }
                 },
                 "require-directory": {
@@ -10746,7 +10753,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "^7.1.3"
+                        "glob": "7.1.4"
                     }
                 },
                 "run-queue": {
@@ -10754,7 +10761,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "aproba": "^1.1.1"
+                        "aproba": "1.2.0"
                     },
                     "dependencies": {
                         "aproba": {
@@ -10784,7 +10791,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "semver": "^5.0.3"
+                        "semver": "5.7.1"
                     }
                 },
                 "set-blocking": {
@@ -10797,7 +10804,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2"
+                        "graceful-fs": "4.2.2"
                     }
                 },
                 "shebang-command": {
@@ -10805,7 +10812,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "shebang-regex": "^1.0.0"
+                        "shebang-regex": "1.0.0"
                     }
                 },
                 "shebang-regex": {
@@ -10838,7 +10845,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ip": "^1.1.5",
+                        "ip": "1.1.5",
                         "smart-buffer": "4.0.2"
                     }
                 },
@@ -10847,8 +10854,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "agent-base": "~4.2.1",
-                        "socks": "~2.3.2"
+                        "agent-base": "4.2.1",
+                        "socks": "2.3.2"
                     },
                     "dependencies": {
                         "agent-base": {
@@ -10856,7 +10863,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "es6-promisify": "^5.0.0"
+                                "es6-promisify": "5.0.0"
                             }
                         }
                     }
@@ -10871,8 +10878,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "from2": "^1.3.0",
-                        "stream-iterate": "^1.1.0"
+                        "from2": "1.3.0",
+                        "stream-iterate": "1.2.0"
                     },
                     "dependencies": {
                         "from2": {
@@ -10880,8 +10887,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "inherits": "~2.0.1",
-                                "readable-stream": "~1.1.10"
+                                "inherits": "2.0.4",
+                                "readable-stream": "1.1.14"
                             }
                         },
                         "isarray": {
@@ -10894,10 +10901,10 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.1",
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.4",
                                 "isarray": "0.0.1",
-                                "string_decoder": "~0.10.x"
+                                "string_decoder": "0.10.31"
                             }
                         },
                         "string_decoder": {
@@ -10912,8 +10919,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-expression-parse": "^3.0.0",
-                        "spdx-license-ids": "^3.0.0"
+                        "spdx-expression-parse": "3.0.0",
+                        "spdx-license-ids": "3.0.3"
                     }
                 },
                 "spdx-exceptions": {
@@ -10926,8 +10933,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-exceptions": "^2.1.0",
-                        "spdx-license-ids": "^3.0.0"
+                        "spdx-exceptions": "2.1.0",
+                        "spdx-license-ids": "3.0.3"
                     }
                 },
                 "spdx-license-ids": {
@@ -10945,15 +10952,15 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "asn1": "~0.2.3",
-                        "assert-plus": "^1.0.0",
-                        "bcrypt-pbkdf": "^1.0.0",
-                        "dashdash": "^1.12.0",
-                        "ecc-jsbn": "~0.1.1",
-                        "getpass": "^0.1.1",
-                        "jsbn": "~0.1.0",
-                        "safer-buffer": "^2.0.2",
-                        "tweetnacl": "~0.14.0"
+                        "asn1": "0.2.4",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.2",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.2",
+                        "getpass": "0.1.7",
+                        "jsbn": "0.1.1",
+                        "safer-buffer": "2.1.2",
+                        "tweetnacl": "0.14.5"
                     }
                 },
                 "ssri": {
@@ -10961,7 +10968,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "figgy-pudding": "^3.5.1"
+                        "figgy-pudding": "3.5.1"
                     }
                 },
                 "stream-each": {
@@ -10969,8 +10976,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "stream-shift": "^1.0.0"
+                        "end-of-stream": "1.4.1",
+                        "stream-shift": "1.0.0"
                     }
                 },
                 "stream-iterate": {
@@ -10978,8 +10985,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "readable-stream": "^2.1.5",
-                        "stream-shift": "^1.0.0"
+                        "readable-stream": "2.3.6",
+                        "stream-shift": "1.0.0"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -10987,13 +10994,13 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.4",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "2.0.0",
+                                "safe-buffer": "5.1.2",
+                                "string_decoder": "1.1.1",
+                                "util-deprecate": "1.0.2"
                             }
                         },
                         "string_decoder": {
@@ -11001,7 +11008,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "5.1.2"
                             }
                         }
                     }
@@ -11021,8 +11028,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     },
                     "dependencies": {
                         "ansi-regex": {
@@ -11040,7 +11047,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "^3.0.0"
+                                "ansi-regex": "3.0.0"
                             }
                         }
                     }
@@ -11050,7 +11057,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "stringify-package": {
@@ -11063,7 +11070,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "strip-eof": {
@@ -11081,7 +11088,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 },
                 "tar": {
@@ -11089,13 +11096,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "chownr": "^1.1.1",
-                        "fs-minipass": "^1.2.5",
-                        "minipass": "^2.3.5",
-                        "minizlib": "^1.2.1",
-                        "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.3"
+                        "chownr": "1.1.2",
+                        "fs-minipass": "1.2.6",
+                        "minipass": "2.3.5",
+                        "minizlib": "1.2.1",
+                        "mkdirp": "0.5.1",
+                        "safe-buffer": "5.1.2",
+                        "yallist": "3.0.3"
                     },
                     "dependencies": {
                         "minipass": {
@@ -11103,8 +11110,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "^5.1.2",
-                                "yallist": "^3.0.0"
+                                "safe-buffer": "5.1.2",
+                                "yallist": "3.0.3"
                             }
                         },
                         "yallist": {
@@ -11119,7 +11126,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "execa": "^0.7.0"
+                        "execa": "0.7.0"
                     }
                 },
                 "text-table": {
@@ -11137,8 +11144,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
+                        "readable-stream": "2.3.6",
+                        "xtend": "4.0.1"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -11146,13 +11153,13 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.4",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "2.0.0",
+                                "safe-buffer": "5.1.2",
+                                "string_decoder": "1.1.1",
+                                "util-deprecate": "1.0.2"
                             }
                         },
                         "string_decoder": {
@@ -11160,7 +11167,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "5.1.2"
                             }
                         }
                     }
@@ -11180,8 +11187,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "psl": "^1.1.24",
-                        "punycode": "^1.4.1"
+                        "psl": "1.1.29",
+                        "punycode": "1.4.1"
                     }
                 },
                 "tunnel-agent": {
@@ -11189,7 +11196,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "^5.0.1"
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "tweetnacl": {
@@ -11218,7 +11225,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "unique-slug": "^2.0.0"
+                        "unique-slug": "2.0.0"
                     }
                 },
                 "unique-slug": {
@@ -11226,7 +11233,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "imurmurhash": "^0.1.4"
+                        "imurmurhash": "0.1.4"
                     }
                 },
                 "unique-string": {
@@ -11234,7 +11241,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "crypto-random-string": "^1.0.0"
+                        "crypto-random-string": "1.0.0"
                     }
                 },
                 "unpipe": {
@@ -11252,16 +11259,16 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "boxen": "^1.2.1",
-                        "chalk": "^2.0.1",
-                        "configstore": "^3.0.0",
-                        "import-lazy": "^2.1.0",
-                        "is-ci": "^1.0.10",
-                        "is-installed-globally": "^0.1.0",
-                        "is-npm": "^1.0.0",
-                        "latest-version": "^3.0.0",
-                        "semver-diff": "^2.0.0",
-                        "xdg-basedir": "^3.0.0"
+                        "boxen": "1.3.0",
+                        "chalk": "2.4.1",
+                        "configstore": "3.1.2",
+                        "import-lazy": "2.1.0",
+                        "is-ci": "1.1.0",
+                        "is-installed-globally": "0.1.0",
+                        "is-npm": "1.0.0",
+                        "latest-version": "3.1.0",
+                        "semver-diff": "2.1.0",
+                        "xdg-basedir": "3.0.0"
                     }
                 },
                 "url-parse-lax": {
@@ -11269,7 +11276,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "prepend-http": "^1.0.1"
+                        "prepend-http": "1.0.4"
                     }
                 },
                 "util-deprecate": {
@@ -11287,7 +11294,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "object.getownpropertydescriptors": "^2.0.3"
+                        "object.getownpropertydescriptors": "2.0.3"
                     }
                 },
                 "uuid": {
@@ -11300,8 +11307,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-correct": "^3.0.0",
-                        "spdx-expression-parse": "^3.0.0"
+                        "spdx-correct": "3.0.0",
+                        "spdx-expression-parse": "3.0.0"
                     }
                 },
                 "validate-npm-package-name": {
@@ -11309,7 +11316,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "builtins": "^1.0.3"
+                        "builtins": "1.0.3"
                     }
                 },
                 "verror": {
@@ -11317,9 +11324,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "assert-plus": "^1.0.0",
+                        "assert-plus": "1.0.0",
                         "core-util-is": "1.0.2",
-                        "extsprintf": "^1.2.0"
+                        "extsprintf": "1.3.0"
                     }
                 },
                 "wcwidth": {
@@ -11327,7 +11334,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "defaults": "^1.0.3"
+                        "defaults": "1.0.3"
                     }
                 },
                 "which": {
@@ -11335,7 +11342,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "isexe": "^2.0.0"
+                        "isexe": "2.0.0"
                     }
                 },
                 "which-module": {
@@ -11348,7 +11355,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "string-width": "^1.0.2"
+                        "string-width": "1.0.2"
                     },
                     "dependencies": {
                         "string-width": {
@@ -11356,9 +11363,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
                             }
                         }
                     }
@@ -11368,7 +11375,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "string-width": "^2.1.1"
+                        "string-width": "2.1.1"
                     }
                 },
                 "worker-farm": {
@@ -11376,7 +11383,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "errno": "~0.1.7"
+                        "errno": "0.1.7"
                     }
                 },
                 "wrap-ansi": {
@@ -11384,8 +11391,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
                     },
                     "dependencies": {
                         "string-width": {
@@ -11393,9 +11400,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
                             }
                         }
                     }
@@ -11410,9 +11417,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.11",
-                        "imurmurhash": "^0.1.4",
-                        "signal-exit": "^3.0.2"
+                        "graceful-fs": "4.2.2",
+                        "imurmurhash": "0.1.4",
+                        "signal-exit": "3.0.2"
                     }
                 },
                 "xdg-basedir": {
@@ -11440,18 +11447,18 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cliui": "^4.0.0",
-                        "decamelize": "^1.1.1",
-                        "find-up": "^2.1.0",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^2.0.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^2.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^9.0.2"
+                        "cliui": "4.1.0",
+                        "decamelize": "1.2.0",
+                        "find-up": "2.1.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "2.1.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "9.0.2"
                     },
                     "dependencies": {
                         "y18n": {
@@ -11466,7 +11473,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0"
+                        "camelcase": "4.1.0"
                     }
                 }
             }
@@ -11477,7 +11484,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "^2.0.0"
+                "path-key": "2.0.1"
             }
         },
         "nwsapi": {
@@ -11503,9 +11510,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "^0.1.0",
-                "define-property": "^0.2.5",
-                "kind-of": "^3.0.3"
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "define-property": {
@@ -11514,7 +11521,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "kind-of": {
@@ -11523,7 +11530,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -11546,7 +11553,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.0"
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -11563,10 +11570,10 @@
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "function-bind": "^1.1.1",
-                "has-symbols": "^1.0.0",
-                "object-keys": "^1.0.11"
+                "define-properties": "1.1.3",
+                "function-bind": "1.1.1",
+                "has-symbols": "1.0.0",
+                "object-keys": "1.1.1"
             }
         },
         "object.entries": {
@@ -11575,10 +11582,10 @@
             "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.12.0",
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3"
+                "define-properties": "1.1.3",
+                "es-abstract": "1.14.2",
+                "function-bind": "1.1.1",
+                "has": "1.0.3"
             }
         },
         "object.fromentries": {
@@ -11587,10 +11594,10 @@
             "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.11.0",
-                "function-bind": "^1.1.1",
-                "has": "^1.0.1"
+                "define-properties": "1.1.3",
+                "es-abstract": "1.14.2",
+                "function-bind": "1.1.1",
+                "has": "1.0.3"
             }
         },
         "object.getownpropertydescriptors": {
@@ -11599,8 +11606,8 @@
             "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.5.1"
+                "define-properties": "1.1.3",
+                "es-abstract": "1.14.2"
             }
         },
         "object.pick": {
@@ -11609,7 +11616,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -11626,10 +11633,10 @@
             "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.12.0",
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3"
+                "define-properties": "1.1.3",
+                "es-abstract": "1.14.2",
+                "function-bind": "1.1.1",
+                "has": "1.0.3"
             }
         },
         "on-finished": {
@@ -11647,7 +11654,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "onetime": {
@@ -11656,7 +11663,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "1.2.0"
             }
         },
         "only": {
@@ -11671,7 +11678,7 @@
             "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
             "dev": true,
             "requires": {
-                "is-wsl": "^1.1.0"
+                "is-wsl": "1.1.0"
             }
         },
         "optimist": {
@@ -11680,8 +11687,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
             },
             "dependencies": {
                 "minimist": {
@@ -11704,12 +11711,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.4",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "wordwrap": "~1.0.0"
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
             }
         },
         "os-browserify": {
@@ -11724,9 +11731,9 @@
             "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
             "dev": true,
             "requires": {
-                "execa": "^1.0.0",
-                "lcid": "^2.0.0",
-                "mem": "^4.0.0"
+                "execa": "1.0.0",
+                "lcid": "2.0.0",
+                "mem": "4.3.0"
             }
         },
         "os-tmpdir": {
@@ -11747,7 +11754,7 @@
             "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
             "dev": true,
             "requires": {
-                "p-reduce": "^1.0.0"
+                "p-reduce": "1.0.0"
             }
         },
         "p-finally": {
@@ -11768,7 +11775,7 @@
             "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
             "dev": true,
             "requires": {
-                "p-try": "^2.0.0"
+                "p-try": "2.2.0"
             }
         },
         "p-locate": {
@@ -11777,7 +11784,7 @@
             "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
             "dev": true,
             "requires": {
-                "p-limit": "^2.0.0"
+                "p-limit": "2.2.1"
             }
         },
         "p-reduce": {
@@ -11798,10 +11805,10 @@
             "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
             "dev": true,
             "requires": {
-                "got": "^6.7.1",
-                "registry-auth-token": "^3.0.1",
-                "registry-url": "^3.0.3",
-                "semver": "^5.1.0"
+                "got": "6.7.1",
+                "registry-auth-token": "3.4.0",
+                "registry-url": "3.1.0",
+                "semver": "5.7.1"
             }
         },
         "pako": {
@@ -11816,9 +11823,9 @@
             "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
             "dev": true,
             "requires": {
-                "cyclist": "^1.0.1",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.1.5"
+                "cyclist": "1.0.1",
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.6"
             },
             "dependencies": {
                 "isarray": {
@@ -11833,13 +11840,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -11848,7 +11855,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -11859,7 +11866,7 @@
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "requires": {
-                "callsites": "^3.0.0"
+                "callsites": "3.1.0"
             }
         },
         "parse-asn1": {
@@ -11868,12 +11875,12 @@
             "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
             "dev": true,
             "requires": {
-                "asn1.js": "^4.0.0",
-                "browserify-aes": "^1.0.0",
-                "create-hash": "^1.1.0",
-                "evp_bytestokey": "^1.0.0",
-                "pbkdf2": "^3.0.3",
-                "safe-buffer": "^5.1.1"
+                "asn1.js": "4.10.1",
+                "browserify-aes": "1.2.0",
+                "create-hash": "1.2.0",
+                "evp_bytestokey": "1.0.3",
+                "pbkdf2": "3.0.17",
+                "safe-buffer": "5.1.2"
             }
         },
         "parse-json": {
@@ -11882,7 +11889,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "^1.2.0"
+                "error-ex": "1.3.2"
             }
         },
         "parse-passwd": {
@@ -11957,7 +11964,7 @@
             "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
             "dev": true,
             "requires": {
-                "pify": "^2.0.0"
+                "pify": "2.3.0"
             },
             "dependencies": {
                 "pify": {
@@ -11980,11 +11987,11 @@
             "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
             "dev": true,
             "requires": {
-                "create-hash": "^1.1.2",
-                "create-hmac": "^1.1.4",
-                "ripemd160": "^2.0.1",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
+                "sha.js": "2.4.11"
             }
         },
         "performance-now": {
@@ -12005,7 +12012,7 @@
             "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
             "dev": true,
             "requires": {
-                "node-modules-regexp": "^1.0.0"
+                "node-modules-regexp": "1.0.0"
             }
         },
         "pkg-dir": {
@@ -12014,7 +12021,7 @@
             "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
             "dev": true,
             "requires": {
-                "find-up": "^3.0.0"
+                "find-up": "3.0.0"
             }
         },
         "pn": {
@@ -12040,9 +12047,9 @@
             "integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
+                "chalk": "2.4.2",
+                "source-map": "0.6.1",
+                "supports-color": "6.1.0"
             },
             "dependencies": {
                 "source-map": {
@@ -12057,7 +12064,7 @@
                     "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -12068,7 +12075,7 @@
             "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
             "dev": true,
             "requires": {
-                "postcss": "^7.0.5"
+                "postcss": "7.0.18"
             }
         },
         "postcss-modules-local-by-default": {
@@ -12077,9 +12084,9 @@
             "integrity": "sha512-oLUV5YNkeIBa0yQl7EYnxMgy4N6noxmiwZStaEJUSe2xPMcdNc8WmBQuQCx18H5psYbVxz8zoHk0RAAYZXP9gA==",
             "dev": true,
             "requires": {
-                "postcss": "^7.0.6",
-                "postcss-selector-parser": "^6.0.0",
-                "postcss-value-parser": "^3.3.1"
+                "postcss": "7.0.18",
+                "postcss-selector-parser": "6.0.2",
+                "postcss-value-parser": "3.3.1"
             }
         },
         "postcss-modules-scope": {
@@ -12088,8 +12095,8 @@
             "integrity": "sha512-91Rjps0JnmtUB0cujlc8KIKCsJXWjzuxGeT/+Q2i2HXKZ7nBUeF9YQTZZTNvHVoNYj1AthsjnGLtqDUE0Op79A==",
             "dev": true,
             "requires": {
-                "postcss": "^7.0.6",
-                "postcss-selector-parser": "^6.0.0"
+                "postcss": "7.0.18",
+                "postcss-selector-parser": "6.0.2"
             }
         },
         "postcss-modules-values": {
@@ -12098,8 +12105,8 @@
             "integrity": "sha512-Ki7JZa7ff1N3EIMlPnGTZfUMe69FFwiQPnVSXC9mnn3jozCRBYIxiZd44yJOV2AmabOo4qFf8s0dC/+lweG7+w==",
             "dev": true,
             "requires": {
-                "icss-replace-symbols": "^1.1.0",
-                "postcss": "^7.0.6"
+                "icss-replace-symbols": "1.1.0",
+                "postcss": "7.0.18"
             }
         },
         "postcss-selector-parser": {
@@ -12108,9 +12115,9 @@
             "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
             "dev": true,
             "requires": {
-                "cssesc": "^3.0.0",
-                "indexes-of": "^1.0.1",
-                "uniq": "^1.0.1"
+                "cssesc": "3.0.0",
+                "indexes-of": "1.0.1",
+                "uniq": "1.0.1"
             }
         },
         "postcss-value-parser": {
@@ -12143,10 +12150,10 @@
             "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.9.0",
-                "ansi-regex": "^4.0.0",
-                "ansi-styles": "^3.2.0",
-                "react-is": "^16.8.4"
+                "@jest/types": "24.9.0",
+                "ansi-regex": "4.1.0",
+                "ansi-styles": "3.2.1",
+                "react-is": "16.10.1"
             }
         },
         "private": {
@@ -12185,8 +12192,8 @@
             "integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
             "dev": true,
             "requires": {
-                "kleur": "^3.0.3",
-                "sisteransi": "^1.0.3"
+                "kleur": "3.0.3",
+                "sisteransi": "1.0.3"
             }
         },
         "prop-types": {
@@ -12194,9 +12201,9 @@
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
             "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
             "requires": {
-                "loose-envify": "^1.4.0",
-                "object-assign": "^4.1.1",
-                "react-is": "^16.8.1"
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1",
+                "react-is": "16.10.1"
             }
         },
         "prr": {
@@ -12223,12 +12230,12 @@
             "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "browserify-rsa": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "parse-asn1": "^5.0.0",
-                "randombytes": "^2.0.1",
-                "safe-buffer": "^5.1.2"
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.2.0",
+                "parse-asn1": "5.1.5",
+                "randombytes": "2.1.0",
+                "safe-buffer": "5.1.2"
             }
         },
         "pump": {
@@ -12237,8 +12244,8 @@
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.4",
+                "once": "1.4.0"
             }
         },
         "pumpify": {
@@ -12247,9 +12254,9 @@
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "dev": true,
             "requires": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
+                "duplexify": "3.7.1",
+                "inherits": "2.0.4",
+                "pump": "2.0.1"
             },
             "dependencies": {
                 "pump": {
@@ -12258,8 +12265,8 @@
                     "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
                     "dev": true,
                     "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
+                        "end-of-stream": "1.4.4",
+                        "once": "1.4.0"
                     }
                 }
             }
@@ -12305,7 +12312,7 @@
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "randomfill": {
@@ -12314,8 +12321,8 @@
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "dev": true,
             "requires": {
-                "randombytes": "^2.0.5",
-                "safe-buffer": "^5.1.0"
+                "randombytes": "2.1.0",
+                "safe-buffer": "5.1.2"
             }
         },
         "range-parser": {
@@ -12330,8 +12337,8 @@
             "integrity": "sha512-lzUVMuJ06HF4rYveaz9Tv0WRlUMxJ0Y1hgSkkgg+50iEdaI0TthyEDe08KIHb0XsF6rn8WYTqPCaGTZg3sX+qA==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.1.0",
-                "schema-utils": "^2.0.1"
+                "loader-utils": "1.2.3",
+                "schema-utils": "2.4.1"
             },
             "dependencies": {
                 "schema-utils": {
@@ -12340,8 +12347,8 @@
                     "integrity": "sha512-RqYLpkPZX5Oc3fw/kHHHyP56fg5Y+XBpIpV8nCg0znIALfq3OH+Ea9Hfeac9BAMwG5IICltiZ0vxFvJQONfA5w==",
                     "dev": true,
                     "requires": {
-                        "ajv": "^6.10.2",
-                        "ajv-keywords": "^3.4.1"
+                        "ajv": "6.10.2",
+                        "ajv-keywords": "3.4.1"
                     }
                 }
             }
@@ -12352,10 +12359,10 @@
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
             "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
+                "deep-extend": "0.6.0",
+                "ini": "1.3.5",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
             }
         },
         "rc4": {
@@ -12370,9 +12377,9 @@
             "integrity": "sha512-2bisHwMhxQ3XQz4LiJJwG3360pY965pTl/MRrZYxIBKVj4fOHoDs5aZAkYXGxDRO1Li+SyjTAilQEbOmtQJHzA==",
             "dev": true,
             "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1",
+                "prop-types": "15.7.2"
             }
         },
         "react-docgen": {
@@ -12381,13 +12388,13 @@
             "integrity": "sha512-8xNPTrmvHLGNfqlsCYPdXmSkagP1njI5unP3t8WrjTJ4/5hHuP5nb3XH69CnF67HPV5zTkPoafcRBDGSQO6S6A==",
             "dev": true,
             "requires": {
-                "async": "^2.1.4",
-                "babel-runtime": "^6.9.2",
-                "babylon": "~5.8.3",
-                "commander": "^2.9.0",
-                "doctrine": "^2.0.0",
-                "node-dir": "^0.1.10",
-                "recast": "^0.12.6"
+                "async": "2.6.3",
+                "babel-runtime": "6.26.0",
+                "babylon": "5.8.38",
+                "commander": "2.20.1",
+                "doctrine": "2.1.0",
+                "node-dir": "0.1.17",
+                "recast": "0.12.9"
             },
             "dependencies": {
                 "doctrine": {
@@ -12396,7 +12403,7 @@
                     "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
                     "dev": true,
                     "requires": {
-                        "esutils": "^2.0.2"
+                        "esutils": "2.0.3"
                     }
                 }
             }
@@ -12407,10 +12414,10 @@
             "integrity": "sha512-SmM4ZW0uug0rn95U8uqr52I7UdNf6wdGLeXDmNLfg3y5q5H9eAbdjF5ubQc3bjDyRrvdAB2IKG7X0GzSpnn5Mg==",
             "dev": true,
             "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "scheduler": "^0.16.1"
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1",
+                "prop-types": "15.7.2",
+                "scheduler": "0.16.1"
             }
         },
         "react-is": {
@@ -12423,10 +12430,10 @@
             "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-2.4.0.tgz",
             "integrity": "sha512-ex9MAz2cUAmdUucsjv180OYszdqxHIyEwzWAuMOOuxE7yUmRscxZKR5h0f+vG4shR+SekZYUBk0+gCv8apRADQ==",
             "requires": {
-                "@babel/runtime": "^7.4.5",
-                "fast-deep-equal": "^2.0.1",
-                "hoist-non-react-statics": "^3.3.0",
-                "warning": "^4.0.3"
+                "@babel/runtime": "7.6.2",
+                "fast-deep-equal": "2.0.1",
+                "hoist-non-react-statics": "3.3.0",
+                "warning": "4.0.3"
             }
         },
         "react-leaflet-draw": {
@@ -12434,7 +12441,7 @@
             "resolved": "https://registry.npmjs.org/react-leaflet-draw/-/react-leaflet-draw-0.19.0.tgz",
             "integrity": "sha512-aOB7Nqgl79l62L7vHxhdyKJD6ep+1Q+qTfnrYfmcgF+yK0A1lQA2fUv9N4C0HCbejcyiqx1XYchSCw9Q+Vtc3A==",
             "requires": {
-                "lodash-es": "^4.17.10"
+                "lodash-es": "4.17.15"
             }
         },
         "react-transition-group": {
@@ -12442,10 +12449,10 @@
             "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",
             "integrity": "sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==",
             "requires": {
-                "@babel/runtime": "^7.5.5",
-                "dom-helpers": "^5.0.1",
-                "loose-envify": "^1.4.0",
-                "prop-types": "^15.6.2"
+                "@babel/runtime": "7.6.2",
+                "dom-helpers": "5.1.0",
+                "loose-envify": "1.4.0",
+                "prop-types": "15.7.2"
             }
         },
         "read-pkg": {
@@ -12454,9 +12461,9 @@
             "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
             "dev": true,
             "requires": {
-                "load-json-file": "^2.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^2.0.0"
+                "load-json-file": "2.0.0",
+                "normalize-package-data": "2.5.0",
+                "path-type": "2.0.0"
             }
         },
         "read-pkg-up": {
@@ -12465,8 +12472,8 @@
             "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
             "dev": true,
             "requires": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^2.0.0"
+                "find-up": "2.1.0",
+                "read-pkg": "2.0.0"
             },
             "dependencies": {
                 "find-up": {
@@ -12475,7 +12482,7 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "2.0.0"
                     }
                 },
                 "locate-path": {
@@ -12484,8 +12491,8 @@
                     "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                     "dev": true,
                     "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
                     }
                 },
                 "p-limit": {
@@ -12494,7 +12501,7 @@
                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
                     "dev": true,
                     "requires": {
-                        "p-try": "^1.0.0"
+                        "p-try": "1.0.0"
                     }
                 },
                 "p-locate": {
@@ -12503,7 +12510,7 @@
                     "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                     "dev": true,
                     "requires": {
-                        "p-limit": "^1.1.0"
+                        "p-limit": "1.3.0"
                     }
                 },
                 "p-try": {
@@ -12520,10 +12527,10 @@
             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
             "dev": true,
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
             }
         },
         "readdirp": {
@@ -12532,9 +12539,9 @@
             "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.11",
-                "micromatch": "^3.1.10",
-                "readable-stream": "^2.0.2"
+                "graceful-fs": "4.2.2",
+                "micromatch": "3.1.10",
+                "readable-stream": "2.3.6"
             },
             "dependencies": {
                 "isarray": {
@@ -12549,13 +12556,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -12564,7 +12571,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -12575,7 +12582,7 @@
             "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
             "dev": true,
             "requires": {
-                "util.promisify": "^1.0.0"
+                "util.promisify": "1.0.0"
             }
         },
         "recast": {
@@ -12585,10 +12592,10 @@
             "dev": true,
             "requires": {
                 "ast-types": "0.10.1",
-                "core-js": "^2.4.1",
-                "esprima": "~4.0.0",
-                "private": "~0.1.5",
-                "source-map": "~0.6.1"
+                "core-js": "2.6.9",
+                "esprima": "4.0.1",
+                "private": "0.1.8",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -12605,8 +12612,8 @@
             "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
             "dev": true,
             "requires": {
-                "indent-string": "^3.0.0",
-                "strip-indent": "^2.0.0"
+                "indent-string": "3.2.0",
+                "strip-indent": "2.0.0"
             }
         },
         "regenerate": {
@@ -12621,7 +12628,7 @@
             "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
             "dev": true,
             "requires": {
-                "regenerate": "^1.4.0"
+                "regenerate": "1.4.0"
             }
         },
         "regenerator-runtime": {
@@ -12635,7 +12642,7 @@
             "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
             "dev": true,
             "requires": {
-                "private": "^0.1.6"
+                "private": "0.1.8"
             }
         },
         "regex-not": {
@@ -12644,8 +12651,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^3.0.2",
-                "safe-regex": "^1.1.0"
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "regexpp": {
@@ -12660,12 +12667,12 @@
             "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
             "dev": true,
             "requires": {
-                "regenerate": "^1.4.0",
-                "regenerate-unicode-properties": "^8.1.0",
-                "regjsgen": "^0.5.0",
-                "regjsparser": "^0.6.0",
-                "unicode-match-property-ecmascript": "^1.0.4",
-                "unicode-match-property-value-ecmascript": "^1.1.0"
+                "regenerate": "1.4.0",
+                "regenerate-unicode-properties": "8.1.0",
+                "regjsgen": "0.5.0",
+                "regjsparser": "0.6.0",
+                "unicode-match-property-ecmascript": "1.0.4",
+                "unicode-match-property-value-ecmascript": "1.1.0"
             }
         },
         "registry-auth-token": {
@@ -12674,8 +12681,8 @@
             "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
             "dev": true,
             "requires": {
-                "rc": "^1.1.6",
-                "safe-buffer": "^5.0.1"
+                "rc": "1.2.8",
+                "safe-buffer": "5.1.2"
             }
         },
         "registry-url": {
@@ -12684,7 +12691,7 @@
             "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
             "dev": true,
             "requires": {
-                "rc": "^1.0.1"
+                "rc": "1.2.8"
             }
         },
         "regjsgen": {
@@ -12699,7 +12706,7 @@
             "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
             "dev": true,
             "requires": {
-                "jsesc": "~0.5.0"
+                "jsesc": "0.5.0"
             },
             "dependencies": {
                 "jsesc": {
@@ -12740,26 +12747,26 @@
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "dev": true,
             "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.8.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.8",
+                "extend": "3.0.2",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.3",
+                "har-validator": "5.1.3",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.24",
+                "oauth-sign": "0.9.0",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.4.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.3.3"
             },
             "dependencies": {
                 "punycode": {
@@ -12774,8 +12781,8 @@
                     "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "dev": true,
                     "requires": {
-                        "psl": "^1.1.24",
-                        "punycode": "^1.4.1"
+                        "psl": "1.4.0",
+                        "punycode": "1.4.1"
                     }
                 }
             }
@@ -12786,7 +12793,7 @@
             "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.11"
+                "lodash": "4.17.15"
             }
         },
         "request-promise-native": {
@@ -12796,8 +12803,8 @@
             "dev": true,
             "requires": {
                 "request-promise-core": "1.1.2",
-                "stealthy-require": "^1.1.1",
-                "tough-cookie": "^2.3.3"
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.5.0"
             }
         },
         "require-directory": {
@@ -12818,7 +12825,7 @@
             "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
             "dev": true,
             "requires": {
-                "path-parse": "^1.0.6"
+                "path-parse": "1.0.6"
             }
         },
         "resolve-cwd": {
@@ -12827,7 +12834,7 @@
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
             "dev": true,
             "requires": {
-                "resolve-from": "^3.0.0"
+                "resolve-from": "3.0.0"
             },
             "dependencies": {
                 "resolve-from": {
@@ -12844,8 +12851,8 @@
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "^2.0.0",
-                "global-modules": "^1.0.0"
+                "expand-tilde": "2.0.2",
+                "global-modules": "1.0.0"
             },
             "dependencies": {
                 "global-modules": {
@@ -12854,9 +12861,9 @@
                     "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
                     "dev": true,
                     "requires": {
-                        "global-prefix": "^1.0.1",
-                        "is-windows": "^1.0.1",
-                        "resolve-dir": "^1.0.0"
+                        "global-prefix": "1.0.2",
+                        "is-windows": "1.0.2",
+                        "resolve-dir": "1.0.1"
                     }
                 }
             }
@@ -12873,7 +12880,7 @@
             "integrity": "sha1-xL2p9e+y/OZSR4c6s2u02DT+Fvc=",
             "dev": true,
             "requires": {
-                "http-errors": "~1.6.2",
+                "http-errors": "1.6.3",
                 "path-is-absolute": "1.0.1"
             },
             "dependencies": {
@@ -12883,10 +12890,10 @@
                     "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
                     "dev": true,
                     "requires": {
-                        "depd": "~1.1.2",
+                        "depd": "1.1.2",
                         "inherits": "2.0.3",
                         "setprototypeof": "1.1.0",
-                        "statuses": ">= 1.4.0 < 2"
+                        "statuses": "1.5.0"
                     }
                 },
                 "inherits": {
@@ -12915,8 +12922,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
             }
         },
         "ret": {
@@ -12931,7 +12938,7 @@
             "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
             "dev": true,
             "requires": {
-                "glob": "^7.1.3"
+                "glob": "7.1.4"
             }
         },
         "ripemd160": {
@@ -12940,8 +12947,8 @@
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
             "dev": true,
             "requires": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1"
+                "hash-base": "3.0.4",
+                "inherits": "2.0.4"
             }
         },
         "rsvp": {
@@ -12956,7 +12963,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "^2.1.0"
+                "is-promise": "2.1.0"
             }
         },
         "run-queue": {
@@ -12965,7 +12972,7 @@
             "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1"
+                "aproba": "1.2.0"
             }
         },
         "rw": {
@@ -12979,7 +12986,7 @@
             "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
             "dev": true,
             "requires": {
-                "tslib": "^1.9.0"
+                "tslib": "1.10.0"
             }
         },
         "safe-buffer": {
@@ -12994,7 +13001,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "~0.1.10"
+                "ret": "0.1.15"
             }
         },
         "safer-buffer": {
@@ -13008,15 +13015,15 @@
             "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
             "dev": true,
             "requires": {
-                "@cnakazawa/watch": "^1.0.3",
-                "anymatch": "^2.0.0",
-                "capture-exit": "^2.0.0",
-                "exec-sh": "^0.3.2",
-                "execa": "^1.0.0",
-                "fb-watchman": "^2.0.0",
-                "micromatch": "^3.1.4",
-                "minimist": "^1.1.1",
-                "walker": "~1.0.5"
+                "@cnakazawa/watch": "1.0.3",
+                "anymatch": "2.0.0",
+                "capture-exit": "2.0.0",
+                "exec-sh": "0.3.2",
+                "execa": "1.0.0",
+                "fb-watchman": "2.0.0",
+                "micromatch": "3.1.10",
+                "minimist": "1.2.0",
+                "walker": "1.0.7"
             }
         },
         "sax": {
@@ -13031,8 +13038,8 @@
             "integrity": "sha512-MIuie7SgsqMYOdCXVFZa8SKoNorJZUWHW8dPgto7uEHn1lX3fg2Gu0TzgK8USj76uxV7vB5eRMnZs/cdEHg+cg==",
             "dev": true,
             "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1"
             }
         },
         "schema-utils": {
@@ -13041,9 +13048,9 @@
             "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
             "dev": true,
             "requires": {
-                "ajv": "^6.1.0",
-                "ajv-errors": "^1.0.0",
-                "ajv-keywords": "^3.1.0"
+                "ajv": "6.10.2",
+                "ajv-errors": "1.0.1",
+                "ajv-keywords": "3.4.1"
             }
         },
         "semver": {
@@ -13058,7 +13065,7 @@
             "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
             "dev": true,
             "requires": {
-                "semver": "^5.0.3"
+                "semver": "5.7.1"
             }
         },
         "serialize-javascript": {
@@ -13079,10 +13086,10 @@
             "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.3",
-                "split-string": "^3.0.1"
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -13091,7 +13098,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "is-plain-object": {
@@ -13100,7 +13107,7 @@
                     "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
                     "dev": true,
                     "requires": {
-                        "isobject": "^3.0.1"
+                        "isobject": "3.0.1"
                     }
                 },
                 "isobject": {
@@ -13129,8 +13136,8 @@
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.4",
+                "safe-buffer": "5.1.2"
             }
         },
         "shebang-command": {
@@ -13139,7 +13146,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "^1.0.0"
+                "shebang-regex": "1.0.0"
             }
         },
         "shebang-regex": {
@@ -13178,9 +13185,9 @@
             "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.0",
-                "astral-regex": "^1.0.0",
-                "is-fullwidth-code-point": "^2.0.0"
+                "ansi-styles": "3.2.1",
+                "astral-regex": "1.0.0",
+                "is-fullwidth-code-point": "2.0.0"
             }
         },
         "snapdragon": {
@@ -13189,14 +13196,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "^0.11.1",
-                "debug": "^2.2.0",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "map-cache": "^0.2.2",
-                "source-map": "^0.5.6",
-                "source-map-resolve": "^0.5.0",
-                "use": "^3.1.0"
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.2",
+                "use": "3.1.1"
             },
             "dependencies": {
                 "debug": {
@@ -13214,7 +13221,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -13223,7 +13230,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "ms": {
@@ -13240,9 +13247,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.0",
-                "snapdragon-util": "^3.0.1"
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -13251,7 +13258,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -13260,7 +13267,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -13269,7 +13276,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -13278,9 +13285,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "isobject": {
@@ -13297,7 +13304,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "^3.2.0"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -13306,7 +13313,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -13329,11 +13336,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "^2.1.1",
-                "decode-uri-component": "^0.2.0",
-                "resolve-url": "^0.2.1",
-                "source-map-url": "^0.4.0",
-                "urix": "^0.1.0"
+                "atob": "2.1.2",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
             }
         },
         "source-map-support": {
@@ -13342,8 +13349,8 @@
             "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
+                "buffer-from": "1.1.1",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -13366,8 +13373,8 @@
             "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.5"
             }
         },
         "spdx-exceptions": {
@@ -13382,8 +13389,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-exceptions": "2.2.0",
+                "spdx-license-ids": "3.0.5"
             }
         },
         "spdx-license-ids": {
@@ -13398,7 +13405,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^3.0.0"
+                "extend-shallow": "3.0.2"
             }
         },
         "sprintf-js": {
@@ -13413,15 +13420,15 @@
             "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "dev": true,
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.4",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.2",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.2",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2",
+                "tweetnacl": "0.14.5"
             }
         },
         "ssri": {
@@ -13430,7 +13437,7 @@
             "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
             "dev": true,
             "requires": {
-                "figgy-pudding": "^3.5.1"
+                "figgy-pudding": "3.5.1"
             }
         },
         "stack-utils": {
@@ -13445,8 +13452,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "^0.2.5",
-                "object-copy": "^0.1.0"
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -13455,7 +13462,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -13478,8 +13485,8 @@
             "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "^2.0.2"
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.6"
             },
             "dependencies": {
                 "isarray": {
@@ -13494,13 +13501,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -13509,7 +13516,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -13520,8 +13527,8 @@
             "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.4",
+                "stream-shift": "1.0.0"
             }
         },
         "stream-http": {
@@ -13530,11 +13537,11 @@
             "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
             "dev": true,
             "requires": {
-                "builtin-status-codes": "^3.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.3.6",
-                "to-arraybuffer": "^1.0.0",
-                "xtend": "^4.0.0"
+                "builtin-status-codes": "3.0.0",
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.6",
+                "to-arraybuffer": "1.0.1",
+                "xtend": "4.0.2"
             },
             "dependencies": {
                 "isarray": {
@@ -13549,13 +13556,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -13564,7 +13571,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -13581,8 +13588,8 @@
             "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
             "dev": true,
             "requires": {
-                "astral-regex": "^1.0.0",
-                "strip-ansi": "^4.0.0"
+                "astral-regex": "1.0.0",
+                "strip-ansi": "4.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -13597,7 +13604,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -13608,9 +13615,9 @@
             "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
             "dev": true,
             "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
+                "emoji-regex": "7.0.3",
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "5.2.0"
             }
         },
         "string.prototype.trimleft": {
@@ -13619,8 +13626,8 @@
             "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.3",
-                "function-bind": "^1.1.1"
+                "define-properties": "1.1.3",
+                "function-bind": "1.1.1"
             }
         },
         "string.prototype.trimright": {
@@ -13629,8 +13636,8 @@
             "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.3",
-                "function-bind": "^1.1.1"
+                "define-properties": "1.1.3",
+                "function-bind": "1.1.1"
             }
         },
         "string_decoder": {
@@ -13645,7 +13652,7 @@
             "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
             "dev": true,
             "requires": {
-                "ansi-regex": "^4.1.0"
+                "ansi-regex": "4.1.0"
             }
         },
         "strip-bom": {
@@ -13678,8 +13685,8 @@
             "integrity": "sha512-T+UNsAcl3Yg+BsPKs1vd22Fr8sVT+CJMtzqc6LEw9bbJZb43lm9GoeIfUcDEefBSWC0BhYbcdupV1GtI4DGzxg==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.1.0",
-                "schema-utils": "^0.4.5"
+                "loader-utils": "1.2.3",
+                "schema-utils": "0.4.7"
             },
             "dependencies": {
                 "schema-utils": {
@@ -13688,8 +13695,8 @@
                     "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
                     "dev": true,
                     "requires": {
-                        "ajv": "^6.1.0",
-                        "ajv-keywords": "^3.1.0"
+                        "ajv": "6.10.2",
+                        "ajv-keywords": "3.4.1"
                     }
                 }
             }
@@ -13700,7 +13707,7 @@
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "dev": true,
             "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
             }
         },
         "symbol-tree": {
@@ -13715,10 +13722,10 @@
             "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
             "dev": true,
             "requires": {
-                "ajv": "^6.10.2",
-                "lodash": "^4.17.14",
-                "slice-ansi": "^2.1.0",
-                "string-width": "^3.0.0"
+                "ajv": "6.10.2",
+                "lodash": "4.17.15",
+                "slice-ansi": "2.1.0",
+                "string-width": "3.1.0"
             }
         },
         "tapable": {
@@ -13733,7 +13740,7 @@
             "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
             "dev": true,
             "requires": {
-                "execa": "^0.7.0"
+                "execa": "0.7.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -13742,9 +13749,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^4.0.1",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
+                        "lru-cache": "4.1.5",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.1"
                     }
                 },
                 "execa": {
@@ -13753,13 +13760,13 @@
                     "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                     }
                 },
                 "get-stream": {
@@ -13774,8 +13781,8 @@
                     "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
                     }
                 },
                 "yallist": {
@@ -13792,9 +13799,9 @@
             "integrity": "sha512-Kcrn3RiW8NtHBP0ssOAzwa2MsIRQ8lJWiBG/K7JgqPlomA3mtb2DEmp4/hrUA+Jujx+WZ02zqd7GYD+QRBB/2Q==",
             "dev": true,
             "requires": {
-                "commander": "^2.20.0",
-                "source-map": "~0.6.1",
-                "source-map-support": "~0.5.12"
+                "commander": "2.20.1",
+                "source-map": "0.6.1",
+                "source-map-support": "0.5.13"
             },
             "dependencies": {
                 "source-map": {
@@ -13811,15 +13818,15 @@
             "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
             "dev": true,
             "requires": {
-                "cacache": "^12.0.2",
-                "find-cache-dir": "^2.1.0",
-                "is-wsl": "^1.1.0",
-                "schema-utils": "^1.0.0",
-                "serialize-javascript": "^1.7.0",
-                "source-map": "^0.6.1",
-                "terser": "^4.1.2",
-                "webpack-sources": "^1.4.0",
-                "worker-farm": "^1.7.0"
+                "cacache": "12.0.3",
+                "find-cache-dir": "2.1.0",
+                "is-wsl": "1.1.0",
+                "schema-utils": "1.0.0",
+                "serialize-javascript": "1.9.1",
+                "source-map": "0.6.1",
+                "terser": "4.3.4",
+                "webpack-sources": "1.4.3",
+                "worker-farm": "1.7.0"
             },
             "dependencies": {
                 "source-map": {
@@ -13836,10 +13843,10 @@
             "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
             "dev": true,
             "requires": {
-                "glob": "^7.1.3",
-                "minimatch": "^3.0.4",
-                "read-pkg-up": "^4.0.0",
-                "require-main-filename": "^2.0.0"
+                "glob": "7.1.4",
+                "minimatch": "3.0.4",
+                "read-pkg-up": "4.0.0",
+                "require-main-filename": "2.0.0"
             },
             "dependencies": {
                 "load-json-file": {
@@ -13848,10 +13855,10 @@
                     "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^4.0.0",
-                        "pify": "^3.0.0",
-                        "strip-bom": "^3.0.0"
+                        "graceful-fs": "4.2.2",
+                        "parse-json": "4.0.0",
+                        "pify": "3.0.0",
+                        "strip-bom": "3.0.0"
                     }
                 },
                 "parse-json": {
@@ -13860,8 +13867,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "^1.3.1",
-                        "json-parse-better-errors": "^1.0.1"
+                        "error-ex": "1.3.2",
+                        "json-parse-better-errors": "1.0.2"
                     }
                 },
                 "path-type": {
@@ -13870,7 +13877,7 @@
                     "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
                     "dev": true,
                     "requires": {
-                        "pify": "^3.0.0"
+                        "pify": "3.0.0"
                     }
                 },
                 "pify": {
@@ -13885,9 +13892,9 @@
                     "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "^4.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^3.0.0"
+                        "load-json-file": "4.0.0",
+                        "normalize-package-data": "2.5.0",
+                        "path-type": "3.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -13896,8 +13903,8 @@
                     "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
                     "dev": true,
                     "requires": {
-                        "find-up": "^3.0.0",
-                        "read-pkg": "^3.0.0"
+                        "find-up": "3.0.0",
+                        "read-pkg": "3.0.0"
                     }
                 }
             }
@@ -13914,7 +13921,7 @@
             "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
             "dev": true,
             "requires": {
-                "any-promise": "^1.0.0"
+                "any-promise": "1.3.0"
             }
         },
         "thenify-all": {
@@ -13923,7 +13930,7 @@
             "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
             "dev": true,
             "requires": {
-                "thenify": ">= 3.1.0 < 4"
+                "thenify": "3.3.0"
             }
         },
         "throat": {
@@ -13944,8 +13951,8 @@
             "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "~2.3.6",
-                "xtend": "~4.0.1"
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.2"
             },
             "dependencies": {
                 "isarray": {
@@ -13960,13 +13967,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.4",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.1",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -13975,7 +13982,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -13998,7 +14005,7 @@
             "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
             "dev": true,
             "requires": {
-                "setimmediate": "^1.0.4"
+                "setimmediate": "1.0.5"
             }
         },
         "tiny-warning": {
@@ -14012,7 +14019,7 @@
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "dev": true,
             "requires": {
-                "os-tmpdir": "~1.0.2"
+                "os-tmpdir": "1.0.2"
             }
         },
         "tmpl": {
@@ -14039,7 +14046,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -14048,7 +14055,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -14059,10 +14066,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "regex-not": "^1.0.2",
-                "safe-regex": "^1.1.0"
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "to-regex-range": {
@@ -14071,8 +14078,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1"
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
             }
         },
         "toidentifier": {
@@ -14087,8 +14094,8 @@
             "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
             "dev": true,
             "requires": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
+                "psl": "1.4.0",
+                "punycode": "2.1.1"
             }
         },
         "tr46": {
@@ -14097,7 +14104,7 @@
             "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
             "dev": true,
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             }
         },
         "trampa": {
@@ -14130,7 +14137,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "tweetnacl": {
@@ -14151,7 +14158,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2"
+                "prelude-ls": "1.1.2"
             }
         },
         "type-detect": {
@@ -14167,7 +14174,7 @@
             "dev": true,
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "~2.1.24"
+                "mime-types": "2.1.24"
             }
         },
         "typedarray": {
@@ -14189,8 +14196,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "commander": "~2.20.0",
-                "source-map": "~0.6.1"
+                "commander": "2.20.1",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -14214,8 +14221,8 @@
             "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
             "dev": true,
             "requires": {
-                "unicode-canonical-property-names-ecmascript": "^1.0.4",
-                "unicode-property-aliases-ecmascript": "^1.0.4"
+                "unicode-canonical-property-names-ecmascript": "1.0.4",
+                "unicode-property-aliases-ecmascript": "1.0.5"
             }
         },
         "unicode-match-property-value-ecmascript": {
@@ -14236,10 +14243,10 @@
             "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
             "dev": true,
             "requires": {
-                "arr-union": "^3.1.0",
-                "get-value": "^2.0.6",
-                "is-extendable": "^0.1.1",
-                "set-value": "^2.0.1"
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "2.0.1"
             }
         },
         "uniq": {
@@ -14254,7 +14261,7 @@
             "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
             "dev": true,
             "requires": {
-                "unique-slug": "^2.0.0"
+                "unique-slug": "2.0.2"
             }
         },
         "unique-slug": {
@@ -14263,7 +14270,7 @@
             "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
             "dev": true,
             "requires": {
-                "imurmurhash": "^0.1.4"
+                "imurmurhash": "0.1.4"
             }
         },
         "unique-string": {
@@ -14272,7 +14279,7 @@
             "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
             "dev": true,
             "requires": {
-                "crypto-random-string": "^1.0.0"
+                "crypto-random-string": "1.0.0"
             }
         },
         "unset-value": {
@@ -14281,8 +14288,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "^0.3.1",
-                "isobject": "^3.0.0"
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "has-value": {
@@ -14291,9 +14298,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "^2.0.3",
-                        "has-values": "^0.1.4",
-                        "isobject": "^2.0.0"
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -14345,16 +14352,16 @@
             "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
             "dev": true,
             "requires": {
-                "boxen": "^1.2.1",
-                "chalk": "^2.0.1",
-                "configstore": "^3.0.0",
-                "import-lazy": "^2.1.0",
-                "is-ci": "^1.0.10",
-                "is-installed-globally": "^0.1.0",
-                "is-npm": "^1.0.0",
-                "latest-version": "^3.0.0",
-                "semver-diff": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
+                "boxen": "1.3.0",
+                "chalk": "2.4.2",
+                "configstore": "3.1.2",
+                "import-lazy": "2.1.0",
+                "is-ci": "1.2.1",
+                "is-installed-globally": "0.1.0",
+                "is-npm": "1.0.0",
+                "latest-version": "3.1.0",
+                "semver-diff": "2.1.0",
+                "xdg-basedir": "3.0.0"
             },
             "dependencies": {
                 "ci-info": {
@@ -14369,7 +14376,7 @@
                     "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
                     "dev": true,
                     "requires": {
-                        "ci-info": "^1.5.0"
+                        "ci-info": "1.6.0"
                     }
                 }
             }
@@ -14380,7 +14387,7 @@
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "dev": true,
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             }
         },
         "urix": {
@@ -14419,9 +14426,9 @@
             "integrity": "sha512-kVrp/8VfEm5fUt+fl2E0FQyrpmOYgMEkBsv8+UDP1wFhszECq5JyGF33I7cajlVY90zRZ6MyfgKXngLvHYZX8A==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.2.3",
-                "mime": "^2.4.4",
-                "schema-utils": "^2.0.0"
+                "loader-utils": "1.2.3",
+                "mime": "2.4.4",
+                "schema-utils": "2.4.1"
             },
             "dependencies": {
                 "schema-utils": {
@@ -14430,8 +14437,8 @@
                     "integrity": "sha512-RqYLpkPZX5Oc3fw/kHHHyP56fg5Y+XBpIpV8nCg0znIALfq3OH+Ea9Hfeac9BAMwG5IICltiZ0vxFvJQONfA5w==",
                     "dev": true,
                     "requires": {
-                        "ajv": "^6.10.2",
-                        "ajv-keywords": "^3.4.1"
+                        "ajv": "6.10.2",
+                        "ajv-keywords": "3.4.1"
                     }
                 }
             }
@@ -14442,7 +14449,7 @@
             "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
             "dev": true,
             "requires": {
-                "prepend-http": "^1.0.1"
+                "prepend-http": "1.0.4"
             }
         },
         "use": {
@@ -14480,8 +14487,8 @@
             "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "object.getownpropertydescriptors": "^2.0.3"
+                "define-properties": "1.1.3",
+                "object.getownpropertydescriptors": "2.0.3"
             }
         },
         "uuid": {
@@ -14502,8 +14509,8 @@
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "dev": true,
             "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
+                "spdx-correct": "3.1.0",
+                "spdx-expression-parse": "3.0.0"
             }
         },
         "vary": {
@@ -14518,9 +14525,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             }
         },
         "vm-browserify": {
@@ -14535,7 +14542,7 @@
             "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
             "dev": true,
             "requires": {
-                "browser-process-hrtime": "^0.1.2"
+                "browser-process-hrtime": "0.1.3"
             }
         },
         "walker": {
@@ -14544,7 +14551,7 @@
             "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
             "dev": true,
             "requires": {
-                "makeerror": "1.0.x"
+                "makeerror": "1.0.11"
             }
         },
         "warning": {
@@ -14552,7 +14559,7 @@
             "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
             "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
             "requires": {
-                "loose-envify": "^1.0.0"
+                "loose-envify": "1.4.0"
             }
         },
         "watchpack": {
@@ -14561,9 +14568,9 @@
             "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
             "dev": true,
             "requires": {
-                "chokidar": "^2.0.2",
-                "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0"
+                "chokidar": "2.1.8",
+                "graceful-fs": "4.2.2",
+                "neo-async": "2.6.1"
             }
         },
         "webidl-conversions": {
@@ -14582,25 +14589,25 @@
                 "@webassemblyjs/helper-module-context": "1.8.5",
                 "@webassemblyjs/wasm-edit": "1.8.5",
                 "@webassemblyjs/wasm-parser": "1.8.5",
-                "acorn": "^6.2.1",
-                "ajv": "^6.10.2",
-                "ajv-keywords": "^3.4.1",
-                "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^4.1.0",
-                "eslint-scope": "^4.0.3",
-                "json-parse-better-errors": "^1.0.2",
-                "loader-runner": "^2.4.0",
-                "loader-utils": "^1.2.3",
-                "memory-fs": "^0.4.1",
-                "micromatch": "^3.1.10",
-                "mkdirp": "^0.5.1",
-                "neo-async": "^2.6.1",
-                "node-libs-browser": "^2.2.1",
-                "schema-utils": "^1.0.0",
-                "tapable": "^1.1.3",
-                "terser-webpack-plugin": "^1.4.1",
-                "watchpack": "^1.6.0",
-                "webpack-sources": "^1.4.1"
+                "acorn": "6.3.0",
+                "ajv": "6.10.2",
+                "ajv-keywords": "3.4.1",
+                "chrome-trace-event": "1.0.2",
+                "enhanced-resolve": "4.1.0",
+                "eslint-scope": "4.0.3",
+                "json-parse-better-errors": "1.0.2",
+                "loader-runner": "2.4.0",
+                "loader-utils": "1.2.3",
+                "memory-fs": "0.4.1",
+                "micromatch": "3.1.10",
+                "mkdirp": "0.5.1",
+                "neo-async": "2.6.1",
+                "node-libs-browser": "2.2.1",
+                "schema-utils": "1.0.0",
+                "tapable": "1.1.3",
+                "terser-webpack-plugin": "1.4.1",
+                "watchpack": "1.6.0",
+                "webpack-sources": "1.4.3"
             },
             "dependencies": {
                 "eslint-scope": {
@@ -14609,8 +14616,8 @@
                     "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
                     "dev": true,
                     "requires": {
-                        "esrecurse": "^4.1.0",
-                        "estraverse": "^4.1.1"
+                        "esrecurse": "4.2.1",
+                        "estraverse": "4.3.0"
                     }
                 }
             }
@@ -14640,7 +14647,7 @@
                     "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 },
                 "yargs": {
@@ -14649,17 +14656,17 @@
                     "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
                     "dev": true,
                     "requires": {
-                        "cliui": "^5.0.0",
-                        "find-up": "^3.0.0",
-                        "get-caller-file": "^2.0.1",
-                        "os-locale": "^3.1.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^2.0.0",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^3.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^4.0.0",
-                        "yargs-parser": "^13.1.0"
+                        "cliui": "5.0.0",
+                        "find-up": "3.0.0",
+                        "get-caller-file": "2.0.5",
+                        "os-locale": "3.1.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "2.0.0",
+                        "set-blocking": "2.0.0",
+                        "string-width": "3.1.0",
+                        "which-module": "2.0.0",
+                        "y18n": "4.0.0",
+                        "yargs-parser": "13.1.1"
                     }
                 }
             }
@@ -14670,11 +14677,11 @@
             "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
             "dev": true,
             "requires": {
-                "memory-fs": "^0.4.1",
-                "mime": "^2.4.4",
-                "mkdirp": "^0.5.1",
-                "range-parser": "^1.2.1",
-                "webpack-log": "^2.0.0"
+                "memory-fs": "0.4.1",
+                "mime": "2.4.4",
+                "mkdirp": "0.5.1",
+                "range-parser": "1.2.1",
+                "webpack-log": "2.0.0"
             },
             "dependencies": {
                 "webpack-log": {
@@ -14683,8 +14690,8 @@
                     "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
                     "dev": true,
                     "requires": {
-                        "ansi-colors": "^3.0.0",
-                        "uuid": "^3.3.2"
+                        "ansi-colors": "3.2.4",
+                        "uuid": "3.3.3"
                     }
                 }
             }
@@ -14695,12 +14702,12 @@
             "integrity": "sha512-6k91015hZ4Okkz8u6OzRgJygEL+3J3ay6HVZhWBF3tT2P0rZJ0mgca39dotJxngggUm3S8707c0vrcynn1IzEQ==",
             "dev": true,
             "requires": {
-                "json-stringify-safe": "^5.0.1",
-                "loglevelnext": "^1.0.2",
-                "strip-ansi": "^4.0.0",
-                "uuid": "^3.1.0",
-                "webpack-log": "^1.1.1",
-                "ws": "^4.0.0"
+                "json-stringify-safe": "5.0.1",
+                "loglevelnext": "1.0.5",
+                "strip-ansi": "4.0.0",
+                "uuid": "3.3.3",
+                "webpack-log": "1.2.0",
+                "ws": "4.1.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -14715,7 +14722,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 },
                 "ws": {
@@ -14724,8 +14731,8 @@
                     "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
                     "dev": true,
                     "requires": {
-                        "async-limiter": "~1.0.0",
-                        "safe-buffer": "~5.1.0"
+                        "async-limiter": "1.0.1",
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -14736,10 +14743,10 @@
             "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
             "dev": true,
             "requires": {
-                "chalk": "^2.1.0",
-                "log-symbols": "^2.1.0",
-                "loglevelnext": "^1.0.1",
-                "uuid": "^3.1.0"
+                "chalk": "2.4.2",
+                "log-symbols": "2.2.0",
+                "loglevelnext": "1.0.5",
+                "uuid": "3.3.3"
             }
         },
         "webpack-serve": {
@@ -14748,30 +14755,30 @@
             "integrity": "sha512-WhI9PMY2YLFliZhDsQFE5Os/On5Py6DGZpeBJyDM8xl0cspxgvXmWFywACn2YWWDgowqIxRqveyGh2RwdFWTNQ==",
             "dev": true,
             "requires": {
-                "@shellscape/koa-static": "^4.0.4",
-                "@webpack-contrib/config-loader": "^1.1.1",
-                "chalk": "^2.3.0",
-                "clipboardy": "^1.2.2",
-                "cosmiconfig": "^5.0.2",
-                "debug": "^3.1.0",
-                "find-up": "^2.1.0",
-                "get-port": "^3.2.0",
-                "import-local": "^1.0.0",
-                "killable": "^1.0.0",
-                "koa": "^2.4.1",
-                "koa-webpack": "^4.0.0",
-                "lodash": "^4.17.5",
-                "loud-rejection": "^1.6.0",
-                "meow": "^5.0.0",
-                "nanobus": "^4.3.1",
-                "opn": "^5.1.0",
-                "resolve": "^1.6.0",
-                "time-fix-plugin": "^2.0.0",
-                "update-notifier": "^2.3.0",
+                "@shellscape/koa-static": "4.0.5",
+                "@webpack-contrib/config-loader": "1.2.1",
+                "chalk": "2.4.2",
+                "clipboardy": "1.2.3",
+                "cosmiconfig": "5.2.1",
+                "debug": "3.2.6",
+                "find-up": "2.1.0",
+                "get-port": "3.2.0",
+                "import-local": "1.0.0",
+                "killable": "1.0.1",
+                "koa": "2.8.2",
+                "koa-webpack": "4.0.0",
+                "lodash": "4.17.15",
+                "loud-rejection": "1.6.0",
+                "meow": "5.0.0",
+                "nanobus": "4.4.0",
+                "opn": "5.5.0",
+                "resolve": "1.12.0",
+                "time-fix-plugin": "2.0.6",
+                "update-notifier": "2.5.0",
                 "url-join": "3.0.0",
-                "v8-compile-cache": "^2.0.0",
-                "webpack-hot-client": "^3.0.0",
-                "webpack-log": "^1.1.2"
+                "v8-compile-cache": "2.0.3",
+                "webpack-hot-client": "3.0.0",
+                "webpack-log": "1.2.0"
             },
             "dependencies": {
                 "debug": {
@@ -14780,7 +14787,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "find-up": {
@@ -14789,7 +14796,7 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "2.0.0"
                     }
                 },
                 "import-local": {
@@ -14798,8 +14805,8 @@
                     "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
                     "dev": true,
                     "requires": {
-                        "pkg-dir": "^2.0.0",
-                        "resolve-cwd": "^2.0.0"
+                        "pkg-dir": "2.0.0",
+                        "resolve-cwd": "2.0.0"
                     }
                 },
                 "locate-path": {
@@ -14808,8 +14815,8 @@
                     "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                     "dev": true,
                     "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
                     }
                 },
                 "p-limit": {
@@ -14818,7 +14825,7 @@
                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
                     "dev": true,
                     "requires": {
-                        "p-try": "^1.0.0"
+                        "p-try": "1.0.0"
                     }
                 },
                 "p-locate": {
@@ -14827,7 +14834,7 @@
                     "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                     "dev": true,
                     "requires": {
-                        "p-limit": "^1.1.0"
+                        "p-limit": "1.3.0"
                     }
                 },
                 "p-try": {
@@ -14842,7 +14849,7 @@
                     "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
                     "dev": true,
                     "requires": {
-                        "find-up": "^2.1.0"
+                        "find-up": "2.1.0"
                     }
                 }
             }
@@ -14853,8 +14860,8 @@
             "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
             "dev": true,
             "requires": {
-                "source-list-map": "^2.0.0",
-                "source-map": "~0.6.1"
+                "source-list-map": "2.0.1",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -14886,9 +14893,9 @@
             "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
             "dev": true,
             "requires": {
-                "lodash.sortby": "^4.7.0",
-                "tr46": "^1.0.1",
-                "webidl-conversions": "^4.0.2"
+                "lodash.sortby": "4.7.0",
+                "tr46": "1.0.1",
+                "webidl-conversions": "4.0.2"
             }
         },
         "which": {
@@ -14897,7 +14904,7 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "which-module": {
@@ -14912,7 +14919,7 @@
             "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
             "dev": true,
             "requires": {
-                "string-width": "^2.1.1"
+                "string-width": "2.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -14927,8 +14934,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -14937,7 +14944,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -14954,7 +14961,7 @@
             "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
             "dev": true,
             "requires": {
-                "errno": "~0.1.7"
+                "errno": "0.1.7"
             }
         },
         "wrap-ansi": {
@@ -14963,9 +14970,9 @@
             "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.0",
-                "string-width": "^3.0.0",
-                "strip-ansi": "^5.0.0"
+                "ansi-styles": "3.2.1",
+                "string-width": "3.1.0",
+                "strip-ansi": "5.2.0"
             }
         },
         "wrappy": {
@@ -14980,7 +14987,7 @@
             "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
             "dev": true,
             "requires": {
-                "mkdirp": "^0.5.1"
+                "mkdirp": "0.5.1"
             }
         },
         "write-file-atomic": {
@@ -14989,9 +14996,9 @@
             "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.2"
+                "graceful-fs": "4.2.2",
+                "imurmurhash": "0.1.4",
+                "signal-exit": "3.0.2"
             }
         },
         "ws": {
@@ -15000,7 +15007,7 @@
             "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
             "dev": true,
             "requires": {
-                "async-limiter": "~1.0.0"
+                "async-limiter": "1.0.1"
             }
         },
         "xdg-basedir": {
@@ -15039,16 +15046,16 @@
             "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
             "dev": true,
             "requires": {
-                "cliui": "^5.0.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^2.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
-                "string-width": "^3.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^13.1.1"
+                "cliui": "5.0.0",
+                "find-up": "3.0.0",
+                "get-caller-file": "2.0.5",
+                "require-directory": "2.1.1",
+                "require-main-filename": "2.0.0",
+                "set-blocking": "2.0.0",
+                "string-width": "3.1.0",
+                "which-module": "2.0.0",
+                "y18n": "4.0.0",
+                "yargs-parser": "13.1.1"
             }
         },
         "yargs-parser": {
@@ -15057,8 +15064,8 @@
             "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
             "dev": true,
             "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
+                "camelcase": "5.3.1",
+                "decamelize": "1.2.0"
             }
         },
         "ylru": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "webviz_subsurface_components",
+    "version": "1.0.0",
     "description": "Custom Dash components for use in Webviz",
     "main": "build/index.js",
     "scripts": {
@@ -28,8 +29,10 @@
     },
     "devDependencies": {
         "@babel/core": "^7.5.5",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-react": "^7.0.0",
+        "@plotly/webpack-dash-dynamic-import": "^1.1.1",
         "babel-eslint": "^9.0.0",
         "babel-loader": "^8.0.0",
         "chai": "^4.2.0",

--- a/tests/test_hm.py
+++ b/tests/test_hm.py
@@ -1,3 +1,4 @@
+import json
 import dash
 from dash.dependencies import Input, Output
 import webviz_subsurface_components
@@ -6,8 +7,8 @@ import dash_html_components as html
 # Basic test for the component rendering.
 def test_render_hm(dash_duo):
 
-    with open('tests/data/hm_data.json', 'r') as f:
-        hm_data = f.read()
+    with open('tests/data/hm_data.json', 'r') as json_file:
+        hm_data = json.load(json_file)
 
     app = dash.Dash(__name__)
 

--- a/tests/test_hm.py
+++ b/tests/test_hm.py
@@ -19,7 +19,4 @@ def test_render_hm(dash_duo):
 
     dash_duo.start_server(app)
 
-    # Get text of first data series
-    my_component = dash_duo.wait_for_element_by_css_selector('#g_history_matching_plot > text', timeout=4)
-
-    assert 'Misfit overview for Iteration 0' == my_component.text
+    dash_duo.wait_for_text_to_equal('#g_history_matching_plot > text', 'Misfit overview for Iteration 0', timeout=4)

--- a/tests/test_hm.py
+++ b/tests/test_hm.py
@@ -22,4 +22,4 @@ def test_render_hm(dash_duo):
 
     print(dash_duo.get_logs())
 
-    #dash_duo.wait_for_text_to_equal('#title', 'Misfit overview for Iteration 0', timeout=4)
+    dash_duo.wait_for_text_to_equal('#title', 'Misfit overview for Iteration 0', timeout=4)

--- a/tests/test_hm.py
+++ b/tests/test_hm.py
@@ -20,4 +20,7 @@ def test_render_hm(dash_duo):
 
     dash_duo.start_server(app)
 
-    dash_duo.wait_for_text_to_equal('#title', 'Misfit overview for Iteration 0', timeout=4)
+    # Get text of first data series
+    my_component = dash_duo.wait_for_element_by_css_selector('#g_history_matching_plot > text', timeout=4)
+
+    assert 'Misfit overview for Iteration 0' == my_component.text

--- a/tests/test_hm.py
+++ b/tests/test_hm.py
@@ -20,7 +20,4 @@ def test_render_hm(dash_duo):
 
     dash_duo.start_server(app)
 
-    # Get text of first data series
-    my_component = dash_duo.wait_for_element_by_css_selector('#g_history_matching_plot > text', timeout=4)
-
-    assert 'Misfit overview for Iteration 0' == my_component.text
+    dash_duo.wait_for_text_to_equal('#title', 'Misfit overview for Iteration 0', timeout=4)

--- a/tests/test_hm.py
+++ b/tests/test_hm.py
@@ -20,4 +20,6 @@ def test_render_hm(dash_duo):
 
     dash_duo.start_server(app)
 
-    dash_duo.wait_for_text_to_equal('#title', 'Misfit overview for Iteration 0', timeout=4)
+    print(dash_duo.get_logs())
+
+    #dash_duo.wait_for_text_to_equal('#title', 'Misfit overview for Iteration 0', timeout=4)

--- a/tests/test_hm.py
+++ b/tests/test_hm.py
@@ -19,4 +19,4 @@ def test_render_hm(dash_duo):
 
     dash_duo.start_server(app)
 
-    dash_duo.wait_for_text_to_equal('#g_history_matching_plot > text', 'Misfit overview for Iteration 0', timeout=4)
+    dash_duo.wait_for_text_to_equal('#title', 'Misfit overview for Iteration 0', timeout=4)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,6 @@
 const path = require("path");
+const WebpackDashDynamicImport = require('@plotly/webpack-dash-dynamic-import');
+
 const packagejson = require("./package.json");
 
 const dashLibraryName = packagejson.name.replace(/-/g, "_");
@@ -93,5 +95,8 @@ module.exports = (env, argv) => {
             ],
         },
         devtool,
+        plugins: [
+            new WebpackDashDynamicImport()
+        ]
     };
 };

--- a/webviz_subsurface_components/__init__.py
+++ b/webviz_subsurface_components/__init__.py
@@ -44,6 +44,7 @@ _js_dist = [
         "relative_package_path": "webviz_subsurface_components.min.js",
         "dev_package_path": "webviz_subsurface_components.dev.js",
         "namespace": package_name,
+        "async": "eager",
     }
 ]
 


### PR DESCRIPTION
There appears to be [recent changes](https://github.com/plotly/dash/blob/dev/CHANGELOG.md#140---2019-10-08) to the Dash framework. Change out tests to comply with updated test framework.

Also in `dash >= 1.5`, there is added dynamic import which third-party components need to implement as well.