### PR TITLE
Remove + in scm version tag as it breaks Dash's new fingerprint system

### DIFF
--- a/webviz_subsurface_components/__init__.py
+++ b/webviz_subsurface_components/__init__.py
@@ -14,7 +14,9 @@ from ._imports_ import __all__
 
 try:
     # Dash fingerprint system does not work with +. E.g. a development version tag like
-    # 0.0.10.dev25+gbe9818b.d20191103 will break Dash's fingerprint system.
+    # 0.0.10.dev11+abcd1234.d20191103 will break Dash's fingerprint system.
+    # Need to replace + with some supporter character as long as
+    # https://github.com/plotly/dash/issues/995 is open.
     __version__ = get_distribution(__name__).version.replace("+", ".")
 except DistributionNotFound:
     # package is not installed

--- a/webviz_subsurface_components/__init__.py
+++ b/webviz_subsurface_components/__init__.py
@@ -15,7 +15,7 @@ from ._imports_ import __all__
 try:
     # Dash fingerprint system does not work with +. E.g. a development version tag like
     # 0.0.10.dev11+abcd1234.d20191103 will break Dash's fingerprint system.
-    # Need to replace + with some supporter character as long as
+    # Need to replace + with some supported character as long as
     # https://github.com/plotly/dash/issues/995 is open.
     __version__ = get_distribution(__name__).version.replace("+", ".")
 except DistributionNotFound:

--- a/webviz_subsurface_components/__init__.py
+++ b/webviz_subsurface_components/__init__.py
@@ -13,7 +13,9 @@ from ._imports_ import *
 from ._imports_ import __all__
 
 try:
-    __version__ = get_distribution(__name__).version
+    # Dash fingerprint system does not work with +. E.g. a development version tag like
+    # 0.0.10.dev25+gbe9818b.d20191103 will break Dash's fingerprint system.
+    __version__ = get_distribution(__name__).version.replace("+", ".")
 except DistributionNotFound:
     # package is not installed
     pass
@@ -42,12 +44,9 @@ _this_module = _sys.modules[__name__]
 _js_dist = [
     {
         "relative_package_path": "webviz_subsurface_components.min.js",
+        "dev_package_path": "webviz_subsurface_components.dev.js",
         "namespace": package_name,
-    },
-    {
-        "relative_package_path": "webviz_subsurface_components.dev.js",
-        "namespace": package_name,
-    },
+    }
 ]
 
 _css_dist = []

--- a/webviz_subsurface_components/__init__.py
+++ b/webviz_subsurface_components/__init__.py
@@ -42,9 +42,12 @@ _this_module = _sys.modules[__name__]
 _js_dist = [
     {
         "relative_package_path": "webviz_subsurface_components.min.js",
-        "dev_package_path": "webviz_subsurface_components.dev.js",
         "namespace": package_name,
-    }
+    },
+    {
+        "relative_package_path": "webviz_subsurface_components.dev.js",
+        "namespace": package_name,
+    },
 ]
 
 _css_dist = []


### PR DESCRIPTION
Development tags in SCM versions has a `+` which breaks the new fingerprint system in `dash >= 1.5` (Dash  currently replace `.` with `_`, bot not other characters like `+`, see [this line](https://github.com/plotly/dash/blob/40b5357f262ac207f94ac980e6cb928d94df65b7/dash/fingerprint.py#L12)). We can solve this downstream in `webviz` by doing the replacement ourselves.