### PR TITLE
WIP: Add completion overview

### DIFF
--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -50,7 +50,9 @@ class App extends Component {
                     <option value="Morris">Morris</option>
                     <option value="SubsurfaceMap">SubsurfaceMap</option>
                     <option value="LayeredMap">LayeredMap</option>
-                    <option value="CompletionOverview">CompletionOverview</option>
+                    <option value="CompletionOverview">
+                        CompletionOverview
+                    </option>
                 </select>
                 {this.renderDemo()}
             </div>

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -4,11 +4,12 @@ import HistoryMatchDemo from "./HistoryMatchDemo";
 import MorrisDemo from "./MorrisDemo";
 import SubsurfaceMapDemo from "./SubsurfaceMapDemo";
 import LayeredMapDemo from "./LayeredMapDemo";
+import CompletionOverviewDemo from "./CompletionOverviewDemo";
 
 class App extends Component {
     constructor(props) {
         super(props);
-        this.state = { value: "LayeredMap" };
+        this.state = { value: "CompletionOverview" };
     }
 
     onChange(e) {
@@ -29,6 +30,9 @@ class App extends Component {
             case "LayeredMap": {
                 return <LayeredMapDemo />;
             }
+            case "CompletionOverview": {
+                return <CompletionOverviewDemo />;
+            }
             default: {
                 return null;
             }
@@ -46,6 +50,7 @@ class App extends Component {
                     <option value="Morris">Morris</option>
                     <option value="SubsurfaceMap">SubsurfaceMap</option>
                     <option value="LayeredMap">LayeredMap</option>
+                    <option value="CompletionOverview">CompletionOverview</option>
                 </select>
                 {this.renderDemo()}
             </div>

--- a/src/demo/CompletionOverviewDemo.js
+++ b/src/demo/CompletionOverviewDemo.js
@@ -39,6 +39,162 @@ const data = {
                 kvkh: 20,
             },
         },
+        "Y-1H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-2H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-3H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-4H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+    },
+    "2020-10-01": {
+        "X-1H": {
+            1: {
+                state: "perforated",
+                kvkh: 10,
+            },
+        },
+        "X-2H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "X-3H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-1H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-2H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-3H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-4H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+    },
+    "2021-10-01": {
+        "X-1H": {
+            1: {
+                state: "perforated",
+                kvkh: 10,
+            },
+        },
+        "X-2H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "X-3H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-1H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-2H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-3H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-4H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+    },
+    "2022-10-01": {
+        "X-1H": {
+            1: {
+                state: "perforated",
+                kvkh: 10,
+            },
+        },
+        "X-2H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "X-3H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-1H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-2H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-3H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "Y-4H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
     },
 };
 

--- a/src/demo/CompletionOverviewDemo.js
+++ b/src/demo/CompletionOverviewDemo.js
@@ -1,12 +1,50 @@
 import React, { Component } from "react";
 import CompletionOverview from "../lib/components/CompletionOverview";
 
+const layers = [
+    "Garn 4.2",
+    "Garn 4.1",
+    "Garn 3.3",
+    "Garn 3.2",
+    "Garn 3.1",
+    "Garn 2.2",
+    "Garn 2.1",
+    "Not",
+    "Ile 3.3",
+    "Ile 3.2",
+    "Ile 3.1",
+    "Ile 2",
+    "Ile 1",
+    "Ror",
+    "Tilje",
+];
+
+const data = {
+    "2019-10-01": {
+        "X-1H": {
+            1: {
+                state: "perforated",
+                kvkh: 10,
+            },
+        },
+        "X-2H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+        "X-3H": {
+            2: {
+                state: "perforated",
+                kvkh: 20,
+            },
+        },
+    },
+};
 
 class CompletionOverviewDemo extends Component {
     render() {
-        return (
-            <CompletionOverview />
-        );
+        return <CompletionOverview layers={layers} data={data} />;
     }
 }
 

--- a/src/demo/CompletionOverviewDemo.js
+++ b/src/demo/CompletionOverviewDemo.js
@@ -1,0 +1,13 @@
+import React, { Component } from "react";
+import CompletionOverview from "../lib/components/CompletionOverview";
+
+
+class CompletionOverviewDemo extends Component {
+    render() {
+        return (
+            <CompletionOverview />
+        );
+    }
+}
+
+export default CompletionOverviewDemo;

--- a/src/lib/components/CompletionOverview.js
+++ b/src/lib/components/CompletionOverview.js
@@ -1,48 +1,34 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import * as d3 from "d3";
+import render_completion from "../private_components/completion_overview/render_completion";
 
+// For en gitt sortering har bronnene et gitt x-koordinat.
+//   - Initier én SVG-gruppe per brønn. Behold disse i en dictionary.
+//   - Lag også rects for hvert lagt (men som i utgangspunktet ikke vises).
+
+// For time-slider: Når flyttes over bestemt tidsintervall:
+//   - Fjern/legg til kompletteringene på tidspunktet den er på.
+//
 
 class CompletionOverview extends Component {
-
     constructor(props) {
         super(props);
-        this.props.width = "100%";
-        this.props.height = "400px";
+        this.props.height = 300;
+        this.props.id = "some-id";
     }
 
-    componentDidMount(){
-        const number_layers = 20;
-        const color_range = d3.scaleOrdinal().domain(d3.range(number_layers)).range(d3.schemeSet3);
-
-        const layer2pixels = d3.scaleLinear()
-          .domain([0, number_layers]) // unit: km
-          .range([0, this.props.height]) // unit: pixels
-
-        d3.select("#some-id").append("rect")
-                             .attr("width", 200)
-                             .attr("height", 200);
-
-        d3.select("#some-id")
-          .selectAll("rect.bar_neg")
-          .data(d3.range(number_layers))
-            .enter()
-            .append("rect")
-            .attr("x", (d) => 100)
-            .attr("y", (d) => layer2pixels(d))
-            .attr("width", 100)
-            .attr("height", 100)
-            .attr("fill", (d) => myColor(d))
+    componentDidMount() {
+        render_completion(
+            this.props.id,
+            this.props.layers,
+            this.props.data,
+            this.props.height
+        );
     }
 
     render() {
-        return (
-            <div>
-                <svg id="some-id" width={this.props.width} height={this.props.height}></svg>
-            </div>
-        );
+        return <div id={this.props.id} width="100%"></div>;
     }
 }
-
 
 export default CompletionOverview;

--- a/src/lib/components/CompletionOverview.js
+++ b/src/lib/components/CompletionOverview.js
@@ -1,0 +1,48 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import * as d3 from "d3";
+
+
+class CompletionOverview extends Component {
+
+    constructor(props) {
+        super(props);
+        this.props.width = "100%";
+        this.props.height = "400px";
+    }
+
+    componentDidMount(){
+        const number_layers = 20;
+        const color_range = d3.scaleOrdinal().domain(d3.range(number_layers)).range(d3.schemeSet3);
+
+        const layer2pixels = d3.scaleLinear()
+          .domain([0, number_layers]) // unit: km
+          .range([0, this.props.height]) // unit: pixels
+
+        d3.select("#some-id").append("rect")
+                             .attr("width", 200)
+                             .attr("height", 200);
+
+        d3.select("#some-id")
+          .selectAll("rect.bar_neg")
+          .data(d3.range(number_layers))
+            .enter()
+            .append("rect")
+            .attr("x", (d) => 100)
+            .attr("y", (d) => layer2pixels(d))
+            .attr("width", 100)
+            .attr("height", 100)
+            .attr("fill", (d) => myColor(d))
+    }
+
+    render() {
+        return (
+            <div>
+                <svg id="some-id" width={this.props.width} height={this.props.height}></svg>
+            </div>
+        );
+    }
+}
+
+
+export default CompletionOverview;

--- a/src/lib/components/CompletionOverview.js
+++ b/src/lib/components/CompletionOverview.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import render_completion from "../private_components/completion_overview/render_completion";
+import CompletionOverviewD3 from "../private_components/completion_overview/render_completion";
 
 class CompletionOverview extends Component {
     constructor(props) {
@@ -10,7 +10,7 @@ class CompletionOverview extends Component {
     }
 
     componentDidMount() {
-        render_completion(
+        this.completion_overview = new CompletionOverviewD3(
             this.props.id,
             this.props.layers,
             this.props.data,

--- a/src/lib/components/CompletionOverview.js
+++ b/src/lib/components/CompletionOverview.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import render_completion from "../private_components/completion_overview/render_completion";
 
-
 class CompletionOverview extends Component {
     constructor(props) {
         super(props);

--- a/src/lib/components/CompletionOverview.js
+++ b/src/lib/components/CompletionOverview.js
@@ -2,13 +2,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import render_completion from "../private_components/completion_overview/render_completion";
 
-// For en gitt sortering har bronnene et gitt x-koordinat.
-//   - Initier én SVG-gruppe per brønn. Behold disse i en dictionary.
-//   - Lag også rects for hvert lagt (men som i utgangspunktet ikke vises).
-
-// For time-slider: Når flyttes over bestemt tidsintervall:
-//   - Fjern/legg til kompletteringene på tidspunktet den er på.
-//
 
 class CompletionOverview extends Component {
     constructor(props) {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -3,5 +3,6 @@ import HistoryMatch from "./components/HistoryMatch";
 import Map from "./components/Map";
 import Morris from "./components/Morris";
 import LayeredMap from "./components/LayeredMap";
+import CompletionOverview from "./components/CompletionOverview";
 
-export { HistoryMatch, Morris, Map, LayeredMap };
+export { HistoryMatch, Morris, Map, LayeredMap, CompletionOverview };

--- a/src/lib/private_components/completion_overview/render_completion.js
+++ b/src/lib/private_components/completion_overview/render_completion.js
@@ -1,0 +1,88 @@
+import * as d3 from "d3";
+
+function render_completion(parent_id, layers, data, height) {
+    const SPACE_LABEL_PLOT = 5; // Space between labels and plot, in pixels
+
+    const parent = d3.select("#" + parent_id);
+
+    const width = parent.node().offsetWidth;
+
+    const svg = parent
+        .append("svg")
+        .attr("width", width)
+        .attr("height", height);
+
+    const dates = Object.keys(data).sort();
+    const wells = Object.keys(data)
+        .flatMap(date => Object.keys(data[date]))
+        .sort();
+
+    const number_layers = layers.length;
+    const layer_colors = d3
+        .scaleOrdinal()
+        .domain(d3.range(number_layers))
+        .range(d3.schemePastel1);
+
+    const layer2pixels = d3
+        .scaleLinear()
+        .domain([0, number_layers])
+        .range([0, height]);
+    const layer_height = layer2pixels(1) - layer2pixels(0);
+
+    const g_layer_labels = svg.append("g");
+
+    g_layer_labels
+        .selectAll()
+        .data(d3.range(number_layers))
+        .enter()
+        .append("text")
+        .attr("dominant-baseline", "central")
+        .attr("text-anchor", "end")
+        .attr("y", d => layer2pixels(d) + 0.5 * layer_height)
+        .text(d => layers[d]);
+
+    const width_labels = g_layer_labels.node().getBBox().width;
+    g_layer_labels.attr("transform", `translate(${width_labels}, 0)`);
+
+    const width_layers = width - width_labels - SPACE_LABEL_PLOT;
+
+    const horizontal_offset_wells = d3
+        .scaleLinear()
+        .domain([0, wells.length - 1])
+        .range([0.1 * width_layers, 0.9 * width_layers]);
+
+    const g_completion_plot = svg
+        .append("g")
+        .attr("transform", `translate(${width_labels + SPACE_LABEL_PLOT}, 0)`);
+
+    g_completion_plot
+        .append("g")
+        .selectAll()
+        .data(d3.range(number_layers))
+        .enter()
+        .append("rect")
+        .attr("y", i => layer2pixels(i))
+        .attr("width", width_layers)
+        .attr("height", layer_height)
+        .attr("fill", i => layer_colors(i));
+
+    g_completion_plot
+        .append("g")
+        .selectAll()
+        .data(wells)
+        .enter()
+        .append("g")
+        .attr(
+            "transform",
+            (well, i) => `translate(${horizontal_offset_wells(i)}, 0)`
+        )
+        .selectAll()
+        .data(d3.range(number_layers))
+        .enter()
+        .append("line")
+        .attr("y1", i => layer2pixels(i))
+        .attr("y2", i => layer2pixels(i) + layer_height)
+        .attr("stroke", "black");
+}
+
+export default render_completion;

--- a/src/lib/private_components/completion_overview/render_completion.js
+++ b/src/lib/private_components/completion_overview/render_completion.js
@@ -1,88 +1,180 @@
 import * as d3 from "d3";
+import Slider from "../shared/slider";
 
-function render_completion(parent_id, layers, data, height) {
-    const SPACE_LABEL_PLOT = 5; // Space between labels and plot, in pixels
+class CompletionOverviewD3 {
+    constructor(container, layers, data, height) {
+        this.container = container;
+        this.layers = layers;
+        this.data = data;
+        this.height = height;
 
-    const parent = d3.select("#" + parent_id);
+        this.render_completion();
+    }
 
-    const width = parent.node().offsetWidth;
+    render_completion() {
+        const SPACE_LABEL_PLOT = 5; // Space between labels and plot, in pixels
 
-    const svg = parent
-        .append("svg")
-        .attr("width", width)
-        .attr("height", height);
+        const dates = Object.keys(this.data).sort();
+        const wells = [
+            ...new Set(
+                Object.keys(this.data)
+                    .flatMap(date => Object.keys(this.data[date]))
+                    .sort()
+            ),
+        ];
 
-    const dates = Object.keys(data).sort();
-    const wells = Object.keys(data)
-        .flatMap(date => Object.keys(data[date]))
-        .sort();
+        const parent = d3.select("#" + this.container);
 
-    const number_layers = layers.length;
-    const layer_colors = d3
-        .scaleOrdinal()
-        .domain(d3.range(number_layers))
-        .range(d3.schemePastel1);
+        const width = parent.node().offsetWidth;
 
-    const layer2pixels = d3
-        .scaleLinear()
-        .domain([0, number_layers])
-        .range([0, height]);
-    const layer_height = layer2pixels(1) - layer2pixels(0);
+        const svg = parent
+            .append("svg")
+            .style("overflow", "visible")
+            .attr("width", width)
+            .attr("height", this.height);
 
-    const g_layer_labels = svg.append("g");
+        const sliderContainer = svg.append("g");
 
-    g_layer_labels
-        .selectAll()
-        .data(d3.range(number_layers))
-        .enter()
-        .append("text")
-        .attr("dominant-baseline", "central")
-        .attr("text-anchor", "end")
-        .attr("y", d => layer2pixels(d) + 0.5 * layer_height)
-        .text(d => layers[d]);
+        const iterationPicker = new Slider({
+            parentElement: sliderContainer,
+            data: dates,
+            length: width,
+            width: 80,
+            position: {
+                x: 50,
+                y: 40,
+            },
+            numberOfVisibleTicks: 0,
+        });
 
-    const width_labels = g_layer_labels.node().getBBox().width;
-    g_layer_labels.attr("transform", `translate(${width_labels}, 0)`);
+        //this.iterationPicker.on("change", index => {
+        //    this._setIteration(index);
+        //});
 
-    const width_layers = width - width_labels - SPACE_LABEL_PLOT;
+        iterationPicker.render();
 
-    const horizontal_offset_wells = d3
-        .scaleLinear()
-        .domain([0, wells.length - 1])
-        .range([0.1 * width_layers, 0.9 * width_layers]);
+        const width_layer_labels = calculate_label_bbox(svg, this.layers).width;
+        const height_well_labels = calculate_label_bbox(svg, wells, 90).height;
 
-    const g_completion_plot = svg
-        .append("g")
-        .attr("transform", `translate(${width_labels + SPACE_LABEL_PLOT}, 0)`);
+        const width_completion_plot =
+            width - width_layer_labels - SPACE_LABEL_PLOT;
+        const height_completion_plot =
+            this.height - height_well_labels - SPACE_LABEL_PLOT;
 
-    g_completion_plot
-        .append("g")
-        .selectAll()
-        .data(d3.range(number_layers))
-        .enter()
-        .append("rect")
-        .attr("y", i => layer2pixels(i))
-        .attr("width", width_layers)
-        .attr("height", layer_height)
-        .attr("fill", i => layer_colors(i));
+        const number_layers = this.layers.length;
+        const layer_colors = d3
+            .scaleOrdinal()
+            .domain(d3.range(number_layers))
+            .range(d3.schemePastel1);
 
-    g_completion_plot
-        .append("g")
-        .selectAll()
-        .data(wells)
-        .enter()
-        .append("g")
-        .attr(
-            "transform",
-            (well, i) => `translate(${horizontal_offset_wells(i)}, 0)`
-        )
-        .selectAll()
-        .data(d3.range(number_layers))
-        .enter()
-        .append("line")
-        .attr("y1", i => layer2pixels(i))
-        .attr("y2", i => layer2pixels(i) + layer_height)
-        .attr("stroke", "black");
+        const layer2pixels = d3
+            .scaleLinear()
+            .domain([0, number_layers])
+            .range([0, height_completion_plot]);
+        const layer_height = layer2pixels(1) - layer2pixels(0);
+
+        const g_layer_labels = svg.append("g");
+
+        g_layer_labels
+            .selectAll()
+            .data(d3.range(number_layers))
+            .enter()
+            .append("text")
+            .attr("dominant-baseline", "central")
+            .attr("text-anchor", "end")
+            .attr(
+                "y",
+                d =>
+                    height_well_labels +
+                    SPACE_LABEL_PLOT +
+                    layer2pixels(d) +
+                    0.5 * layer_height
+            )
+            .text(d => this.layers[d]);
+
+        g_layer_labels.attr("transform", `translate(${width_layer_labels}, 0)`);
+
+        const horizontal_offset_wells = d3
+            .scaleLinear()
+            .domain([0, wells.length - 1])
+            .range([0.1 * width_completion_plot, 0.9 * width_completion_plot]);
+
+        const g_completion_plot = svg
+            .append("g")
+            .attr(
+                "transform",
+                `translate(${width_layer_labels +
+                    SPACE_LABEL_PLOT}, ${height_well_labels +
+                    SPACE_LABEL_PLOT})`
+            );
+
+        g_completion_plot
+            .append("g")
+            .selectAll()
+            .data(d3.range(number_layers))
+            .enter()
+            .append("rect")
+            .attr("y", i => layer2pixels(i))
+            .attr("width", width_completion_plot)
+            .attr("height", layer_height)
+            .attr("fill", i => layer_colors(i));
+
+        g_completion_plot
+            .append("g")
+            .selectAll()
+            .data(wells)
+            .enter()
+            .append("g")
+            .attr(
+                "transform",
+                (well, i) => `translate(${horizontal_offset_wells(i)}, 0)`
+            )
+            .selectAll()
+            .data(d3.range(number_layers))
+            .enter()
+            .append("line")
+            .attr("y1", i => layer2pixels(i))
+            .attr("y2", i => layer2pixels(i) + layer_height)
+            .attr("stroke", "black");
+
+        const g_well_labels = svg
+            .append("g")
+            .attr(
+                "transform",
+                `translate(${width_layer_labels + SPACE_LABEL_PLOT}, 0)`
+            )
+            .selectAll()
+            .data(wells)
+            .enter()
+            .append("text")
+            .attr("text-anchor", "end")
+            .attr("dominant-baseline", "central")
+            .attr(
+                "transform",
+                (well, i) =>
+                    `translate(${horizontal_offset_wells(i)}, 0) rotate(-90)`
+            )
+            .text(well => well);
+    }
+
 }
 
-export default render_completion;
+function calculate_label_bbox(svg, labels, rotation) {
+    const g_text_to_remove = svg.append("g").style("visibility", "hidden");
+    g_text_to_remove
+        .selectAll()
+        .data(labels)
+        .enter()
+        .append("text")
+        .attr("transform", `rotate(${rotation ? rotation : 0})`)
+        .text(label => label);
+
+    const bbox = g_text_to_remove.node().getBBox();
+    const result = { width: bbox.width, height: bbox.height };
+
+    g_text_to_remove.remove();
+
+    return result;
+}
+
+export default CompletionOverviewD3;


### PR DESCRIPTION
Related to https://github.com/equinor/webviz-subsurface/issues/95.

- [X] Add to React demo with some dummy data
- [X] Render layer names and pastel colored layers with equal thickness.
- [X] Add well placeholders.
- [ ] Add slider such that user can select time step.
- [ ] Add/remove completions for the different wells interactively when time step changes.
- [ ] Add possibility for choosing order of wells (i.e. sort on formations, alphabetically, chronologically).
- [ ] Let line thickness represent total `kvkh`.