### PR TITLE
Set LayeredMap zIndex to 0

### DIFF
--- a/src/lib/components/LayeredMap.js
+++ b/src/lib/components/LayeredMap.js
@@ -217,7 +217,7 @@ class LayeredMap extends Component {
         return (
             <Map
                 id={this.props.id}
-                style={{ zIndex:0, height: this.props.height }}
+                style={{ zIndex: 0, height: this.props.height }}
                 ref={this.mapRef}
                 attributionControl={false}
                 crs={CRS.Simple}

--- a/src/lib/components/LayeredMap.js
+++ b/src/lib/components/LayeredMap.js
@@ -217,7 +217,7 @@ class LayeredMap extends Component {
         return (
             <Map
                 id={this.props.id}
-                style={{ height: this.props.height }}
+                style={{ zIndex:0, height: this.props.height }}
                 ref={this.mapRef}
                 attributionControl={false}
                 crs={CRS.Simple}


### PR DESCRIPTION
Default zIndex must be high as other components such as dropdowns are always rendered below the map. Setting Map zindex to 0 should solve it.