### PR TITLE
Support dash==1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - black --check webviz_subsurface_components tests examples setup.py
   - npm run test
   - npm run linting
-  - npm run build:all
+  - npm run build
   - pip install .
   - pytest
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,29 +4,41 @@
     "lockfileVersion": 1,
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-            "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+            "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.0.0"
+                "@babel/highlight": "^7.8.3"
+            }
+        },
+        "@babel/compat-data": {
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.1.tgz",
+            "integrity": "sha512-Z+6ZOXvyOWYxJ50BwxzdhRnRsGST8Y3jaZgxYig575lTjVSs3KtJnmESwZegg6e2Dn0td1eDhoWlp1wI4BTCPw==",
+            "dev": true,
+            "requires": {
+                "browserslist": "^4.8.2",
+                "invariant": "^2.2.4",
+                "semver": "^5.5.0"
             }
         },
         "@babel/core": {
-            "version": "7.7.5",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.5.tgz",
-            "integrity": "sha512-M42+ScN4+1S9iB6f+TL7QBpoQETxbclx+KNoKJABghnKYE+fMzSGqst0BZJc8CpI625bwPwYgUyRvxZ+0mZzpw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
+            "integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.5.5",
-                "@babel/generator": "^7.7.4",
-                "@babel/helpers": "^7.7.4",
-                "@babel/parser": "^7.7.5",
-                "@babel/template": "^7.7.4",
-                "@babel/traverse": "^7.7.4",
-                "@babel/types": "^7.7.4",
+                "@babel/code-frame": "^7.8.3",
+                "@babel/generator": "^7.8.3",
+                "@babel/helpers": "^7.8.3",
+                "@babel/parser": "^7.8.3",
+                "@babel/template": "^7.8.3",
+                "@babel/traverse": "^7.8.3",
+                "@babel/types": "^7.8.3",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.1",
                 "json5": "^2.1.0",
                 "lodash": "^4.17.13",
                 "resolve": "^1.3.2",
@@ -35,244 +47,257 @@
             }
         },
         "@babel/generator": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-            "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
+            "integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.7.4",
+                "@babel/types": "^7.8.3",
                 "jsesc": "^2.5.1",
                 "lodash": "^4.17.13",
                 "source-map": "^0.5.0"
             }
         },
         "@babel/helper-annotate-as-pure": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
-            "integrity": "sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
+            "integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.7.4"
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-builder-binary-assignment-operator-visitor": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.4.tgz",
-            "integrity": "sha512-Biq/d/WtvfftWZ9Uf39hbPBYDUo986m5Bb4zhkeYDGUllF43D+nUe5M6Vuo6/8JDK/0YX/uBdeoQpyaNhNugZQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
+            "integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
             "dev": true,
             "requires": {
-                "@babel/helper-explode-assignable-expression": "^7.7.4",
-                "@babel/types": "^7.7.4"
+                "@babel/helper-explode-assignable-expression": "^7.8.3",
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-builder-react-jsx": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.4.tgz",
-            "integrity": "sha512-kvbfHJNN9dg4rkEM4xn1s8d1/h6TYNvajy9L1wx4qLn9HFg0IkTsQi4rfBe92nxrPUFcMsHoMV+8rU7MJb3fCA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.8.3.tgz",
+            "integrity": "sha512-JT8mfnpTkKNCboTqZsQTdGo3l3Ik3l7QIt9hh0O9DYiwVel37VoJpILKM4YFbP2euF32nkQSb+F9cUk9b7DDXQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.7.4",
+                "@babel/types": "^7.8.3",
                 "esutils": "^2.0.0"
             }
         },
         "@babel/helper-call-delegate": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.4.tgz",
-            "integrity": "sha512-8JH9/B7J7tCYJ2PpWVpw9JhPuEVHztagNVuQAFBVFYluRMlpG7F1CgKEgGeL6KFqcsIa92ZYVj6DSc0XwmN1ZA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.8.3.tgz",
+            "integrity": "sha512-6Q05px0Eb+N4/GTyKPPvnkig7Lylw+QzihMpws9iiZQv7ZImf84ZsZpQH7QoWN4n4tm81SnSzPgHw2qtO0Zf3A==",
             "dev": true,
             "requires": {
-                "@babel/helper-hoist-variables": "^7.7.4",
-                "@babel/traverse": "^7.7.4",
-                "@babel/types": "^7.7.4"
+                "@babel/helper-hoist-variables": "^7.8.3",
+                "@babel/traverse": "^7.8.3",
+                "@babel/types": "^7.8.3"
+            }
+        },
+        "@babel/helper-compilation-targets": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.3.tgz",
+            "integrity": "sha512-JLylPCsFjhLN+6uBSSh3iYdxKdeO9MNmoY96PE/99d8kyBFaXLORtAVhqN6iHa+wtPeqxKLghDOZry0+Aiw9Tw==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.8.1",
+                "browserslist": "^4.8.2",
+                "invariant": "^2.2.4",
+                "levenary": "^1.1.0",
+                "semver": "^5.5.0"
             }
         },
         "@babel/helper-create-regexp-features-plugin": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz",
-            "integrity": "sha512-Mt+jBKaxL0zfOIWrfQpnfYCN7/rS6GKx6CCCfuoqVVd+17R8zNDlzVYmIi9qyb2wOk002NsmSTDymkIygDUH7A==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.3.tgz",
+            "integrity": "sha512-Gcsm1OHCUr9o9TcJln57xhWHtdXbA2pgQ58S0Lxlks0WMGNXuki4+GLfX0p+L2ZkINUGZvfkz8rzoqJQSthI+Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-regex": "^7.4.4",
+                "@babel/helper-regex": "^7.8.3",
                 "regexpu-core": "^4.6.0"
             }
         },
         "@babel/helper-define-map": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.4.tgz",
-            "integrity": "sha512-v5LorqOa0nVQUvAUTUF3KPastvUt/HzByXNamKQ6RdJRTV7j8rLL+WB5C/MzzWAwOomxDhYFb1wLLxHqox86lg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
+            "integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.7.4",
-                "@babel/types": "^7.7.4",
+                "@babel/helper-function-name": "^7.8.3",
+                "@babel/types": "^7.8.3",
                 "lodash": "^4.17.13"
             }
         },
         "@babel/helper-explode-assignable-expression": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz",
-            "integrity": "sha512-2/SicuFrNSXsZNBxe5UGdLr+HZg+raWBLE9vC98bdYOKX/U6PY0mdGlYUJdtTDPSU0Lw0PNbKKDpwYHJLn2jLg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
+            "integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.7.4",
-                "@babel/types": "^7.7.4"
+                "@babel/traverse": "^7.8.3",
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-            "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+            "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.7.4",
-                "@babel/template": "^7.7.4",
-                "@babel/types": "^7.7.4"
+                "@babel/helper-get-function-arity": "^7.8.3",
+                "@babel/template": "^7.8.3",
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-            "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+            "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.7.4"
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-hoist-variables": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.4.tgz",
-            "integrity": "sha512-wQC4xyvc1Jo/FnLirL6CEgPgPCa8M74tOdjWpRhQYapz5JC7u3NYU1zCVoVAGCE3EaIP9T1A3iW0WLJ+reZlpQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
+            "integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.7.4"
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz",
-            "integrity": "sha512-9KcA1X2E3OjXl/ykfMMInBK+uVdfIVakVe7W7Lg3wfXUNyS3Q1HWLFRwZIjhqiCGbslummPDnmb7vIekS0C1vw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+            "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.7.4"
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
-            "integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+            "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.7.4"
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.7.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.5.tgz",
-            "integrity": "sha512-A7pSxyJf1gN5qXVcidwLWydjftUN878VkalhXX5iQDuGyiGK3sOrrKKHF4/A4fwHtnsotv/NipwAeLzY4KQPvw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.3.tgz",
+            "integrity": "sha512-C7NG6B7vfBa/pwCOshpMbOYUmrYQDfCpVL/JCRu0ek8B5p8kue1+BCXpg2vOYs7w5ACB9GTOBYQ5U6NwrMg+3Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.7.4",
-                "@babel/helper-simple-access": "^7.7.4",
-                "@babel/helper-split-export-declaration": "^7.7.4",
-                "@babel/template": "^7.7.4",
-                "@babel/types": "^7.7.4",
+                "@babel/helper-module-imports": "^7.8.3",
+                "@babel/helper-simple-access": "^7.8.3",
+                "@babel/helper-split-export-declaration": "^7.8.3",
+                "@babel/template": "^7.8.3",
+                "@babel/types": "^7.8.3",
                 "lodash": "^4.17.13"
             }
         },
         "@babel/helper-optimise-call-expression": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz",
-            "integrity": "sha512-VB7gWZ2fDkSuqW6b1AKXkJWO5NyNI3bFL/kK79/30moK57blr6NbH8xcl2XcKCwOmJosftWunZqfO84IGq3ZZg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+            "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.7.4"
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-plugin-utils": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-            "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+            "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
             "dev": true
         },
         "@babel/helper-regex": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
-            "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
+            "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
             "dev": true,
             "requires": {
                 "lodash": "^4.17.13"
             }
         },
         "@babel/helper-remap-async-to-generator": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
-            "integrity": "sha512-Sk4xmtVdM9sA/jCI80f+KS+Md+ZHIpjuqmYPk1M7F/upHou5e4ReYmExAiu6PVe65BhJPZA2CY9x9k4BqE5klw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
+            "integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.7.4",
-                "@babel/helper-wrap-function": "^7.7.4",
-                "@babel/template": "^7.7.4",
-                "@babel/traverse": "^7.7.4",
-                "@babel/types": "^7.7.4"
+                "@babel/helper-annotate-as-pure": "^7.8.3",
+                "@babel/helper-wrap-function": "^7.8.3",
+                "@babel/template": "^7.8.3",
+                "@babel/traverse": "^7.8.3",
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-replace-supers": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
-            "integrity": "sha512-pP0tfgg9hsZWo5ZboYGuBn/bbYT/hdLPVSS4NMmiRJdwWhP0IznPwN9AE1JwyGsjSPLC364I0Qh5p+EPkGPNpg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.3.tgz",
+            "integrity": "sha512-xOUssL6ho41U81etpLoT2RTdvdus4VfHamCuAm4AHxGr+0it5fnwoVdwUJ7GFEqCsQYzJUhcbsN9wB9apcYKFA==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.7.4",
-                "@babel/helper-optimise-call-expression": "^7.7.4",
-                "@babel/traverse": "^7.7.4",
-                "@babel/types": "^7.7.4"
+                "@babel/helper-member-expression-to-functions": "^7.8.3",
+                "@babel/helper-optimise-call-expression": "^7.8.3",
+                "@babel/traverse": "^7.8.3",
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-simple-access": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz",
-            "integrity": "sha512-zK7THeEXfan7UlWsG2A6CI/L9jVnI5+xxKZOdej39Y0YtDYKx9raHk5F2EtK9K8DHRTihYwg20ADt9S36GR78A==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+            "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.7.4",
-                "@babel/types": "^7.7.4"
+                "@babel/template": "^7.8.3",
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-            "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+            "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.7.4"
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-wrap-function": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
-            "integrity": "sha512-VsfzZt6wmsocOaVU0OokwrIytHND55yvyT4BPB9AIIgwr8+x7617hetdJTsuGwygN5RC6mxA9EJztTjuwm2ofg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
+            "integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.7.4",
-                "@babel/template": "^7.7.4",
-                "@babel/traverse": "^7.7.4",
-                "@babel/types": "^7.7.4"
+                "@babel/helper-function-name": "^7.8.3",
+                "@babel/template": "^7.8.3",
+                "@babel/traverse": "^7.8.3",
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helpers": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
-            "integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.3.tgz",
+            "integrity": "sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.7.4",
-                "@babel/traverse": "^7.7.4",
-                "@babel/types": "^7.7.4"
+                "@babel/template": "^7.8.3",
+                "@babel/traverse": "^7.8.3",
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/highlight": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-            "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+            "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.0",
@@ -281,593 +306,638 @@
             }
         },
         "@babel/parser": {
-            "version": "7.7.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-            "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
+            "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
             "dev": true
         },
         "@babel/plugin-proposal-async-generator-functions": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz",
-            "integrity": "sha512-1ypyZvGRXriY/QP668+s8sFr2mqinhkRDMPSQLNghCQE+GAkFtp+wkHVvg2+Hdki8gwP+NFzJBJ/N1BfzCCDEw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
+            "integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-remap-async-to-generator": "^7.7.4",
-                "@babel/plugin-syntax-async-generators": "^7.7.4"
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-remap-async-to-generator": "^7.8.3",
+                "@babel/plugin-syntax-async-generators": "^7.8.0"
             }
         },
         "@babel/plugin-proposal-dynamic-import": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.4.tgz",
-            "integrity": "sha512-StH+nGAdO6qDB1l8sZ5UBV8AC3F2VW2I8Vfld73TMKyptMU9DY5YsJAS8U81+vEtxcH3Y/La0wG0btDrhpnhjQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
+            "integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-dynamic-import": "^7.7.4"
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.0"
             }
         },
         "@babel/plugin-proposal-json-strings": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.7.4.tgz",
-            "integrity": "sha512-wQvt3akcBTfLU/wYoqm/ws7YOAQKu8EVJEvHip/mzkNtjaclQoCCIqKXFP5/eyfnfbQCDV3OLRIK3mIVyXuZlw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
+            "integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-json-strings": "^7.7.4"
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
             }
         },
         "@babel/plugin-proposal-object-rest-spread": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
-            "integrity": "sha512-rnpnZR3/iWKmiQyJ3LKJpSwLDcX/nSXhdLk4Aq/tXOApIvyu7qoabrige0ylsAJffaUC51WiBu209Q0U+86OWQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.3.tgz",
+            "integrity": "sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-object-rest-spread": "^7.7.4"
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.0"
             }
         },
         "@babel/plugin-proposal-optional-catch-binding": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz",
-            "integrity": "sha512-DyM7U2bnsQerCQ+sejcTNZh8KQEUuC3ufzdnVnSiUv/qoGJp2Z3hanKL18KDhsBT5Wj6a7CMT5mdyCNJsEaA9w==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-optional-chaining": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz",
+            "integrity": "sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.0"
             }
         },
         "@babel/plugin-proposal-unicode-property-regex": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.4.tgz",
-            "integrity": "sha512-cHgqHgYvffluZk85dJ02vloErm3Y6xtH+2noOBOJ2kXOJH3aVCDnj5eR/lVNlTnYu4hndAPJD3rTFjW3qee0PA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.3.tgz",
+            "integrity": "sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.7.4",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-syntax-async-generators": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz",
-            "integrity": "sha512-Li4+EjSpBgxcsmeEF8IFcfV/+yJGxHXDirDkEoyFjumuwbmfCVHUt0HuowD/iGM7OhIRyXJH9YXxqiH6N815+g==",
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
         "@babel/plugin-syntax-dynamic-import": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz",
-            "integrity": "sha512-jHQW0vbRGvwQNgyVxwDh4yuXu4bH1f5/EICJLAhl1SblLs2CDhrsmCk+v5XLdE9wxtAFRyxx+P//Iw+a5L/tTg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+            "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
         "@babel/plugin-syntax-json-strings": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.7.4.tgz",
-            "integrity": "sha512-QpGupahTQW1mHRXddMG5srgpHWqRLwJnJZKXTigB9RPFCCGbDGCgBeM/iC82ICXp414WeYx/tD54w7M2qRqTMg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
         "@babel/plugin-syntax-jsx": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.7.4.tgz",
-            "integrity": "sha512-wuy6fiMe9y7HeZBWXYCGt2RGxZOj0BImZ9EyXJVnVGBKO/Br592rbR3rtIQn0eQhAk9vqaKP5n8tVqEFBQMfLg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.8.3.tgz",
+            "integrity": "sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-syntax-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
         "@babel/plugin-syntax-object-rest-spread": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
-            "integrity": "sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+            "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
         "@babel/plugin-syntax-optional-catch-binding": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
-            "integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-chaining": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
         "@babel/plugin-syntax-top-level-await": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.4.tgz",
-            "integrity": "sha512-wdsOw0MvkL1UIgiQ/IFr3ETcfv1xb8RMM0H9wbiDyLaJFyiDg5oZvDLCXosIXmFeIlweML5iOBXAkqddkYNizg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
+            "integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-arrow-functions": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.7.4.tgz",
-            "integrity": "sha512-zUXy3e8jBNPiffmqkHRNDdZM2r8DWhCB7HhcoyZjiK1TxYEluLHAvQuYnTT+ARqRpabWqy/NHkO6e3MsYB5YfA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
+            "integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-async-to-generator": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz",
-            "integrity": "sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
+            "integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.7.4",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-remap-async-to-generator": "^7.7.4"
+                "@babel/helper-module-imports": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-remap-async-to-generator": "^7.8.3"
             }
         },
         "@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz",
-            "integrity": "sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
+            "integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-block-scoping": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.7.4.tgz",
-            "integrity": "sha512-2VBe9u0G+fDt9B5OV5DQH4KBf5DoiNkwFKOz0TCvBWvdAN2rOykCTkrL+jTLxfCAm76l9Qo5OqL7HBOx2dWggg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
+            "integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.8.3",
                 "lodash": "^4.17.13"
             }
         },
         "@babel/plugin-transform-classes": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.4.tgz",
-            "integrity": "sha512-sK1mjWat7K+buWRuImEzjNf68qrKcrddtpQo3swi9j7dUcG6y6R6+Di039QN2bD1dykeswlagupEmpOatFHHUg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.3.tgz",
+            "integrity": "sha512-SjT0cwFJ+7Rbr1vQsvphAHwUHvSUPmMjMU/0P59G8U2HLFqSa082JO7zkbDNWs9kH/IUqpHI6xWNesGf8haF1w==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.7.4",
-                "@babel/helper-define-map": "^7.7.4",
-                "@babel/helper-function-name": "^7.7.4",
-                "@babel/helper-optimise-call-expression": "^7.7.4",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-replace-supers": "^7.7.4",
-                "@babel/helper-split-export-declaration": "^7.7.4",
+                "@babel/helper-annotate-as-pure": "^7.8.3",
+                "@babel/helper-define-map": "^7.8.3",
+                "@babel/helper-function-name": "^7.8.3",
+                "@babel/helper-optimise-call-expression": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-replace-supers": "^7.8.3",
+                "@babel/helper-split-export-declaration": "^7.8.3",
                 "globals": "^11.1.0"
             }
         },
         "@babel/plugin-transform-computed-properties": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.7.4.tgz",
-            "integrity": "sha512-bSNsOsZnlpLLyQew35rl4Fma3yKWqK3ImWMSC/Nc+6nGjC9s5NFWAer1YQ899/6s9HxO2zQC1WoFNfkOqRkqRQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
+            "integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-destructuring": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.7.4.tgz",
-            "integrity": "sha512-4jFMXI1Cu2aXbcXXl8Lr6YubCn6Oc7k9lLsu8v61TZh+1jny2BWmdtvY9zSUlLdGUvcy9DMAWyZEOqjsbeg/wA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.3.tgz",
+            "integrity": "sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-dotall-regex": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.4.tgz",
-            "integrity": "sha512-mk0cH1zyMa/XHeb6LOTXTbG7uIJ8Rrjlzu91pUx/KS3JpcgaTDwMS8kM+ar8SLOvlL2Lofi4CGBAjCo3a2x+lw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
+            "integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.7.4",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-duplicate-keys": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.7.4.tgz",
-            "integrity": "sha512-g1y4/G6xGWMD85Tlft5XedGaZBCIVN+/P0bs6eabmcPP9egFleMAo65OOjlhcz1njpwagyY3t0nsQC9oTFegJA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
+            "integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.7.4.tgz",
-            "integrity": "sha512-MCqiLfCKm6KEA1dglf6Uqq1ElDIZwFuzz1WH5mTf8k2uQSxEJMbOIEh7IZv7uichr7PMfi5YVSrr1vz+ipp7AQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
+            "integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.7.4",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-for-of": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz",
-            "integrity": "sha512-zZ1fD1B8keYtEcKF+M1TROfeHTKnijcVQm0yO/Yu1f7qoDoxEIc/+GX6Go430Bg84eM/xwPFp0+h4EbZg7epAA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.3.tgz",
+            "integrity": "sha512-ZjXznLNTxhpf4Q5q3x1NsngzGA38t9naWH8Gt+0qYZEJAcvPI9waSStSh56u19Ofjr7QmD0wUsQ8hw8s/p1VnA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-function-name": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.4.tgz",
-            "integrity": "sha512-E/x09TvjHNhsULs2IusN+aJNRV5zKwxu1cpirZyRPw+FyyIKEHPXTsadj48bVpc1R5Qq1B5ZkzumuFLytnbT6g==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
+            "integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.7.4",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-function-name": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-literals": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.7.4.tgz",
-            "integrity": "sha512-X2MSV7LfJFm4aZfxd0yLVFrEXAgPqYoDG53Br/tCKiKYfX0MjVjQeWPIhPHHsCqzwQANq+FLN786fF5rgLS+gw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
+            "integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-member-expression-literals": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.7.4.tgz",
-            "integrity": "sha512-9VMwMO7i69LHTesL0RdGy93JU6a+qOPuvB4F4d0kR0zyVjJRVJRaoaGjhtki6SzQUu8yen/vxPKN6CWnCUw6bA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
+            "integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-modules-amd": {
-            "version": "7.7.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.5.tgz",
-            "integrity": "sha512-CT57FG4A2ZUNU1v+HdvDSDrjNWBrtCmSH6YbbgN3Lrf0Di/q/lWRxZrE72p3+HCCz9UjfZOEBdphgC0nzOS6DQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.8.3.tgz",
+            "integrity": "sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.7.5",
-                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-module-transforms": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3",
                 "babel-plugin-dynamic-import-node": "^2.3.0"
             }
         },
         "@babel/plugin-transform-modules-commonjs": {
-            "version": "7.7.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.5.tgz",
-            "integrity": "sha512-9Cq4zTFExwFhQI6MT1aFxgqhIsMWQWDVwOgLzl7PTWJHsNaqFvklAU+Oz6AQLAS0dJKTwZSOCo20INwktxpi3Q==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.8.3.tgz",
+            "integrity": "sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.7.5",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-simple-access": "^7.7.4",
+                "@babel/helper-module-transforms": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-simple-access": "^7.8.3",
                 "babel-plugin-dynamic-import-node": "^2.3.0"
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.4.tgz",
-            "integrity": "sha512-y2c96hmcsUi6LrMqvmNDPBBiGCiQu0aYqpHatVVu6kD4mFEXKjyNxd/drc18XXAf9dv7UXjrZwBVmTTGaGP8iw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.8.3.tgz",
+            "integrity": "sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==",
             "dev": true,
             "requires": {
-                "@babel/helper-hoist-variables": "^7.7.4",
-                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-hoist-variables": "^7.8.3",
+                "@babel/helper-module-transforms": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3",
                 "babel-plugin-dynamic-import-node": "^2.3.0"
             }
         },
         "@babel/plugin-transform-modules-umd": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.4.tgz",
-            "integrity": "sha512-u2B8TIi0qZI4j8q4C51ktfO7E3cQ0qnaXFI1/OXITordD40tt17g/sXqgNNCcMTcBFKrUPcGDx+TBJuZxLx7tw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.8.3.tgz",
+            "integrity": "sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.7.4",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-module-transforms": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.4.tgz",
-            "integrity": "sha512-jBUkiqLKvUWpv9GLSuHUFYdmHg0ujC1JEYoZUfeOOfNydZXp1sXObgyPatpcwjWgsdBGsagWW0cdJpX/DO2jMw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
+            "integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.7.4"
+                "@babel/helper-create-regexp-features-plugin": "^7.8.3"
             }
         },
         "@babel/plugin-transform-new-target": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.7.4.tgz",
-            "integrity": "sha512-CnPRiNtOG1vRodnsyGX37bHQleHE14B9dnnlgSeEs3ek3fHN1A1SScglTCg1sfbe7sRQ2BUcpgpTpWSfMKz3gg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
+            "integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-object-super": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
-            "integrity": "sha512-ho+dAEhC2aRnff2JCA0SAK7V2R62zJd/7dmtoe7MHcso4C2mS+vZjn1Pb1pCVZvJs1mgsvv5+7sT+m3Bysb6eg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
+            "integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-replace-supers": "^7.7.4"
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-replace-supers": "^7.8.3"
             }
         },
         "@babel/plugin-transform-parameters": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.4.tgz",
-            "integrity": "sha512-VJwhVePWPa0DqE9vcfptaJSzNDKrWU/4FbYCjZERtmqEs05g3UMXnYMZoXja7JAJ7Y7sPZipwm/pGApZt7wHlw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.3.tgz",
+            "integrity": "sha512-/pqngtGb54JwMBZ6S/D3XYylQDFtGjWrnoCF4gXZOUpFV/ujbxnoNGNvDGu6doFWRPBveE72qTx/RRU44j5I/Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-call-delegate": "^7.7.4",
-                "@babel/helper-get-function-arity": "^7.7.4",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-call-delegate": "^7.8.3",
+                "@babel/helper-get-function-arity": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-property-literals": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.7.4.tgz",
-            "integrity": "sha512-MatJhlC4iHsIskWYyawl53KuHrt+kALSADLQQ/HkhTjX954fkxIEh4q5slL4oRAnsm/eDoZ4q0CIZpcqBuxhJQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
+            "integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-react-display-name": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.7.4.tgz",
-            "integrity": "sha512-sBbIvqYkthai0X0vkD2xsAwluBp+LtNHH+/V4a5ydifmTtb8KOVOlrMIk/MYmIc4uTYDnjZUHQildYNo36SRJw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.8.3.tgz",
+            "integrity": "sha512-3Jy/PCw8Fe6uBKtEgz3M82ljt+lTg+xJaM4og+eyu83qLT87ZUSckn0wy7r31jflURWLO83TW6Ylf7lyXj3m5A==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-react-jsx": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.4.tgz",
-            "integrity": "sha512-LixU4BS95ZTEAZdPaIuyg/k8FiiqN9laQ0dMHB4MlpydHY53uQdWCUrwjLr5o6ilS6fAgZey4Q14XBjl5tL6xw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.8.3.tgz",
+            "integrity": "sha512-r0h+mUiyL595ikykci+fbwm9YzmuOrUBi0b+FDIKmi3fPQyFokWVEMJnRWHJPPQEjyFJyna9WZC6Viv6UHSv1g==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-react-jsx": "^7.7.4",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-jsx": "^7.7.4"
+                "@babel/helper-builder-react-jsx": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-jsx": "^7.8.3"
             }
         },
         "@babel/plugin-transform-react-jsx-self": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.7.4.tgz",
-            "integrity": "sha512-PWYjSfqrO273mc1pKCRTIJXyqfc9vWYBax88yIhQb+bpw3XChVC7VWS4VwRVs63wFHKxizvGSd00XEr+YB9Q2A==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.8.3.tgz",
+            "integrity": "sha512-01OT7s5oa0XTLf2I8XGsL8+KqV9lx3EZV+jxn/L2LQ97CGKila2YMroTkCEIE0HV/FF7CMSRsIAybopdN9NTdg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-jsx": "^7.7.4"
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-jsx": "^7.8.3"
             }
         },
         "@babel/plugin-transform-react-jsx-source": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.7.4.tgz",
-            "integrity": "sha512-5ZU9FnPhqtHsOXxutRtXZAzoEJwDaP32QcobbMP1/qt7NYcsCNK8XgzJcJfoEr/ZnzVvUNInNjIW22Z6I8p9mg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.8.3.tgz",
+            "integrity": "sha512-PLMgdMGuVDtRS/SzjNEQYUT8f4z1xb2BAT54vM1X5efkVuYBf5WyGUMbpmARcfq3NaglIwz08UVQK4HHHbC6ag==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-jsx": "^7.7.4"
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-jsx": "^7.8.3"
             }
         },
         "@babel/plugin-transform-regenerator": {
-            "version": "7.7.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.5.tgz",
-            "integrity": "sha512-/8I8tPvX2FkuEyWbjRCt4qTAgZK0DVy8QRguhA524UH48RfGJy94On2ri+dCuwOpcerPRl9O4ebQkRcVzIaGBw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.3.tgz",
+            "integrity": "sha512-qt/kcur/FxrQrzFR432FGZznkVAjiyFtCOANjkAKwCbt465L6ZCiUQh2oMYGU3Wo8LRFJxNDFwWn106S5wVUNA==",
             "dev": true,
             "requires": {
                 "regenerator-transform": "^0.14.0"
             }
         },
         "@babel/plugin-transform-reserved-words": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.7.4.tgz",
-            "integrity": "sha512-OrPiUB5s5XvkCO1lS7D8ZtHcswIC57j62acAnJZKqGGnHP+TIc/ljQSrgdX/QyOTdEK5COAhuc820Hi1q2UgLQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
+            "integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-shorthand-properties": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.7.4.tgz",
-            "integrity": "sha512-q+suddWRfIcnyG5YiDP58sT65AJDZSUhXQDZE3r04AuqD6d/XLaQPPXSBzP2zGerkgBivqtQm9XKGLuHqBID6Q==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
+            "integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-spread": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.7.4.tgz",
-            "integrity": "sha512-8OSs0FLe5/80cndziPlg4R0K6HcWSM0zyNhHhLsmw/Nc5MaA49cAsnoJ/t/YZf8qkG7fD+UjTRaApVDB526d7Q==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
+            "integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-sticky-regex": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.7.4.tgz",
-            "integrity": "sha512-Ls2NASyL6qtVe1H1hXts9yuEeONV2TJZmplLONkMPUG158CtmnrzW5Q5teibM5UVOFjG0D3IC5mzXR6pPpUY7A==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
+            "integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-regex": "^7.8.3"
             }
         },
         "@babel/plugin-transform-template-literals": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.7.4.tgz",
-            "integrity": "sha512-sA+KxLwF3QwGj5abMHkHgshp9+rRz+oY9uoRil4CyLtgEuE/88dpkeWgNk5qKVsJE9iSfly3nvHapdRiIS2wnQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
+            "integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.7.4",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-annotate-as-pure": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-typeof-symbol": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.7.4.tgz",
-            "integrity": "sha512-KQPUQ/7mqe2m0B8VecdyaW5XcQYaePyl9R7IsKd+irzj6jvbhoGnRE+M0aNkyAzI07VfUQ9266L5xMARitV3wg==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.3.tgz",
+            "integrity": "sha512-3TrkKd4LPqm4jHs6nPtSDI/SV9Cm5PRJkHLUgTcqRQQTMAZ44ZaAdDZJtvWFSaRcvT0a1rTmJ5ZA5tDKjleF3g==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-transform-unicode-regex": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.4.tgz",
-            "integrity": "sha512-N77UUIV+WCvE+5yHw+oks3m18/umd7y392Zv7mYTpFqHtkpcc+QUz+gLJNTWVlWROIWeLqY0f3OjZxV5TcXnRw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
+            "integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.7.4",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/preset-env": {
-            "version": "7.7.6",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.6.tgz",
-            "integrity": "sha512-k5hO17iF/Q7tR9Jv8PdNBZWYW6RofxhnxKjBMc0nG4JTaWvOTiPoO/RLFwAKcA4FpmuBFm6jkoqaRJLGi0zdaQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.3.tgz",
+            "integrity": "sha512-Rs4RPL2KjSLSE2mWAx5/iCH+GC1ikKdxPrhnRS6PfFVaiZeom22VFKN4X8ZthyN61kAaR05tfXTbCvatl9WIQg==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.7.4",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-proposal-async-generator-functions": "^7.7.4",
-                "@babel/plugin-proposal-dynamic-import": "^7.7.4",
-                "@babel/plugin-proposal-json-strings": "^7.7.4",
-                "@babel/plugin-proposal-object-rest-spread": "^7.7.4",
-                "@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
-                "@babel/plugin-proposal-unicode-property-regex": "^7.7.4",
-                "@babel/plugin-syntax-async-generators": "^7.7.4",
-                "@babel/plugin-syntax-dynamic-import": "^7.7.4",
-                "@babel/plugin-syntax-json-strings": "^7.7.4",
-                "@babel/plugin-syntax-object-rest-spread": "^7.7.4",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.7.4",
-                "@babel/plugin-syntax-top-level-await": "^7.7.4",
-                "@babel/plugin-transform-arrow-functions": "^7.7.4",
-                "@babel/plugin-transform-async-to-generator": "^7.7.4",
-                "@babel/plugin-transform-block-scoped-functions": "^7.7.4",
-                "@babel/plugin-transform-block-scoping": "^7.7.4",
-                "@babel/plugin-transform-classes": "^7.7.4",
-                "@babel/plugin-transform-computed-properties": "^7.7.4",
-                "@babel/plugin-transform-destructuring": "^7.7.4",
-                "@babel/plugin-transform-dotall-regex": "^7.7.4",
-                "@babel/plugin-transform-duplicate-keys": "^7.7.4",
-                "@babel/plugin-transform-exponentiation-operator": "^7.7.4",
-                "@babel/plugin-transform-for-of": "^7.7.4",
-                "@babel/plugin-transform-function-name": "^7.7.4",
-                "@babel/plugin-transform-literals": "^7.7.4",
-                "@babel/plugin-transform-member-expression-literals": "^7.7.4",
-                "@babel/plugin-transform-modules-amd": "^7.7.5",
-                "@babel/plugin-transform-modules-commonjs": "^7.7.5",
-                "@babel/plugin-transform-modules-systemjs": "^7.7.4",
-                "@babel/plugin-transform-modules-umd": "^7.7.4",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
-                "@babel/plugin-transform-new-target": "^7.7.4",
-                "@babel/plugin-transform-object-super": "^7.7.4",
-                "@babel/plugin-transform-parameters": "^7.7.4",
-                "@babel/plugin-transform-property-literals": "^7.7.4",
-                "@babel/plugin-transform-regenerator": "^7.7.5",
-                "@babel/plugin-transform-reserved-words": "^7.7.4",
-                "@babel/plugin-transform-shorthand-properties": "^7.7.4",
-                "@babel/plugin-transform-spread": "^7.7.4",
-                "@babel/plugin-transform-sticky-regex": "^7.7.4",
-                "@babel/plugin-transform-template-literals": "^7.7.4",
-                "@babel/plugin-transform-typeof-symbol": "^7.7.4",
-                "@babel/plugin-transform-unicode-regex": "^7.7.4",
-                "@babel/types": "^7.7.4",
-                "browserslist": "^4.6.0",
-                "core-js-compat": "^3.4.7",
+                "@babel/compat-data": "^7.8.0",
+                "@babel/helper-compilation-targets": "^7.8.3",
+                "@babel/helper-module-imports": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+                "@babel/plugin-proposal-dynamic-import": "^7.8.3",
+                "@babel/plugin-proposal-json-strings": "^7.8.3",
+                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-proposal-optional-chaining": "^7.8.3",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+                "@babel/plugin-syntax-async-generators": "^7.8.0",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+                "@babel/plugin-syntax-json-strings": "^7.8.0",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+                "@babel/plugin-syntax-top-level-await": "^7.8.3",
+                "@babel/plugin-transform-arrow-functions": "^7.8.3",
+                "@babel/plugin-transform-async-to-generator": "^7.8.3",
+                "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+                "@babel/plugin-transform-block-scoping": "^7.8.3",
+                "@babel/plugin-transform-classes": "^7.8.3",
+                "@babel/plugin-transform-computed-properties": "^7.8.3",
+                "@babel/plugin-transform-destructuring": "^7.8.3",
+                "@babel/plugin-transform-dotall-regex": "^7.8.3",
+                "@babel/plugin-transform-duplicate-keys": "^7.8.3",
+                "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+                "@babel/plugin-transform-for-of": "^7.8.3",
+                "@babel/plugin-transform-function-name": "^7.8.3",
+                "@babel/plugin-transform-literals": "^7.8.3",
+                "@babel/plugin-transform-member-expression-literals": "^7.8.3",
+                "@babel/plugin-transform-modules-amd": "^7.8.3",
+                "@babel/plugin-transform-modules-commonjs": "^7.8.3",
+                "@babel/plugin-transform-modules-systemjs": "^7.8.3",
+                "@babel/plugin-transform-modules-umd": "^7.8.3",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+                "@babel/plugin-transform-new-target": "^7.8.3",
+                "@babel/plugin-transform-object-super": "^7.8.3",
+                "@babel/plugin-transform-parameters": "^7.8.3",
+                "@babel/plugin-transform-property-literals": "^7.8.3",
+                "@babel/plugin-transform-regenerator": "^7.8.3",
+                "@babel/plugin-transform-reserved-words": "^7.8.3",
+                "@babel/plugin-transform-shorthand-properties": "^7.8.3",
+                "@babel/plugin-transform-spread": "^7.8.3",
+                "@babel/plugin-transform-sticky-regex": "^7.8.3",
+                "@babel/plugin-transform-template-literals": "^7.8.3",
+                "@babel/plugin-transform-typeof-symbol": "^7.8.3",
+                "@babel/plugin-transform-unicode-regex": "^7.8.3",
+                "@babel/types": "^7.8.3",
+                "browserslist": "^4.8.2",
+                "core-js-compat": "^3.6.2",
                 "invariant": "^2.2.2",
-                "js-levenshtein": "^1.1.3",
+                "levenary": "^1.1.0",
                 "semver": "^5.5.0"
             }
         },
         "@babel/preset-react": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.7.4.tgz",
-            "integrity": "sha512-j+vZtg0/8pQr1H8wKoaJyGL2IEk3rG/GIvua7Sec7meXVIvGycihlGMx5xcU00kqCJbwzHs18xTu3YfREOqQ+g==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.8.3.tgz",
+            "integrity": "sha512-9hx0CwZg92jGb7iHYQVgi0tOEHP/kM60CtWJQnmbATSPIQQ2xYzfoCI3EdqAhFBeeJwYMdWQuDUHMsuDbH9hyQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-transform-react-display-name": "^7.7.4",
-                "@babel/plugin-transform-react-jsx": "^7.7.4",
-                "@babel/plugin-transform-react-jsx-self": "^7.7.4",
-                "@babel/plugin-transform-react-jsx-source": "^7.7.4"
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-transform-react-display-name": "^7.8.3",
+                "@babel/plugin-transform-react-jsx": "^7.8.3",
+                "@babel/plugin-transform-react-jsx-self": "^7.8.3",
+                "@babel/plugin-transform-react-jsx-source": "^7.8.3"
             }
         },
         "@babel/runtime": {
-            "version": "7.7.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
-            "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
+            "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
             "requires": {
                 "regenerator-runtime": "^0.13.2"
             }
         },
         "@babel/template": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-            "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+            "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.7.4",
-                "@babel/types": "^7.7.4"
+                "@babel/code-frame": "^7.8.3",
+                "@babel/parser": "^7.8.3",
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/traverse": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-            "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
+            "integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.5.5",
-                "@babel/generator": "^7.7.4",
-                "@babel/helper-function-name": "^7.7.4",
-                "@babel/helper-split-export-declaration": "^7.7.4",
-                "@babel/parser": "^7.7.4",
-                "@babel/types": "^7.7.4",
+                "@babel/code-frame": "^7.8.3",
+                "@babel/generator": "^7.8.3",
+                "@babel/helper-function-name": "^7.8.3",
+                "@babel/helper-split-export-declaration": "^7.8.3",
+                "@babel/parser": "^7.8.3",
+                "@babel/types": "^7.8.3",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
                 "lodash": "^4.17.13"
             }
         },
         "@babel/types": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-            "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+            "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
             "dev": true,
             "requires": {
                 "esutils": "^2.0.2",
@@ -875,220 +945,18 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
-        "@cnakazawa/watch": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
-            "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
-            "dev": true,
-            "requires": {
-                "exec-sh": "^0.3.2",
-                "minimist": "^1.2.0"
-            }
-        },
         "@emotion/hash": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.3.tgz",
-            "integrity": "sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw=="
-        },
-        "@jest/console": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
-            "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
-            "dev": true,
-            "requires": {
-                "@jest/source-map": "^24.9.0",
-                "chalk": "^2.0.1",
-                "slash": "^2.0.0"
-            }
-        },
-        "@jest/core": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
-            "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
-            "dev": true,
-            "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/reporters": "^24.9.0",
-                "@jest/test-result": "^24.9.0",
-                "@jest/transform": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.1",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.1.15",
-                "jest-changed-files": "^24.9.0",
-                "jest-config": "^24.9.0",
-                "jest-haste-map": "^24.9.0",
-                "jest-message-util": "^24.9.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve": "^24.9.0",
-                "jest-resolve-dependencies": "^24.9.0",
-                "jest-runner": "^24.9.0",
-                "jest-runtime": "^24.9.0",
-                "jest-snapshot": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "jest-validate": "^24.9.0",
-                "jest-watcher": "^24.9.0",
-                "micromatch": "^3.1.10",
-                "p-each-series": "^1.0.0",
-                "realpath-native": "^1.1.0",
-                "rimraf": "^2.5.4",
-                "slash": "^2.0.0",
-                "strip-ansi": "^5.0.0"
-            }
-        },
-        "@jest/environment": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
-            "integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
-            "dev": true,
-            "requires": {
-                "@jest/fake-timers": "^24.9.0",
-                "@jest/transform": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "jest-mock": "^24.9.0"
-            }
-        },
-        "@jest/fake-timers": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
-            "integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
-            "dev": true,
-            "requires": {
-                "@jest/types": "^24.9.0",
-                "jest-message-util": "^24.9.0",
-                "jest-mock": "^24.9.0"
-            }
-        },
-        "@jest/reporters": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
-            "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
-            "dev": true,
-            "requires": {
-                "@jest/environment": "^24.9.0",
-                "@jest/test-result": "^24.9.0",
-                "@jest/transform": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "chalk": "^2.0.1",
-                "exit": "^0.1.2",
-                "glob": "^7.1.2",
-                "istanbul-lib-coverage": "^2.0.2",
-                "istanbul-lib-instrument": "^3.0.1",
-                "istanbul-lib-report": "^2.0.4",
-                "istanbul-lib-source-maps": "^3.0.1",
-                "istanbul-reports": "^2.2.6",
-                "jest-haste-map": "^24.9.0",
-                "jest-resolve": "^24.9.0",
-                "jest-runtime": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "jest-worker": "^24.6.0",
-                "node-notifier": "^5.4.2",
-                "slash": "^2.0.0",
-                "source-map": "^0.6.0",
-                "string-length": "^2.0.0"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
-        "@jest/source-map": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
-            "integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
-            "dev": true,
-            "requires": {
-                "callsites": "^3.0.0",
-                "graceful-fs": "^4.1.15",
-                "source-map": "^0.6.0"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
-        "@jest/test-result": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
-            "integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
-            "dev": true,
-            "requires": {
-                "@jest/console": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "@types/istanbul-lib-coverage": "^2.0.0"
-            }
-        },
-        "@jest/test-sequencer": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
-            "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
-            "dev": true,
-            "requires": {
-                "@jest/test-result": "^24.9.0",
-                "jest-haste-map": "^24.9.0",
-                "jest-runner": "^24.9.0",
-                "jest-runtime": "^24.9.0"
-            }
-        },
-        "@jest/transform": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
-            "integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
-            "dev": true,
-            "requires": {
-                "@babel/core": "^7.1.0",
-                "@jest/types": "^24.9.0",
-                "babel-plugin-istanbul": "^5.1.0",
-                "chalk": "^2.0.1",
-                "convert-source-map": "^1.4.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "graceful-fs": "^4.1.15",
-                "jest-haste-map": "^24.9.0",
-                "jest-regex-util": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "micromatch": "^3.1.10",
-                "pirates": "^4.0.1",
-                "realpath-native": "^1.1.0",
-                "slash": "^2.0.0",
-                "source-map": "^0.6.1",
-                "write-file-atomic": "2.4.1"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
-        "@jest/types": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-            "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-            "dev": true,
-            "requires": {
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^1.1.1",
-                "@types/yargs": "^13.0.0"
-            }
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.4.tgz",
+            "integrity": "sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A=="
         },
         "@material-ui/core": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.8.0.tgz",
-            "integrity": "sha512-ODyvWlDOP0D3tU32wVlYRNrdS+LeJxB3xJbXdDxq6gnG4JhKk79+ylP0cImjPBI2yEZw0hcYHWFZOGD+0R1X4g==",
+            "version": "4.8.3",
+            "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.8.3.tgz",
+            "integrity": "sha512-ZJbfJQmkuZCSQTf0nzpfZwizmDdCq8ruZxnPNFnhoKDqgJpMvV8TJRi8vdI9ls1tMuTqxlhyhw8556fxOpWpFQ==",
             "requires": {
                 "@babel/runtime": "^7.4.4",
-                "@material-ui/styles": "^4.7.1",
+                "@material-ui/styles": "^4.8.2",
                 "@material-ui/system": "^4.7.1",
                 "@material-ui/types": "^4.1.1",
                 "@material-ui/utils": "^4.7.1",
@@ -1104,12 +972,12 @@
             }
         },
         "@material-ui/styles": {
-            "version": "4.7.1",
-            "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.7.1.tgz",
-            "integrity": "sha512-BBfxVThaPrglqHmKtSdrZJxnbFGJqKdZ5ZvDarj3HsmkteGCXsP1ohrDi5TWoa5JEJFo9S6q6NywqsENZn9rZA==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.8.2.tgz",
+            "integrity": "sha512-r5U+93pkpwQOmHTmwyn2sqTio6PHd873xvSHiKP6fdybAXXX6CZgVvh3W8saZNbYr/QXsS8OHmFv7sYJLt5Yfg==",
             "requires": {
                 "@babel/runtime": "^7.4.4",
-                "@emotion/hash": "^0.7.1",
+                "@emotion/hash": "^0.7.4",
                 "@material-ui/types": "^4.1.1",
                 "@material-ui/utils": "^4.7.1",
                 "clsx": "^1.0.2",
@@ -1210,72 +1078,6 @@
                 }
             }
         },
-        "@types/babel__core": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
-            "integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
-            "dev": true,
-            "requires": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0",
-                "@types/babel__generator": "*",
-                "@types/babel__template": "*",
-                "@types/babel__traverse": "*"
-            }
-        },
-        "@types/babel__generator": {
-            "version": "7.6.1",
-            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
-            "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "@types/babel__template": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-            "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
-            "dev": true,
-            "requires": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "@types/babel__traverse": {
-            "version": "7.0.8",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.8.tgz",
-            "integrity": "sha512-yGeB2dHEdvxjP0y4UbRtQaSkXJ9649fYCmIdRoul5kfAoGCwxuCbMhag0k3RPfnuh9kPGm8x89btcfDEXdVWGw==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.3.0"
-            }
-        },
-        "@types/istanbul-lib-coverage": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-            "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
-            "dev": true
-        },
-        "@types/istanbul-lib-report": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-            "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
-            "dev": true,
-            "requires": {
-                "@types/istanbul-lib-coverage": "*"
-            }
-        },
-        "@types/istanbul-reports": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-            "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
-            "dev": true,
-            "requires": {
-                "@types/istanbul-lib-coverage": "*",
-                "@types/istanbul-lib-report": "*"
-            }
-        },
         "@types/prop-types": {
             "version": "15.7.3",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -1288,9 +1090,9 @@
             "dev": true
         },
         "@types/react": {
-            "version": "16.9.16",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.16.tgz",
-            "integrity": "sha512-dQ3wlehuBbYlfvRXfF5G+5TbZF3xqgkikK7DWAsQXe2KnzV+kjD4W2ea+ThCrKASZn9h98bjjPzoTYzfRqyBkw==",
+            "version": "16.9.17",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.17.tgz",
+            "integrity": "sha512-UP27In4fp4sWF5JgyV6pwVPAQM83Fj76JOcg02X5BZcpSu5Wx+fP9RMqc2v0ssBoQIFvD5JdKY41gjJJKmw6Bg==",
             "requires": {
                 "@types/prop-types": "*",
                 "csstype": "^2.2.0"
@@ -1303,27 +1105,6 @@
             "requires": {
                 "@types/react": "*"
             }
-        },
-        "@types/stack-utils": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
-            "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
-            "dev": true
-        },
-        "@types/yargs": {
-            "version": "13.0.3",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz",
-            "integrity": "sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==",
-            "dev": true,
-            "requires": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "@types/yargs-parser": {
-            "version": "13.1.0",
-            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
-            "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
-            "dev": true
         },
         "@webassemblyjs/ast": {
             "version": "1.8.5",
@@ -1561,12 +1342,6 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
-        "abab": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-            "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
-            "dev": true
-        },
         "accepts": {
             "version": "1.3.7",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -1583,26 +1358,10 @@
             "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
             "dev": true
         },
-        "acorn-globals": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
-            "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
-            "dev": true,
-            "requires": {
-                "acorn": "^6.0.1",
-                "acorn-walk": "^6.0.1"
-            }
-        },
         "acorn-jsx": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
             "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
-            "dev": true
-        },
-        "acorn-walk": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-            "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
             "dev": true
         },
         "ajv": {
@@ -1778,12 +1537,6 @@
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
             "dev": true
         },
-        "array-equal": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-            "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-            "dev": true
-        },
         "array-find-index": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -1791,13 +1544,14 @@
             "dev": true
         },
         "array-includes": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.0.tgz",
-            "integrity": "sha512-ONOEQoKrvXPKk7Su92Co0YMqYO32FfqJTzkKU9u2UpIXyYZIzLSvpdg4AwvSw4mSUW0czu6inK+zby6Oj6gDjQ==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
+            "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
             "dev": true,
             "requires": {
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.0-next.0"
+                "es-abstract": "^1.17.0",
+                "is-string": "^1.0.5"
             }
         },
         "array-unique": {
@@ -1821,15 +1575,6 @@
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
             "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
             "dev": true
-        },
-        "asn1": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-            "dev": true,
-            "requires": {
-                "safer-buffer": "~2.1.0"
-            }
         },
         "asn1.js": {
             "version": "4.10.1",
@@ -1868,18 +1613,6 @@
                     }
                 }
             }
-        },
-        "assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-            "dev": true
-        },
-        "assertion-error": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-            "dev": true
         },
         "assign-symbols": {
             "version": "1.0.0",
@@ -1920,57 +1653,24 @@
             "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
             "dev": true
         },
-        "asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-            "dev": true
-        },
         "atob": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
         },
-        "aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-            "dev": true
-        },
-        "aws4": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
-            "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
-            "dev": true
-        },
         "babel-eslint": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
-            "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+            "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
                 "@babel/parser": "^7.0.0",
                 "@babel/traverse": "^7.0.0",
                 "@babel/types": "^7.0.0",
-                "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "^1.0.0"
-            }
-        },
-        "babel-jest": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
-            "integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
-            "dev": true,
-            "requires": {
-                "@jest/transform": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "@types/babel__core": "^7.1.0",
-                "babel-plugin-istanbul": "^5.1.0",
-                "babel-preset-jest": "^24.9.0",
-                "chalk": "^2.4.2",
-                "slash": "^2.0.0"
+                "eslint-visitor-keys": "^1.0.0",
+                "resolve": "^1.12.0"
             }
         },
         "babel-loader": {
@@ -1992,37 +1692,6 @@
             "dev": true,
             "requires": {
                 "object.assign": "^4.1.0"
-            }
-        },
-        "babel-plugin-istanbul": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
-            "integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "find-up": "^3.0.0",
-                "istanbul-lib-instrument": "^3.3.0",
-                "test-exclude": "^5.2.3"
-            }
-        },
-        "babel-plugin-jest-hoist": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
-            "integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
-            "dev": true,
-            "requires": {
-                "@types/babel__traverse": "^7.0.6"
-            }
-        },
-        "babel-preset-jest": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
-            "integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
-            "dev": true,
-            "requires": {
-                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-                "babel-plugin-jest-hoist": "^24.9.0"
             }
         },
         "babel-runtime": {
@@ -2115,15 +1784,6 @@
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
             "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
             "dev": true
-        },
-        "bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-            "dev": true,
-            "requires": {
-                "tweetnacl": "^0.14.3"
-            }
         },
         "big.js": {
             "version": "5.2.2",
@@ -2258,29 +1918,6 @@
             "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
             "dev": true
         },
-        "browser-process-hrtime": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
-            "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
-            "dev": true
-        },
-        "browser-resolve": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-            "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-            "dev": true,
-            "requires": {
-                "resolve": "1.1.7"
-            },
-            "dependencies": {
-                "resolve": {
-                    "version": "1.1.7",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-                    "dev": true
-                }
-            }
-        },
         "browserify-aes": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -2353,23 +1990,14 @@
             }
         },
         "browserslist": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-            "integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+            "version": "4.8.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.3.tgz",
+            "integrity": "sha512-iU43cMMknxG1ClEZ2MDKeonKE1CCrFVkQK2AqO2YWFmvIrx4JWrvQ4w4hQez6EpVI8rHTtqh/ruHHDHSOKxvUg==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001015",
+                "caniuse-lite": "^1.0.30001017",
                 "electron-to-chromium": "^1.3.322",
-                "node-releases": "^1.1.42"
-            }
-        },
-        "bser": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-            "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
-            "dev": true,
-            "requires": {
-                "node-int64": "^0.4.0"
+                "node-releases": "^1.1.44"
             }
         },
         "buffer": {
@@ -2529,45 +2157,16 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001016",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-            "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
+            "version": "1.0.30001021",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001021.tgz",
+            "integrity": "sha512-wuMhT7/hwkgd8gldgp2jcrUjOU9RXJ4XxGumQeOsUr91l3WwmM68Cpa/ymCnWEDqakwFXhuDQbaKNHXBPgeE9g==",
             "dev": true
-        },
-        "capture-exit": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
-            "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
-            "dev": true,
-            "requires": {
-                "rsvp": "^4.8.4"
-            }
         },
         "capture-stack-trace": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
             "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
             "dev": true
-        },
-        "caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-            "dev": true
-        },
-        "chai": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-            "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-            "dev": true,
-            "requires": {
-                "assertion-error": "^1.1.0",
-                "check-error": "^1.0.2",
-                "deep-eql": "^3.0.1",
-                "get-func-name": "^2.0.0",
-                "pathval": "^1.1.0",
-                "type-detect": "^4.0.5"
-            }
         },
         "chalk": {
             "version": "2.4.2",
@@ -2584,12 +2183,6 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
             "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-            "dev": true
-        },
-        "check-error": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-            "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
             "dev": true
         },
         "chokidar": {
@@ -2628,9 +2221,9 @@
             }
         },
         "ci-info": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+            "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
             "dev": true
         },
         "cipher-base": {
@@ -2825,15 +2418,6 @@
                 "simple-swizzle": "^0.2.2"
             }
         },
-        "combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
-            "requires": {
-                "delayed-stream": "~1.0.0"
-            }
-        },
         "commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -2876,9 +2460,9 @@
                     "dev": true
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -3038,19 +2622,19 @@
             "dev": true
         },
         "core-js-compat": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.5.0.tgz",
-            "integrity": "sha512-E7iJB72svRjJTnm9HDvujzNVMCm3ZcDYEedkJ/sDTNsy/0yooCd9Cg7GSzE7b4e0LfIkjijdB1tqg0pGwxWeWg==",
+            "version": "3.6.4",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
+            "integrity": "sha512-zAa3IZPvsJ0slViBQ2z+vgyyTuhd3MFn1rBQjZSKVEgB0UMYhUkCj9jJUVPgGTGqWvsBVmfnruXgTcNyTlEiSA==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.8.2",
-                "semver": "^6.3.0"
+                "browserslist": "^4.8.3",
+                "semver": "7.0.0"
             },
             "dependencies": {
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+                    "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
                     "dev": true
                 }
             }
@@ -3369,21 +2953,6 @@
                 "css-tree": "1.0.0-alpha.37"
             }
         },
-        "cssom": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-            "dev": true
-        },
-        "cssstyle": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
-            "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
-            "dev": true,
-            "requires": {
-                "cssom": "0.3.x"
-            }
-        },
         "csstype": {
             "version": "2.6.8",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
@@ -3415,9 +2984,9 @@
             }
         },
         "d3": {
-            "version": "5.14.2",
-            "resolved": "https://registry.npmjs.org/d3/-/d3-5.14.2.tgz",
-            "integrity": "sha512-Ccipa9XrYW5N0QkP6u0Qb8kU6WekIXBiDenmZm1zLvuq/9pBBhRCJLCICEOsH5Og4B0Xw02bhqGkK5VN/oPH0w==",
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-5.15.0.tgz",
+            "integrity": "sha512-C+E80SL2nLLtmykZ6klwYj5rPqB5nlfN5LdWEAVdWPppqTD8taoJi2PxLZjPeYT8FFRR2yucXq+kBlOnnvZeLg==",
             "requires": {
                 "d3-array": "1",
                 "d3-axis": "1",
@@ -3550,9 +3119,9 @@
             }
         },
         "d3-format": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.2.tgz",
-            "integrity": "sha512-gco1Ih54PgMsyIXgttLxEhNy/mXxq8+rLnCb5shQk+P5TsiySrwWU5gpB4zen626J4LIwBxHvDChyA8qDm57ww=="
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.3.tgz",
+            "integrity": "sha512-mm/nE2Y9HgGyjP+rKIekeITVgBtX97o1nrvHCWX8F/yBYyevUTvu9vb5pUnKwrcSw7o7GuwMOWjS9gFDs4O+uQ=="
         },
         "d3-geo": {
             "version": "1.11.9",
@@ -3636,9 +3205,9 @@
             "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
         },
         "d3-time-format": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.2.tgz",
-            "integrity": "sha512-pweL2Ri2wqMY+wlW/wpkl8T3CUzKAha8S9nmiQlMABab8r5MJN0PD1V4YyRNVaKQfeh4Z0+VO70TLw6ESVOYzw==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.3.tgz",
+            "integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
             "requires": {
                 "d3-time": "1"
             }
@@ -3676,39 +3245,6 @@
                 "d3-interpolate": "1",
                 "d3-selection": "1",
                 "d3-transition": "1"
-            }
-        },
-        "dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
-        },
-        "data-urls": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
-            "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
-            "dev": true,
-            "requires": {
-                "abab": "^2.0.0",
-                "whatwg-mimetype": "^2.2.0",
-                "whatwg-url": "^7.0.0"
-            },
-            "dependencies": {
-                "whatwg-url": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-                    "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-                    "dev": true,
-                    "requires": {
-                        "lodash.sortby": "^4.7.0",
-                        "tr46": "^1.0.1",
-                        "webidl-conversions": "^4.0.2"
-                    }
-                }
             }
         },
         "debug": {
@@ -3749,15 +3285,6 @@
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
-        },
-        "deep-eql": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-            "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-            "dev": true,
-            "requires": {
-                "type-detect": "^4.0.0"
-            }
         },
         "deep-equal": {
             "version": "1.0.1",
@@ -3827,12 +3354,6 @@
                 }
             }
         },
-        "delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-            "dev": true
-        },
         "delegates": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -3865,18 +3386,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
             "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
-            "dev": true
-        },
-        "detect-newline": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-            "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
-            "dev": true
-        },
-        "diff-sequences": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
-            "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
             "dev": true
         },
         "diffie-hellman": {
@@ -3938,15 +3447,6 @@
             "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
             "dev": true
         },
-        "domexception": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-            "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-            "dev": true,
-            "requires": {
-                "webidl-conversions": "^4.0.2"
-            }
-        },
         "domutils": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
@@ -3991,9 +3491,9 @@
                     "dev": true
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -4016,16 +3516,6 @@
                 }
             }
         },
-        "ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-            "dev": true,
-            "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
-        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -4033,9 +3523,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.322",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
-            "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==",
+            "version": "1.3.335",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.335.tgz",
+            "integrity": "sha512-ngKsDGd/xr2lAZvilxTfdvfEiQKmavyXd6irlswaHnewmXoz6JgbM9FUNwgp3NFIUHHegh1F87H8f5BJ8zABxw==",
             "dev": true
         },
         "elliptic": {
@@ -4108,9 +3598,9 @@
                     }
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -4164,22 +3654,22 @@
             "dev": true
         },
         "es-abstract": {
-            "version": "1.17.0-next.1",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
-            "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+            "version": "1.17.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.2.tgz",
+            "integrity": "sha512-YoKuru3Lyoy7yVTBSH2j7UxTqe/je3dWAruC0sHvZX1GNd5zX8SSLvQqEgO9b3Ex8IW+goFI9arEEsFIbulhOw==",
             "dev": true,
             "requires": {
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.1",
-                "is-callable": "^1.1.4",
-                "is-regex": "^1.0.4",
+                "is-callable": "^1.1.5",
+                "is-regex": "^1.0.5",
                 "object-inspect": "^1.7.0",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.0",
-                "string.prototype.trimleft": "^2.1.0",
-                "string.prototype.trimright": "^2.1.0"
+                "string.prototype.trimleft": "^2.1.1",
+                "string.prototype.trimright": "^2.1.1"
             }
         },
         "es-to-primitive": {
@@ -4237,34 +3727,6 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
-        "escodegen": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
-            "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
-            "dev": true,
-            "requires": {
-                "esprima": "^3.1.3",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
-            },
-            "dependencies": {
-                "esprima": {
-                    "version": "3.1.3",
-                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true,
-                    "optional": true
-                }
-            }
-        },
         "eslint": {
             "version": "5.16.0",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
@@ -4315,16 +3777,6 @@
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
                 },
-                "eslint-scope": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-                    "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-                    "dev": true,
-                    "requires": {
-                        "esrecurse": "^4.1.0",
-                        "estraverse": "^4.1.1"
-                    }
-                },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -4346,13 +3798,13 @@
             }
         },
         "eslint-import-resolver-node": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-            "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
+            "integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
             "dev": true,
             "requires": {
                 "debug": "^2.6.9",
-                "resolve": "^1.5.0"
+                "resolve": "^1.13.1"
             },
             "dependencies": {
                 "debug": {
@@ -4373,9 +3825,9 @@
             }
         },
         "eslint-module-utils": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.0.tgz",
-            "integrity": "sha512-kCo8pZaNz2dsAW7nCUjuVoI11EBXXpIzfNxmaoLhXoRDOnqXLC4iSGVRdZPhOitfbdEfMEfKOiENaK6wDPZEGw==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
+            "integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
             "dev": true,
             "requires": {
                 "debug": "^2.6.9",
@@ -4451,16 +3903,10 @@
                 }
             }
         },
-        "eslint-plugin-eslint-plugin": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-2.1.0.tgz",
-            "integrity": "sha512-kT3A/ZJftt28gbl/Cv04qezb/NQ1dwYIbi8lyf806XMxkus7DvOVCLIfTXMrorp322Pnoez7+zabXH29tADIDg==",
-            "dev": true
-        },
         "eslint-plugin-import": {
-            "version": "2.19.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.19.1.tgz",
-            "integrity": "sha512-x68131aKoCZlCae7rDXKSAQmbT5DQuManyXo2sK6fJJ0aK5CWAkv6A6HJZGgqC8IhjQxYPgo6/IY4Oz8AFsbBw==",
+            "version": "2.20.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.0.tgz",
+            "integrity": "sha512-NK42oA0mUc8Ngn4kONOPsPB1XhbUvNHqF+g307dPV28aknPoiNnKLFd9em4nkswwepdF5ouieqv5Th/63U7YJQ==",
             "dev": true,
             "requires": {
                 "array-includes": "^3.0.3",
@@ -4511,21 +3957,20 @@
             }
         },
         "eslint-plugin-react": {
-            "version": "7.17.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.17.0.tgz",
-            "integrity": "sha512-ODB7yg6lxhBVMeiH1c7E95FLD4E/TwmFjltiU+ethv7KPdCwgiFuOZg9zNRHyufStTDLl/dEFqI2Q1VPmCd78A==",
+            "version": "7.18.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.18.0.tgz",
+            "integrity": "sha512-p+PGoGeV4SaZRDsXqdj9OWcOrOpZn8gXoGPcIQTzo2IDMbAKhNDnME9myZWqO3Ic4R3YmwAZ1lDjWl2R2hMUVQ==",
             "dev": true,
             "requires": {
-                "array-includes": "^3.0.3",
+                "array-includes": "^3.1.1",
                 "doctrine": "^2.1.0",
-                "eslint-plugin-eslint-plugin": "^2.1.0",
                 "has": "^1.0.3",
                 "jsx-ast-utils": "^2.2.3",
-                "object.entries": "^1.1.0",
-                "object.fromentries": "^2.0.1",
-                "object.values": "^1.1.0",
+                "object.entries": "^1.1.1",
+                "object.fromentries": "^2.0.2",
+                "object.values": "^1.1.1",
                 "prop-types": "^15.7.2",
-                "resolve": "^1.13.1"
+                "resolve": "^1.14.2"
             },
             "dependencies": {
                 "doctrine": {
@@ -4540,9 +3985,9 @@
             }
         },
         "eslint-scope": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-            "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+            "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
             "dev": true,
             "requires": {
                 "esrecurse": "^4.1.0",
@@ -4612,9 +4057,9 @@
             "dev": true
         },
         "events": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-            "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+            "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
             "dev": true
         },
         "evp_bytestokey": {
@@ -4626,12 +4071,6 @@
                 "md5.js": "^1.3.4",
                 "safe-buffer": "^5.1.1"
             }
-        },
-        "exec-sh": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
-            "integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
-            "dev": true
         },
         "execa": {
             "version": "1.0.0",
@@ -4647,12 +4086,6 @@
                 "signal-exit": "^3.0.0",
                 "strip-eof": "^1.0.0"
             }
-        },
-        "exit": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-            "dev": true
         },
         "expand-brackets": {
             "version": "2.1.4",
@@ -4713,20 +4146,6 @@
                 "homedir-polyfill": "^1.0.1"
             }
         },
-        "expect": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
-            "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
-            "dev": true,
-            "requires": {
-                "@jest/types": "^24.9.0",
-                "ansi-styles": "^3.2.0",
-                "jest-get-type": "^24.9.0",
-                "jest-matcher-utils": "^24.9.0",
-                "jest-message-util": "^24.9.0",
-                "jest-regex-util": "^24.9.0"
-            }
-        },
         "ext": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
@@ -4743,12 +4162,6 @@
                     "dev": true
                 }
             }
-        },
-        "extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "dev": true
         },
         "extend-shallow": {
             "version": "3.0.2",
@@ -4847,12 +4260,6 @@
                 }
             }
         },
-        "extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-            "dev": true
-        },
         "fast-deep-equal": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
@@ -4869,15 +4276,6 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
-        },
-        "fb-watchman": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
-            "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
-            "dev": true,
-            "requires": {
-                "bser": "2.1.1"
-            }
         },
         "figgy-pudding": {
             "version": "3.5.1",
@@ -4999,9 +4397,9 @@
                     "dev": true
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -5029,23 +4427,6 @@
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
-        },
-        "forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-            "dev": true
-        },
-        "form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-            "dev": true,
-            "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-            }
         },
         "fragment-cache": {
             "version": "0.2.1",
@@ -5079,9 +4460,9 @@
                     "dev": true
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -5692,16 +5073,16 @@
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
+        "gensync": {
+            "version": "1.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+            "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+            "dev": true
+        },
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true
-        },
-        "get-func-name": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
             "dev": true
         },
         "get-port": {
@@ -5730,15 +5111,6 @@
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
             "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
             "dev": true
-        },
-        "getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
         },
         "glob": {
             "version": "7.1.6",
@@ -5857,48 +5229,6 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
             "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
             "dev": true
-        },
-        "growly": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-            "dev": true
-        },
-        "handlebars": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-            "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
-            "dev": true,
-            "requires": {
-                "neo-async": "^2.6.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
-        "har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-            "dev": true
-        },
-        "har-validator": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-            "dev": true,
-            "requires": {
-                "ajv": "^6.5.5",
-                "har-schema": "^2.0.0"
-            }
         },
         "has": {
             "version": "1.0.3",
@@ -6031,15 +5361,6 @@
             "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
             "dev": true
         },
-        "html-encoding-sniffer": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-            "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-            "dev": true,
-            "requires": {
-                "whatwg-encoding": "^1.0.1"
-            }
-        },
         "http-assert": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.4.1.tgz",
@@ -6061,17 +5382,6 @@
                 "setprototypeof": "1.1.1",
                 "statuses": ">= 1.5.0 < 2",
                 "toidentifier": "1.0.0"
-            }
-        },
-        "http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
             }
         },
         "https-browserify": {
@@ -6317,18 +5627,18 @@
             "dev": true
         },
         "is-callable": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+            "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
             "dev": true
         },
         "is-ci": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+            "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
             "dev": true,
             "requires": {
-                "ci-info": "^2.0.0"
+                "ci-info": "^1.5.0"
             }
         },
         "is-color-stop": {
@@ -6366,9 +5676,9 @@
             }
         },
         "is-date-object": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+            "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
             "dev": true
         },
         "is-descriptor": {
@@ -6412,12 +5722,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
             "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-            "dev": true
-        },
-        "is-generator-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-            "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
             "dev": true
         },
         "is-generator-function": {
@@ -6545,6 +5849,12 @@
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
             "dev": true
         },
+        "is-string": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+            "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+            "dev": true
+        },
         "is-svg": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
@@ -6562,12 +5872,6 @@
             "requires": {
                 "has-symbols": "^1.0.1"
             }
-        },
-        "is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-            "dev": true
         },
         "is-windows": {
             "version": "1.0.2",
@@ -6599,533 +5903,6 @@
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
             "dev": true
         },
-        "isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-            "dev": true
-        },
-        "istanbul-lib-coverage": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-            "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
-            "dev": true
-        },
-        "istanbul-lib-instrument": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
-            "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
-            "dev": true,
-            "requires": {
-                "@babel/generator": "^7.4.0",
-                "@babel/parser": "^7.4.3",
-                "@babel/template": "^7.4.0",
-                "@babel/traverse": "^7.4.3",
-                "@babel/types": "^7.4.0",
-                "istanbul-lib-coverage": "^2.0.5",
-                "semver": "^6.0.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
-            }
-        },
-        "istanbul-lib-report": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-            "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
-            "dev": true,
-            "requires": {
-                "istanbul-lib-coverage": "^2.0.5",
-                "make-dir": "^2.1.0",
-                "supports-color": "^6.1.0"
-            },
-            "dependencies": {
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
-        "istanbul-lib-source-maps": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-            "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
-            "dev": true,
-            "requires": {
-                "debug": "^4.1.1",
-                "istanbul-lib-coverage": "^2.0.5",
-                "make-dir": "^2.1.0",
-                "rimraf": "^2.6.3",
-                "source-map": "^0.6.1"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
-        "istanbul-reports": {
-            "version": "2.2.6",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-            "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
-            "dev": true,
-            "requires": {
-                "handlebars": "^4.1.2"
-            }
-        },
-        "jest": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
-            "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
-            "dev": true,
-            "requires": {
-                "import-local": "^2.0.0",
-                "jest-cli": "^24.9.0"
-            },
-            "dependencies": {
-                "jest-cli": {
-                    "version": "24.9.0",
-                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
-                    "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
-                    "dev": true,
-                    "requires": {
-                        "@jest/core": "^24.9.0",
-                        "@jest/test-result": "^24.9.0",
-                        "@jest/types": "^24.9.0",
-                        "chalk": "^2.0.1",
-                        "exit": "^0.1.2",
-                        "import-local": "^2.0.0",
-                        "is-ci": "^2.0.0",
-                        "jest-config": "^24.9.0",
-                        "jest-util": "^24.9.0",
-                        "jest-validate": "^24.9.0",
-                        "prompts": "^2.0.1",
-                        "realpath-native": "^1.1.0",
-                        "yargs": "^13.3.0"
-                    }
-                }
-            }
-        },
-        "jest-changed-files": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
-            "integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
-            "dev": true,
-            "requires": {
-                "@jest/types": "^24.9.0",
-                "execa": "^1.0.0",
-                "throat": "^4.0.0"
-            }
-        },
-        "jest-config": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
-            "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
-            "dev": true,
-            "requires": {
-                "@babel/core": "^7.1.0",
-                "@jest/test-sequencer": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "babel-jest": "^24.9.0",
-                "chalk": "^2.0.1",
-                "glob": "^7.1.1",
-                "jest-environment-jsdom": "^24.9.0",
-                "jest-environment-node": "^24.9.0",
-                "jest-get-type": "^24.9.0",
-                "jest-jasmine2": "^24.9.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "jest-validate": "^24.9.0",
-                "micromatch": "^3.1.10",
-                "pretty-format": "^24.9.0",
-                "realpath-native": "^1.1.0"
-            }
-        },
-        "jest-diff": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
-            "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
-            "dev": true,
-            "requires": {
-                "chalk": "^2.0.1",
-                "diff-sequences": "^24.9.0",
-                "jest-get-type": "^24.9.0",
-                "pretty-format": "^24.9.0"
-            }
-        },
-        "jest-docblock": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
-            "integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
-            "dev": true,
-            "requires": {
-                "detect-newline": "^2.1.0"
-            }
-        },
-        "jest-each": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
-            "integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
-            "dev": true,
-            "requires": {
-                "@jest/types": "^24.9.0",
-                "chalk": "^2.0.1",
-                "jest-get-type": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "pretty-format": "^24.9.0"
-            }
-        },
-        "jest-environment-jsdom": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
-            "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
-            "dev": true,
-            "requires": {
-                "@jest/environment": "^24.9.0",
-                "@jest/fake-timers": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "jest-mock": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "jsdom": "^11.5.1"
-            }
-        },
-        "jest-environment-node": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
-            "integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
-            "dev": true,
-            "requires": {
-                "@jest/environment": "^24.9.0",
-                "@jest/fake-timers": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "jest-mock": "^24.9.0",
-                "jest-util": "^24.9.0"
-            }
-        },
-        "jest-get-type": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
-            "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
-            "dev": true
-        },
-        "jest-haste-map": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
-            "integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
-            "dev": true,
-            "requires": {
-                "@jest/types": "^24.9.0",
-                "anymatch": "^2.0.0",
-                "fb-watchman": "^2.0.0",
-                "fsevents": "^1.2.7",
-                "graceful-fs": "^4.1.15",
-                "invariant": "^2.2.4",
-                "jest-serializer": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "jest-worker": "^24.9.0",
-                "micromatch": "^3.1.10",
-                "sane": "^4.0.3",
-                "walker": "^1.0.7"
-            }
-        },
-        "jest-jasmine2": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
-            "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
-            "dev": true,
-            "requires": {
-                "@babel/traverse": "^7.1.0",
-                "@jest/environment": "^24.9.0",
-                "@jest/test-result": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "chalk": "^2.0.1",
-                "co": "^4.6.0",
-                "expect": "^24.9.0",
-                "is-generator-fn": "^2.0.0",
-                "jest-each": "^24.9.0",
-                "jest-matcher-utils": "^24.9.0",
-                "jest-message-util": "^24.9.0",
-                "jest-runtime": "^24.9.0",
-                "jest-snapshot": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "pretty-format": "^24.9.0",
-                "throat": "^4.0.0"
-            }
-        },
-        "jest-leak-detector": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
-            "integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
-            "dev": true,
-            "requires": {
-                "jest-get-type": "^24.9.0",
-                "pretty-format": "^24.9.0"
-            }
-        },
-        "jest-matcher-utils": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
-            "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
-            "dev": true,
-            "requires": {
-                "chalk": "^2.0.1",
-                "jest-diff": "^24.9.0",
-                "jest-get-type": "^24.9.0",
-                "pretty-format": "^24.9.0"
-            }
-        },
-        "jest-message-util": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
-            "integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@jest/test-result": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "@types/stack-utils": "^1.0.1",
-                "chalk": "^2.0.1",
-                "micromatch": "^3.1.10",
-                "slash": "^2.0.0",
-                "stack-utils": "^1.0.1"
-            }
-        },
-        "jest-mock": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
-            "integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
-            "dev": true,
-            "requires": {
-                "@jest/types": "^24.9.0"
-            }
-        },
-        "jest-pnp-resolver": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
-            "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
-            "dev": true
-        },
-        "jest-regex-util": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
-            "integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
-            "dev": true
-        },
-        "jest-resolve": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
-            "integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
-            "dev": true,
-            "requires": {
-                "@jest/types": "^24.9.0",
-                "browser-resolve": "^1.11.3",
-                "chalk": "^2.0.1",
-                "jest-pnp-resolver": "^1.2.1",
-                "realpath-native": "^1.1.0"
-            }
-        },
-        "jest-resolve-dependencies": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
-            "integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
-            "dev": true,
-            "requires": {
-                "@jest/types": "^24.9.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-snapshot": "^24.9.0"
-            }
-        },
-        "jest-runner": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
-            "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
-            "dev": true,
-            "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/environment": "^24.9.0",
-                "@jest/test-result": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "chalk": "^2.4.2",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.1.15",
-                "jest-config": "^24.9.0",
-                "jest-docblock": "^24.3.0",
-                "jest-haste-map": "^24.9.0",
-                "jest-jasmine2": "^24.9.0",
-                "jest-leak-detector": "^24.9.0",
-                "jest-message-util": "^24.9.0",
-                "jest-resolve": "^24.9.0",
-                "jest-runtime": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "jest-worker": "^24.6.0",
-                "source-map-support": "^0.5.6",
-                "throat": "^4.0.0"
-            }
-        },
-        "jest-runtime": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
-            "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
-            "dev": true,
-            "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/environment": "^24.9.0",
-                "@jest/source-map": "^24.3.0",
-                "@jest/transform": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "@types/yargs": "^13.0.0",
-                "chalk": "^2.0.1",
-                "exit": "^0.1.2",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.1.15",
-                "jest-config": "^24.9.0",
-                "jest-haste-map": "^24.9.0",
-                "jest-message-util": "^24.9.0",
-                "jest-mock": "^24.9.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve": "^24.9.0",
-                "jest-snapshot": "^24.9.0",
-                "jest-util": "^24.9.0",
-                "jest-validate": "^24.9.0",
-                "realpath-native": "^1.1.0",
-                "slash": "^2.0.0",
-                "strip-bom": "^3.0.0",
-                "yargs": "^13.3.0"
-            }
-        },
-        "jest-serializer": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
-            "integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
-            "dev": true
-        },
-        "jest-snapshot": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
-            "integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.0.0",
-                "@jest/types": "^24.9.0",
-                "chalk": "^2.0.1",
-                "expect": "^24.9.0",
-                "jest-diff": "^24.9.0",
-                "jest-get-type": "^24.9.0",
-                "jest-matcher-utils": "^24.9.0",
-                "jest-message-util": "^24.9.0",
-                "jest-resolve": "^24.9.0",
-                "mkdirp": "^0.5.1",
-                "natural-compare": "^1.4.0",
-                "pretty-format": "^24.9.0",
-                "semver": "^6.2.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
-            }
-        },
-        "jest-util": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
-            "integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
-            "dev": true,
-            "requires": {
-                "@jest/console": "^24.9.0",
-                "@jest/fake-timers": "^24.9.0",
-                "@jest/source-map": "^24.9.0",
-                "@jest/test-result": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "callsites": "^3.0.0",
-                "chalk": "^2.0.1",
-                "graceful-fs": "^4.1.15",
-                "is-ci": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "slash": "^2.0.0",
-                "source-map": "^0.6.0"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
-        "jest-validate": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
-            "integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
-            "dev": true,
-            "requires": {
-                "@jest/types": "^24.9.0",
-                "camelcase": "^5.3.1",
-                "chalk": "^2.0.1",
-                "jest-get-type": "^24.9.0",
-                "leven": "^3.1.0",
-                "pretty-format": "^24.9.0"
-            }
-        },
-        "jest-watcher": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
-            "integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
-            "dev": true,
-            "requires": {
-                "@jest/test-result": "^24.9.0",
-                "@jest/types": "^24.9.0",
-                "@types/yargs": "^13.0.0",
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.1",
-                "jest-util": "^24.9.0",
-                "string-length": "^2.0.0"
-            }
-        },
-        "jest-worker": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-            "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
-            "dev": true,
-            "requires": {
-                "merge-stream": "^2.0.0",
-                "supports-color": "^6.1.0"
-            },
-            "dependencies": {
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
-        "js-levenshtein": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-            "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
-            "dev": true
-        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7141,54 +5918,6 @@
                 "esprima": "^4.0.0"
             }
         },
-        "jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "dev": true
-        },
-        "jsdom": {
-            "version": "11.12.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
-            "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
-            "dev": true,
-            "requires": {
-                "abab": "^2.0.0",
-                "acorn": "^5.5.3",
-                "acorn-globals": "^4.1.0",
-                "array-equal": "^1.0.0",
-                "cssom": ">= 0.3.2 < 0.4.0",
-                "cssstyle": "^1.0.0",
-                "data-urls": "^1.0.0",
-                "domexception": "^1.0.1",
-                "escodegen": "^1.9.1",
-                "html-encoding-sniffer": "^1.0.2",
-                "left-pad": "^1.3.0",
-                "nwsapi": "^2.0.7",
-                "parse5": "4.0.0",
-                "pn": "^1.1.0",
-                "request": "^2.87.0",
-                "request-promise-native": "^1.0.5",
-                "sax": "^1.2.4",
-                "symbol-tree": "^3.2.2",
-                "tough-cookie": "^2.3.4",
-                "w3c-hr-time": "^1.0.1",
-                "webidl-conversions": "^4.0.2",
-                "whatwg-encoding": "^1.0.3",
-                "whatwg-mimetype": "^2.1.0",
-                "whatwg-url": "^6.4.1",
-                "ws": "^5.2.0",
-                "xml-name-validator": "^3.0.0"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "5.7.3",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-                    "dev": true
-                }
-            }
-        },
         "jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -7199,12 +5928,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-            "dev": true
-        },
-        "json-schema": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
             "dev": true
         },
         "json-schema-traverse": {
@@ -7234,22 +5957,10 @@
                 "minimist": "^1.2.0"
             }
         },
-        "jsprim": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-            }
-        },
         "jss": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0.tgz",
-            "integrity": "sha512-TPpDFsiBjuERiL+dFDq8QCdiF9oDasPcNqCKLGCo/qED3fNYOQ8PX2lZhknyTiAt3tZrfOFbb0lbQ9lTjPZxsQ==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.3.tgz",
+            "integrity": "sha512-AcDvFdOk16If9qvC9KN3oFXsrkHWM9+TaPMpVB9orm3z+nq1Xw3ofHyflRe/mkSucRZnaQtlhZs1hdP3DR9uRw==",
             "requires": {
                 "@babel/runtime": "^7.3.1",
                 "csstype": "^2.6.5",
@@ -7258,81 +5969,69 @@
             }
         },
         "jss-plugin-camel-case": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0.tgz",
-            "integrity": "sha512-yALDL00+pPR4FJh+k07A8FeDvfoPPuXU48HLy63enAubcVd3DnS+2rgqPXglHDGixIDVkCSXecl/l5GAMjzIbA==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.3.tgz",
+            "integrity": "sha512-rild/oFKFkmRP7AoiX9D6bdDAUfmJv8c7sEBvFoi+JP31dn2W8nw4txMKGnV1LJKlFkYprdZt1X99Uvztl1hug==",
             "requires": {
                 "@babel/runtime": "^7.3.1",
                 "hyphenate-style-name": "^1.0.3",
-                "jss": "10.0.0"
+                "jss": "^10.0.3"
             }
         },
         "jss-plugin-default-unit": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0.tgz",
-            "integrity": "sha512-sURozIOdCtGg9ap18erQ+ijndAfEGtTaetxfU3H4qwC18Bi+fdvjlY/ahKbuu0ASs7R/+WKCP7UaRZOjUDMcdQ==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.3.tgz",
+            "integrity": "sha512-n+XfVLPF9Qh7IOTdQ8M4oRpjpg6egjr/r0NNytubbCafMgCILJYIVrMTGgOTydH+uvak8onQY3f/F9hasPUx6g==",
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "jss": "10.0.0"
+                "jss": "^10.0.3"
             }
         },
         "jss-plugin-global": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.0.0.tgz",
-            "integrity": "sha512-80ofWKSQUo62bxLtRoTNe0kFPtHgUbAJeOeR36WEGgWIBEsXLyXOnD5KNnjPqG4heuEkz9eSLccjYST50JnI7Q==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.0.3.tgz",
+            "integrity": "sha512-kNotkAciJIXpIGYnmueaIifBne9rdq31O8Xq1nF7KMfKlskNRANTcEX5rVnsGKl2yubTMYfjKBFCeDgcQn6+gA==",
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "jss": "10.0.0"
+                "jss": "^10.0.3"
             }
         },
         "jss-plugin-nested": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.0.0.tgz",
-            "integrity": "sha512-waxxwl/po1hN3azTyixKnr8ReEqUv5WK7WsO+5AWB0bFndML5Yqnt8ARZ90HEg8/P6WlqE/AB2413TkCRZE8bA==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.0.3.tgz",
+            "integrity": "sha512-OMucRs9YLvWlZ3Ew+VhdgNVMwSS2zZy/2vy+s/etvopnPUzDHgCnJwdY2Wx/SlhLGERJeKKufyih2seH+ui0iw==",
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "jss": "10.0.0",
+                "jss": "^10.0.3",
                 "tiny-warning": "^1.0.2"
             }
         },
         "jss-plugin-props-sort": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0.tgz",
-            "integrity": "sha512-41mf22CImjwNdtOG3r+cdC8+RhwNm616sjHx5YlqTwtSJLyLFinbQC/a4PIFk8xqf1qpFH1kEAIw+yx9HaqZ3g==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.3.tgz",
+            "integrity": "sha512-ufhvdCMnRcDa0tNHoZ12OcVNQQyE10yLMohxo/UIMarLV245rM6n9D19A12epjldRgyiS13SoSyLFCJEobprYg==",
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "jss": "10.0.0"
+                "jss": "^10.0.3"
             }
         },
         "jss-plugin-rule-value-function": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0.tgz",
-            "integrity": "sha512-Jw+BZ8JIw1f12V0SERqGlBT1JEPWax3vuZpMym54NAXpPb7R1LYHiCTIlaJUyqvIfEy3kiHMtgI+r2whGgRIxQ==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.3.tgz",
+            "integrity": "sha512-RWwIT2UBAIwf3f6DQtt5gyjxHMRJoeO9TQku+ueR8dBMakqSSe8vFwQNfjXEoe0W+Tez5HZCTkZKNMulv3Z+9A==",
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "jss": "10.0.0"
+                "jss": "^10.0.3"
             }
         },
         "jss-plugin-vendor-prefixer": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0.tgz",
-            "integrity": "sha512-qslqvL0MUbWuzXJWdUxpj6mdNUX8jr4FFTo3aZnAT65nmzWL7g8oTr9ZxmTXXgdp7ANhS1QWE7036/Q2isFBpw==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.3.tgz",
+            "integrity": "sha512-zVs6e5z4tFRK/fJ5kuTLzXlTFQbLeFTVwk7lTZiYNufmZwKT0kSmnOJDUukcSe7JLGSRztjWhnHB/6voP174gw==",
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "css-vendor": "^2.0.6",
-                "jss": "10.0.0"
-            }
-        },
-        "jsverify": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/jsverify/-/jsverify-0.8.4.tgz",
-            "integrity": "sha512-nUG73Sfi8L4eOkc7pv9sflgAm43v+z6XMuePGVdRoBUxBLJiVcMcf3Xgc4h19eHHF3JwsaagOkUu825UnPBLJw==",
-            "dev": true,
-            "requires": {
-                "lazy-seq": "^1.0.0",
-                "rc4": "~0.1.5",
-                "trampa": "^1.0.0",
-                "typify-parser": "^1.1.0"
+                "css-vendor": "^2.0.7",
+                "jss": "^10.0.3"
             }
         },
         "jsx-ast-utils": {
@@ -7364,12 +6063,6 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
             "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-            "dev": true
-        },
-        "kleur": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
             "dev": true
         },
         "koa": {
@@ -7480,12 +6173,6 @@
                 "package-json": "^4.0.0"
             }
         },
-        "lazy-seq": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lazy-seq/-/lazy-seq-1.0.0.tgz",
-            "integrity": "sha1-iAy4qrJWAmOC4C9T7AiWgqdMW2o=",
-            "dev": true
-        },
         "lcid": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -7505,17 +6192,20 @@
             "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
             "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ=="
         },
-        "left-pad": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-            "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-            "dev": true
-        },
         "leven": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
             "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
             "dev": true
+        },
+        "levenary": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.0.tgz",
+            "integrity": "sha512-VHcwhO0UTpUW7rLPN2/OiWJdgA1e9BqEDALhrgCe/F+uUJnep6CoUsTzMeP8Rh0NGr9uKquXxqe7lwLZo509nQ==",
+            "dev": true,
+            "requires": {
+                "leven": "^3.1.0"
+            }
         },
         "levn": {
             "version": "0.3.0",
@@ -7602,12 +6292,6 @@
             "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
             "dev": true
         },
-        "lodash.sortby": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-            "dev": true
-        },
         "lodash.uniq": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -7674,15 +6358,6 @@
             "requires": {
                 "pify": "^4.0.1",
                 "semver": "^5.6.0"
-            }
-        },
-        "makeerror": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
-            "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-            "dev": true,
-            "requires": {
-                "tmpl": "1.0.x"
             }
         },
         "mamacro": {
@@ -7780,9 +6455,9 @@
                     "dev": true
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -7949,12 +6624,6 @@
                 "is-plain-obj": "^1.1"
             }
         },
-        "merge-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true
-        },
         "micromatch": {
             "version": "3.1.10",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -7993,18 +6662,18 @@
             "dev": true
         },
         "mime-db": {
-            "version": "1.42.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-            "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+            "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.25",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
-            "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+            "version": "2.1.26",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+            "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
             "dev": true,
             "requires": {
-                "mime-db": "1.42.0"
+                "mime-db": "1.43.0"
             }
         },
         "mimic-fn": {
@@ -8256,12 +6925,6 @@
                 "minimatch": "^3.0.2"
             }
         },
-        "node-int64": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
-            "dev": true
-        },
         "node-libs-browser": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -8306,9 +6969,9 @@
                     "dev": true
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -8350,29 +7013,10 @@
                 }
             }
         },
-        "node-modules-regexp": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-            "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
-            "dev": true
-        },
-        "node-notifier": {
-            "version": "5.4.3",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-            "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
-            "dev": true,
-            "requires": {
-                "growly": "^1.3.0",
-                "is-wsl": "^1.1.0",
-                "semver": "^5.5.0",
-                "shellwords": "^0.1.1",
-                "which": "^1.3.0"
-            }
-        },
         "node-releases": {
-            "version": "1.1.43",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.43.tgz",
-            "integrity": "sha512-Rmfnj52WNhvr83MvuAWHEqXVoZXCcDQssSOffU4n4XOL9sPrP61mSZ88g25NqmABDvH7PiAlFCzoSCSdzA293w==",
+            "version": "1.1.45",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.45.tgz",
+            "integrity": "sha512-cXvGSfhITKI8qsV116u2FTzH5EWZJfgG7d4cpqwF8I8+1tWpD6AsvvGRKq2onR0DNj1jfqsjkXZsm14JMS7Cyg==",
             "dev": true,
             "requires": {
                 "semver": "^6.3.0"
@@ -8432,9 +7076,9 @@
             }
         },
         "npm": {
-            "version": "6.13.4",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-6.13.4.tgz",
-            "integrity": "sha512-vTcUL4SCg3AzwInWTbqg1OIaOXlzKSS8Mb8kc5avwrJpcvevDA5J9BhYSuei+fNs3pwOp4lzA5x2FVDXACvoXA==",
+            "version": "6.13.6",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-6.13.6.tgz",
+            "integrity": "sha512-NomC08kv7HIl1FOyLOe9Hp89kYsOsvx52huVIJ7i8hFW8Xp65lDwe/8wTIrh9q9SaQhA8hTrfXPh3BEL3TmMpw==",
             "dev": true,
             "requires": {
                 "JSONStream": "^1.3.5",
@@ -8522,7 +7166,7 @@
                 "once": "~1.4.0",
                 "opener": "^1.5.1",
                 "osenv": "^0.1.5",
-                "pacote": "^9.5.11",
+                "pacote": "^9.5.12",
                 "path-is-inside": "~1.0.2",
                 "promise-inflight": "~1.0.1",
                 "qrcode-terminal": "^0.12.0",
@@ -10804,7 +9448,7 @@
                     }
                 },
                 "pacote": {
-                    "version": "9.5.11",
+                    "version": "9.5.12",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -11940,18 +10584,6 @@
                 "boolbase": "~1.0.0"
             }
         },
-        "nwsapi": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-            "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
-            "dev": true
-        },
-        "oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-            "dev": true
-        },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -12118,24 +10750,6 @@
                 "is-wsl": "^1.1.0"
             }
         },
-        "optimist": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-            "dev": true,
-            "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "0.0.10",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-                    "dev": true
-                }
-            }
-        },
         "optimize-css-assets-webpack-plugin": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.3.tgz",
@@ -12189,15 +10803,6 @@
             "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
             "dev": true
         },
-        "p-each-series": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
-            "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
-            "dev": true,
-            "requires": {
-                "p-reduce": "^1.0.0"
-            }
-        },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -12211,9 +10816,9 @@
             "dev": true
         },
         "p-limit": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-            "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+            "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
             "dev": true,
             "requires": {
                 "p-try": "^2.0.0"
@@ -12227,12 +10832,6 @@
             "requires": {
                 "p-limit": "^2.0.0"
             }
-        },
-        "p-reduce": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-            "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
-            "dev": true
         },
         "p-try": {
             "version": "2.2.0",
@@ -12276,9 +10875,9 @@
                     "dev": true
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -12337,12 +10936,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
             "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-            "dev": true
-        },
-        "parse5": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-            "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
             "dev": true
         },
         "parseurl": {
@@ -12416,12 +11009,6 @@
                 }
             }
         },
-        "pathval": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-            "dev": true
-        },
         "pbkdf2": {
             "version": "3.0.17",
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -12435,26 +11022,11 @@
                 "sha.js": "^2.4.8"
             }
         },
-        "performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-            "dev": true
-        },
         "pify": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
             "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
             "dev": true
-        },
-        "pirates": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
-            "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
-            "dev": true,
-            "requires": {
-                "node-modules-regexp": "^1.0.0"
-            }
         },
         "pkg-dir": {
             "version": "3.0.0",
@@ -12464,12 +11036,6 @@
             "requires": {
                 "find-up": "^3.0.0"
             }
-        },
-        "pn": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-            "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-            "dev": true
         },
         "popper.js": {
             "version": "1.16.0",
@@ -12483,9 +11049,9 @@
             "dev": true
         },
         "postcss": {
-            "version": "7.0.25",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.25.tgz",
-            "integrity": "sha512-NXXVvWq9icrm/TgQC0O6YVFi4StfJz46M1iNd/h6B26Nvh/HKI+q4YZtFN/EjcInZliEscO/WL10BXnc1E5nwg==",
+            "version": "7.0.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
+            "integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
             "dev": true,
             "requires": {
                 "chalk": "^2.4.2",
@@ -12940,18 +11506,6 @@
             "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
             "dev": true
         },
-        "pretty-format": {
-            "version": "24.9.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-            "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-            "dev": true,
-            "requires": {
-                "@jest/types": "^24.9.0",
-                "ansi-regex": "^4.0.0",
-                "ansi-styles": "^3.2.0",
-                "react-is": "^16.8.4"
-            }
-        },
         "private": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -12982,16 +11536,6 @@
             "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
             "dev": true
         },
-        "prompts": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.0.tgz",
-            "integrity": "sha512-NfbbPPg/74fT7wk2XYQ7hAIp9zJyZp5Fu19iRbORqqy1BhtrkZ0fPafBU+7bmn8ie69DpT0R6QpJIN2oisYjJg==",
-            "dev": true,
-            "requires": {
-                "kleur": "^3.0.3",
-                "sisteransi": "^1.0.3"
-            }
-        },
         "prop-types": {
             "version": "15.7.2",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -13012,12 +11556,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-            "dev": true
-        },
-        "psl": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
-            "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==",
             "dev": true
         },
         "public-encrypt": {
@@ -13077,12 +11615,6 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
             "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-            "dev": true
-        },
-        "qs": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
             "dev": true
         },
         "query-string": {
@@ -13154,9 +11686,9 @@
             },
             "dependencies": {
                 "schema-utils": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.1.tgz",
-                    "integrity": "sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==",
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.2.tgz",
+                    "integrity": "sha512-sazKNMBX/jwrXRkOI7N6dtiTVYqzSckzol8SGuHt0lE/v3xSW6cUkOqzu6Bq2tW+dlUzq3CWIqHU3ZKauliqdg==",
                     "dev": true,
                     "requires": {
                         "ajv": "^6.10.2",
@@ -13176,12 +11708,6 @@
                 "minimist": "^1.2.0",
                 "strip-json-comments": "~2.0.1"
             }
-        },
-        "rc4": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/rc4/-/rc4-0.1.5.tgz",
-            "integrity": "sha1-CMbgSgFo9utiHCKrbLEVG9n0pk0=",
-            "dev": true
         },
         "react": {
             "version": "16.12.0",
@@ -13363,9 +11889,9 @@
                     "dev": true
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -13386,15 +11912,6 @@
                         "safe-buffer": "~5.1.0"
                     }
                 }
-            }
-        },
-        "realpath-native": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
-            "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
-            "dev": true,
-            "requires": {
-                "util.promisify": "^1.0.0"
             }
         },
         "recast": {
@@ -13513,9 +12030,9 @@
             "dev": true
         },
         "regjsparser": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.1.tgz",
-            "integrity": "sha512-7LutE94sz/NKSYegK+/4E77+8DipxF+Qn2Tmu362AcmsF2NYq/wx3+ObvU90TKEhjf7hQoFXo23ajjrXP7eUgg==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.2.tgz",
+            "integrity": "sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==",
             "dev": true,
             "requires": {
                 "jsesc": "~0.5.0"
@@ -13553,72 +12070,6 @@
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
         },
-        "request": {
-            "version": "2.88.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-            "dev": true,
-            "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            },
-            "dependencies": {
-                "punycode": {
-                    "version": "1.4.1",
-                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                    "dev": true
-                },
-                "tough-cookie": {
-                    "version": "2.4.3",
-                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-                    "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-                    "dev": true,
-                    "requires": {
-                        "psl": "^1.1.24",
-                        "punycode": "^1.4.1"
-                    }
-                }
-            }
-        },
-        "request-promise-core": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
-            "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
-            "dev": true,
-            "requires": {
-                "lodash": "^4.17.15"
-            }
-        },
-        "request-promise-native": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
-            "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
-            "dev": true,
-            "requires": {
-                "request-promise-core": "1.1.3",
-                "stealthy-require": "^1.1.1",
-                "tough-cookie": "^2.3.3"
-            }
-        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -13632,9 +12083,9 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.0.tgz",
-            "integrity": "sha512-uviWSi5N67j3t3UKFxej1loCH0VZn5XuqdNxoLShPcYPw6cUZn74K1VRj+9myynRX03bxIBEkwlkob/ujLsJVw==",
+            "version": "1.14.2",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
+            "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
             "dev": true,
             "requires": {
                 "path-parse": "^1.0.6"
@@ -13775,12 +12226,6 @@
                 "inherits": "^2.0.1"
             }
         },
-        "rsvp": {
-            "version": "4.8.5",
-            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-            "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-            "dev": true
-        },
         "run-async": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -13805,9 +12250,9 @@
             "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
         },
         "rxjs": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-            "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+            "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
@@ -13832,23 +12277,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
-        "sane": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
-            "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
-            "dev": true,
-            "requires": {
-                "@cnakazawa/watch": "^1.0.3",
-                "anymatch": "^2.0.0",
-                "capture-exit": "^2.0.0",
-                "exec-sh": "^0.3.2",
-                "execa": "^1.0.0",
-                "fb-watchman": "^2.0.0",
-                "micromatch": "^3.1.4",
-                "minimist": "^1.1.1",
-                "walker": "~1.0.5"
-            }
         },
         "sax": {
             "version": "1.2.4",
@@ -13964,12 +12392,6 @@
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
         },
-        "shellwords": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-            "dev": true
-        },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -13992,18 +12414,6 @@
                     "dev": true
                 }
             }
-        },
-        "sisteransi": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
-            "integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==",
-            "dev": true
-        },
-        "slash": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-            "dev": true
         },
         "slice-ansi": {
             "version": "2.1.0",
@@ -14160,12 +12570,12 @@
             "dev": true
         },
         "source-map-resolve": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+            "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
             "dev": true,
             "requires": {
-                "atob": "^2.1.1",
+                "atob": "^2.1.2",
                 "decode-uri-component": "^0.2.0",
                 "resolve-url": "^0.2.1",
                 "source-map-url": "^0.4.0",
@@ -14243,23 +12653,6 @@
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
-        "sshpk": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-            "dev": true,
-            "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            }
-        },
         "ssri": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
@@ -14273,12 +12666,6 @@
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
             "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-            "dev": true
-        },
-        "stack-utils": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
-            "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
             "dev": true
         },
         "static-extend": {
@@ -14308,12 +12695,6 @@
             "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
             "dev": true
         },
-        "stealthy-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-            "dev": true
-        },
         "stream-browserify": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -14331,9 +12712,9 @@
                     "dev": true
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -14386,9 +12767,9 @@
                     "dev": true
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -14423,33 +12804,6 @@
             "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
             "dev": true
         },
-        "string-length": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
-            "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
-            "dev": true,
-            "requires": {
-                "astral-regex": "^1.0.0",
-                "strip-ansi": "^4.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                }
-            }
-        },
         "string-width": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -14462,9 +12816,9 @@
             }
         },
         "string.prototype.trimleft": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-            "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+            "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
             "dev": true,
             "requires": {
                 "define-properties": "^1.1.3",
@@ -14472,9 +12826,9 @@
             }
         },
         "string.prototype.trimright": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-            "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+            "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
             "dev": true,
             "requires": {
                 "define-properties": "^1.1.3",
@@ -14521,9 +12875,9 @@
             "dev": true
         },
         "style-loader": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.0.2.tgz",
-            "integrity": "sha512-xehHGWeCPrr+R/bU82To0j7L7ENzH30RHYmMhmAumbuIpQ/bHmv3SAj1aTRfBSszkXoqNtpKnJyWXEDydS+KeA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.1.2.tgz",
+            "integrity": "sha512-0Mpq1ZHFDCNq1F+6avNBgv+7q8V+mWRuzehxyJT+aKgzyN/yfKTwjYqaYwBgx+11UpQxL21zNQfzzlz+JcGURw==",
             "dev": true,
             "requires": {
                 "loader-utils": "^1.2.3",
@@ -14531,9 +12885,9 @@
             },
             "dependencies": {
                 "schema-utils": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.1.tgz",
-                    "integrity": "sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==",
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.2.tgz",
+                    "integrity": "sha512-sazKNMBX/jwrXRkOI7N6dtiTVYqzSckzol8SGuHt0lE/v3xSW6cUkOqzu6Bq2tW+dlUzq3CWIqHU3ZKauliqdg==",
                     "dev": true,
                     "requires": {
                         "ajv": "^6.10.2",
@@ -14595,12 +12949,6 @@
                 "unquote": "~1.1.1",
                 "util.promisify": "~1.0.0"
             }
-        },
-        "symbol-tree": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-            "dev": true
         },
         "table": {
             "version": "5.4.6",
@@ -14680,9 +13028,9 @@
             }
         },
         "terser": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.3.tgz",
-            "integrity": "sha512-0ikKraVtRDKGzHrzkCv5rUNDzqlhmhowOBqC0XqUHFpW+vJ45+20/IFBcebwKfiS2Z9fJin6Eo+F1zLZsxi8RA==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.3.tgz",
+            "integrity": "sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==",
             "dev": true,
             "requires": {
                 "commander": "^2.20.0",
@@ -14723,78 +13071,6 @@
                 }
             }
         },
-        "test-exclude": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
-            "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.3",
-                "minimatch": "^3.0.4",
-                "read-pkg-up": "^4.0.0",
-                "require-main-filename": "^2.0.0"
-            },
-            "dependencies": {
-                "load-json-file": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-                    "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^4.0.0",
-                        "pify": "^3.0.0",
-                        "strip-bom": "^3.0.0"
-                    }
-                },
-                "parse-json": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-                    "dev": true,
-                    "requires": {
-                        "error-ex": "^1.3.1",
-                        "json-parse-better-errors": "^1.0.1"
-                    }
-                },
-                "path-type": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-                    "dev": true,
-                    "requires": {
-                        "pify": "^3.0.0"
-                    }
-                },
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
-                },
-                "read-pkg": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-                    "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-                    "dev": true,
-                    "requires": {
-                        "load-json-file": "^4.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^3.0.0"
-                    }
-                },
-                "read-pkg-up": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-                    "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "^3.0.0",
-                        "read-pkg": "^3.0.0"
-                    }
-                }
-            }
-        },
         "text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -14819,12 +13095,6 @@
                 "thenify": ">= 3.1.0 < 4"
             }
         },
-        "throat": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-            "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
-            "dev": true
-        },
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -14848,9 +13118,9 @@
                     "dev": true
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -14914,12 +13184,6 @@
                 "os-tmpdir": "~1.0.2"
             }
         },
-        "tmpl": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
-            "dev": true
-        },
         "to-arraybuffer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -14980,31 +13244,6 @@
             "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
             "dev": true
         },
-        "tough-cookie": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-            "dev": true,
-            "requires": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-            }
-        },
-        "tr46": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-            "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-            "dev": true,
-            "requires": {
-                "punycode": "^2.1.0"
-            }
-        },
-        "trampa": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/trampa/-/trampa-1.0.1.tgz",
-            "integrity": "sha512-93WeyHNuRggPEsfCe+yHxCgM2s6H3Q8Wmlt6b6ObJL8qc7eZlRaFjQxwTrB+zbvGtlDRnAkMoYYo3+2uH/fEwA==",
-            "dev": true
-        },
         "trim-newlines": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
@@ -15029,21 +13268,6 @@
             "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
             "dev": true
         },
-        "tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "dev": true
-        },
         "type": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -15058,12 +13282,6 @@
             "requires": {
                 "prelude-ls": "~1.1.2"
             }
-        },
-        "type-detect": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-            "dev": true
         },
         "type-is": {
             "version": "1.6.18",
@@ -15080,32 +13298,6 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
             "dev": true
-        },
-        "typify-parser": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/typify-parser/-/typify-parser-1.1.0.tgz",
-            "integrity": "sha1-rHO/pfJTQ0aOLQ8zRsYRe8A9PJk=",
-            "dev": true
-        },
-        "uglify-js": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
-            "integrity": "sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "commander": "~2.20.3",
-                "source-map": "~0.6.1"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true,
-                    "optional": true
-                }
-            }
         },
         "unicode-canonical-property-names-ecmascript": {
             "version": "1.0.4",
@@ -15266,23 +13458,6 @@
                 "latest-version": "^3.0.0",
                 "semver-diff": "^2.0.0",
                 "xdg-basedir": "^3.0.0"
-            },
-            "dependencies": {
-                "ci-info": {
-                    "version": "1.6.0",
-                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-                    "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-                    "dev": true
-                },
-                "is-ci": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-                    "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-                    "dev": true,
-                    "requires": {
-                        "ci-info": "^1.5.0"
-                    }
-                }
             }
         },
         "uri-js": {
@@ -15336,9 +13511,9 @@
             },
             "dependencies": {
                 "schema-utils": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.1.tgz",
-                    "integrity": "sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==",
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.2.tgz",
+                    "integrity": "sha512-sazKNMBX/jwrXRkOI7N6dtiTVYqzSckzol8SGuHt0lE/v3xSW6cUkOqzu6Bq2tW+dlUzq3CWIqHU3ZKauliqdg==",
                     "dev": true,
                     "requires": {
                         "ajv": "^6.10.2",
@@ -15429,40 +13604,11 @@
             "integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==",
             "dev": true
         },
-        "verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
-        },
         "vm-browserify": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
             "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
             "dev": true
-        },
-        "w3c-hr-time": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
-            "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
-            "dev": true,
-            "requires": {
-                "browser-process-hrtime": "^0.1.2"
-            }
-        },
-        "walker": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
-            "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-            "dev": true,
-            "requires": {
-                "makeerror": "1.0.x"
-            }
         },
         "warning": {
             "version": "4.0.3",
@@ -15483,16 +13629,10 @@
                 "neo-async": "^2.5.0"
             }
         },
-        "webidl-conversions": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-            "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-            "dev": true
-        },
         "webpack": {
-            "version": "4.41.3",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.3.tgz",
-            "integrity": "sha512-EcNzP9jGoxpQAXq1VOoTet0ik7/VVU1MovIfcUSAjLowc7GhcQku/sOXALvq5nPpSei2HF6VRhibeJSC3i/Law==",
+            "version": "4.41.5",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.5.tgz",
+            "integrity": "sha512-wp0Co4vpyumnp3KlkmpM5LWuzvZYayDwM2n17EHFr4qxBBbRokC7DJawPJC7TfSFZ9HZ6GsdH40EBj4UV0nmpw==",
             "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.8.5",
@@ -15518,18 +13658,6 @@
                 "terser-webpack-plugin": "^1.4.3",
                 "watchpack": "^1.6.0",
                 "webpack-sources": "^1.4.1"
-            },
-            "dependencies": {
-                "eslint-scope": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-                    "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-                    "dev": true,
-                    "requires": {
-                        "esrecurse": "^4.1.0",
-                        "estraverse": "^4.1.1"
-                    }
-                }
             }
         },
         "webpack-cli": {
@@ -15644,16 +13772,6 @@
                     "dev": true,
                     "requires": {
                         "ansi-regex": "^3.0.0"
-                    }
-                },
-                "ws": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-                    "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-                    "dev": true,
-                    "requires": {
-                        "async-limiter": "~1.0.0",
-                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -15793,32 +13911,6 @@
                 }
             }
         },
-        "whatwg-encoding": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
-            "dev": true,
-            "requires": {
-                "iconv-lite": "0.4.24"
-            }
-        },
-        "whatwg-mimetype": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
-            "dev": true
-        },
-        "whatwg-url": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-            "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
-            "dev": true,
-            "requires": {
-                "lodash.sortby": "^4.7.0",
-                "tr46": "^1.0.1",
-                "webidl-conversions": "^4.0.2"
-            }
-        },
         "which": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -15876,12 +13968,6 @@
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
             "dev": true
         },
-        "wordwrap": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-            "dev": true
-        },
         "worker-farm": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -15918,9 +14004,9 @@
             }
         },
         "write-file-atomic": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
-            "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+            "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.11",
@@ -15929,24 +14015,19 @@
             }
         },
         "ws": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-            "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+            "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
             "dev": true,
             "requires": {
-                "async-limiter": "~1.0.0"
+                "async-limiter": "~1.0.0",
+                "safe-buffer": "~5.1.0"
             }
         },
         "xdg-basedir": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
             "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-            "dev": true
-        },
-        "xml-name-validator": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
             "dev": true
         },
         "xtend": {

--- a/package.json
+++ b/package.json
@@ -1,21 +1,26 @@
 {
     "name": "webviz_subsurface_components",
     "description": "Custom Dash components for use in Webviz",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/equinor/webviz-subsurface-components.git"
+    },
+    "bugs": {
+        "url": "https://github.com/equinor/webviz-subsurface-components/issues"
+    },
+    "homepage": "https://github.com/equinor/webviz-subsurface-components",
     "main": "build/index.js",
     "scripts": {
         "start": "webpack-serve ./webpack.serve.config.js --open",
         "postinstall": "cp ./package.json webviz_subsurface_components/package.json",
-        "validate-init": "python _validate_init.py",
-        "prepublishOnly": "npm run validate-init",
-        "build:js-dev": "webpack --mode development",
         "build:js": "webpack --mode production",
-        "build:py": "dash-generate-components ./src/lib/components webviz_subsurface_components",
-        "build:all": "npm run build:js && npm run build:js-dev && npm run build:py",
-        "test": "jest",
+        "build:js-dev": "webpack --mode development",
+        "build:py_and_r": "dash-generate-components ./src/lib/components webviz_subsurface_components -p package-info.json --r-prefix ''",
+        "build": "npm run build:js && npm run build:js-dev && npm run build:py_and_r",
         "format": "prettier --write *.js *.json 'src/**/*.+(js|jsx|json|css)'",
         "linting": "prettier --check *.js *.json 'src/**/*.+(js|jsx|json|css)'"
     },
-    "author": "R&T Equinor",
+    "author": "R&T Equinor <akia@equinor.com>",
     "license": "LGPL",
     "dependencies": {
         "@material-ui/core": "^4.3.3",
@@ -30,17 +35,14 @@
         "@babel/core": "^7.5.5",
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-react": "^7.0.0",
-        "babel-eslint": "^9.0.0",
-        "babel-loader": "^8.0.0",
-        "chai": "^4.2.0",
+        "babel-eslint": "^10.0.2",
+        "babel-loader": "^8.0.6",
         "copyfiles": "^2.0.0",
         "css-loader": "^2.1.1",
         "eslint": "^5.16.0",
         "eslint-config-prettier": "^4.3.0",
         "eslint-plugin-import": "^2.18.2",
         "eslint-plugin-react": "^7.14.3",
-        "jest": "^24.9.0",
-        "jsverify": "^0.8.4",
         "mini-css-extract-plugin": "^0.8.0",
         "npm": "^6.13.4",
         "optimize-css-assets-webpack-plugin": "^5.0.3",

--- a/src/lib/components/HistoryMatch.js
+++ b/src/lib/components/HistoryMatch.js
@@ -29,7 +29,7 @@ HistoryMatch.defaultProps = {
 
 HistoryMatch.propTypes = {
     id: PropTypes.string.isRequired,
-
+    height: PropTypes.number,
     data: PropTypes.object,
 };
 

--- a/src/lib/private_components/layered-map-resources/CanvasOverlay.react.js
+++ b/src/lib/private_components/layered-map-resources/CanvasOverlay.react.js
@@ -1,14 +1,12 @@
 import PropTypes from "prop-types";
 import L from "leaflet";
 import { MapLayer, withLeaflet } from "react-leaflet";
-import { toLatLngBounds } from "leaflet/src/geo/LatLngBounds";
-import { Bounds } from "leaflet/src/geometry/Bounds";
 
 class CanvasOverlay extends MapLayer {
     constructor(props) {
         super(props);
         this._map = this.props.leaflet.map;
-        this._bounds = toLatLngBounds(this.props.bounds);
+        this._bounds = L.latLngBounds(this.props.bounds);
     }
 
     createLeafletElement() {
@@ -29,7 +27,7 @@ class CanvasOverlay extends MapLayer {
     }
 
     _reset() {
-        const bounds = new Bounds(
+        const bounds = new L.Bounds(
             this._map.latLngToLayerPoint(this._bounds.getNorthWest()),
             this._map.latLngToLayerPoint(this._bounds.getSouthEast())
         );
@@ -104,7 +102,7 @@ class CanvasOverlay extends MapLayer {
 
     componentDidUpdate(prevProps) {
         if (this.props.drawMethod !== prevProps.drawMethod) {
-            this._bounds = toLatLngBounds(this.props.bounds);
+            this._bounds = L.latLngBounds(this.props.bounds);
             this._reset();
             this.props.drawMethod(this.el);
         }


### PR DESCRIPTION
Solves a building error with `dash==1.8` (missing proptype). Also solves a console error, apparently arising from some strange combination of importing newest `dash_core_components`, as well as indirectly importing some leaflet source files twice.

In addition, building R components now requires author email being defined in `package.json`.