### PR TITLE
Run eslint during CI

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -117,5 +117,10 @@
         "ignore": [-1, 0, 1, 2, 3, 100, 10, 0.5]
     }],
     "no-underscore-dangle": ["off"]
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "build:py_and_r": "dash-generate-components ./src/lib/components webviz_subsurface_components -p package-info.json --r-prefix ''",
         "build": "npm run build:js && npm run build:js-dev && npm run build:py_and_r",
         "format": "prettier --write *.js *.json 'src/**/*.+(js|jsx|json|css)'",
-        "linting": "prettier --check *.js *.json 'src/**/*.+(js|jsx|json|css)'"
+        "linting": "prettier --check *.js *.json 'src/**/*.+(js|jsx|json|css)' && eslint src/"
     },
     "author": "R&T Equinor <akia@equinor.com>",
     "license": "LGPL",

--- a/src/lib/components/HistoryMatch.js
+++ b/src/lib/components/HistoryMatch.js
@@ -11,7 +11,7 @@ class HistoryMatch extends Component {
     }
 
     componentDidMount() {
-        const { data, height } = this.props;
+        const { data } = this.props;
         const parsedData = parseData(data);
         const elementSelector = `#${this.elementId}`;
         const hm = new HistoryMatching();

--- a/src/lib/components/Map.js
+++ b/src/lib/components/Map.js
@@ -31,13 +31,13 @@ const addNegativeFlow = ({ layers, indexies }) =>
             if (
                 indexies[k][i - 1] &&
                 indexies[k][i - 1][j] &&
-                indexies[k][i - 1][j]["FLOWI+"] !== undefined
+                typeof indexies[k][i - 1][j]["FLOWI+"] !== "undefined"
             ) {
                 FLOWInegative = indexies[k][i - 1][j]["FLOWI+"];
             }
             if (
                 indexies[k][i][j - 1] &&
-                indexies[k][i][j - 1]["FLOWJ+"] !== undefined
+                typeof indexies[k][i][j - 1]["FLOWJ+"] !== "undefined"
             ) {
                 FLOWJnegative = indexies[k][i][j - 1]["FLOWJ+"];
             }

--- a/src/lib/private_components/hm-resources/history_matching.js
+++ b/src/lib/private_components/hm-resources/history_matching.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 import * as d3 from "d3";
 import HistoryMatchingPlot from "./history_matching_plot";
 import Slider from "../shared/slider";
@@ -22,11 +23,14 @@ export default class HistoryMatching {
             top: 100,
         };
 
+        // width of plot area
         this.plotWidth =
             d3.select(this.container).node().offsetWidth -
             this.margin.left -
-            this.margin.right; // width of plot area
-        this.plotHeight = 20 * (this.data.iterations[0].labels.length + 1); // height of plot area
+            this.margin.right;
+
+        // height of plot area
+        this.plotHeight = 20 * (this.data.iterations[0].labels.length + 1);
 
         d3.select(this.container)
             .selectAll("*")
@@ -89,10 +93,11 @@ export default class HistoryMatching {
 
     initResize() {
         const resize = () => {
+            // width of plot area
             this.plotWidth =
                 d3.select(this.container).node().offsetWidth -
                 this.margin.left -
-                this.margin.right; // width of plot area
+                this.margin.right;
             this.initVisualisation();
             this.initIterationPicker();
             this.initPlot();

--- a/src/lib/private_components/hm-resources/history_matching_plot.js
+++ b/src/lib/private_components/hm-resources/history_matching_plot.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 import * as d3 from "d3";
 import Component from "../shared/component";
 import Legend from "./legend";

--- a/src/lib/private_components/hm-resources/legend.js
+++ b/src/lib/private_components/hm-resources/legend.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 export default class Legend {
     constructor(config = {}) {
         this.validate(config);

--- a/src/lib/private_components/layered-map-resources/CompositeMapLayer.react.js
+++ b/src/lib/private_components/layered-map-resources/CompositeMapLayer.react.js
@@ -9,6 +9,8 @@ const yx = ([x, y]) => {
     return [y, x];
 };
 
+const DEFAULT_ELEVATION_SCALE = 0.03;
+
 class CompositeMapLayer extends Component {
     renderTooltip(item) {
         if ("tooltip" in item) {
@@ -66,7 +68,9 @@ class CompositeMapLayer extends Component {
                         hillShading={
                             this.props.hillShading && item.allowHillshading
                         }
-                        elevationScale={item.elevationScale || 0.03}
+                        elevationScale={
+                            item.elevationScale || DEFAULT_ELEVATION_SCALE
+                        }
                         lightDirection={this.props.lightDirection}
                         minvalue={item.minvalue}
                         maxvalue={item.maxvalue}
@@ -114,6 +118,9 @@ CompositeMapLayer.propTypes = {
 
     /* Coordinates for selected polyline*/
     lineCoords: PropTypes.func,
+
+    /* Vector specifiyng the light direction*/
+    lightDirection: PropTypes.array,
 
     /* Coordinates for selected polygon*/
     polygonCoords: PropTypes.func,

--- a/src/lib/private_components/layered-map-resources/DrawControls.react.js
+++ b/src/lib/private_components/layered-map-resources/DrawControls.react.js
@@ -35,6 +35,7 @@ const getShapeType = layer => {
     if (layer instanceof L.Polyline) {
         return "polyline";
     }
+    throw new Error("Unknown shape type");
 };
 
 class DrawControls extends Component {

--- a/src/lib/private_components/map/cell.js
+++ b/src/lib/private_components/map/cell.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 import { Vector, Matrix } from "./linear_algebra";
 
 const oneVector = new Vector(1, 1);

--- a/src/lib/private_components/map/color-scale.js
+++ b/src/lib/private_components/map/color-scale.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 /**
  * Component for displaying a colour bar for various values
  * (e.g. a depth colour bar on a map)

--- a/src/lib/private_components/map/compass.js
+++ b/src/lib/private_components/map/compass.js
@@ -1,4 +1,4 @@
-/* eslint-disable react/require-render-return */
+/* eslint-disable react/require-render-return,no-magic-numbers */
 import * as d3 from "d3";
 import SVGTransform from "./util";
 import Component from "./component";

--- a/src/lib/private_components/map/distance-scale.js
+++ b/src/lib/private_components/map/distance-scale.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 export default class DistanceScale {
     constructor(config = {}) {
         this.validate(config);
@@ -8,7 +9,7 @@ export default class DistanceScale {
             throw new Error("Parent element not provided");
         }
 
-        if (config.initialK === undefined) {
+        if (typeof config.initialK === "undefined") {
             throw new Error("Initial K value not provided");
         }
 
@@ -16,7 +17,7 @@ export default class DistanceScale {
             throw new Error("Initial K cannot be 0 or undefined");
         }
 
-        if (config.origMeter2Px === undefined) {
+        if (typeof config.origMeter2Px === "undefined") {
             throw new Error("origMeter2Px not provided");
         }
 
@@ -63,7 +64,8 @@ export default class DistanceScale {
     // to automatically decide on the optimal number of subscales (and length of them)
     // such that each subscale corresponds to an integer number of km.
     renderScale() {
-        const meter2px = this.k * this.origMeter2Px; // px = meter * meter2px;
+        // px = meter * meter2px;
+        const meter2px = this.k * this.origMeter2Px;
 
         const gScaleMaxWidth = 400;
 

--- a/src/lib/private_components/map/field.js
+++ b/src/lib/private_components/map/field.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undefined */
 import { Vector } from "./linear_algebra";
 import { outsideUnitSquare } from "./cell";
 

--- a/src/lib/private_components/map/flow_animation.js
+++ b/src/lib/private_components/map/flow_animation.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 import * as d3 from "d3";
 
 function distance([x1, y1], [x2, y2]) {

--- a/src/lib/private_components/map/flow_map.js
+++ b/src/lib/private_components/map/flow_map.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 import * as d3 from "d3";
 import Map2D from "./map2d";
 import FlowAnimation from "./flow_animation";

--- a/src/lib/private_components/map/grid.js
+++ b/src/lib/private_components/map/grid.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undefined */
 import { range } from "./util";
 /**
  * Two dimensional grid of Cells.

--- a/src/lib/private_components/map/infobox.js
+++ b/src/lib/private_components/map/infobox.js
@@ -1,4 +1,4 @@
-/* eslint-disable react/require-render-return */
+/* eslint-disable react/require-render-return,no-magic-numbers */
 import Component from "./component";
 
 export default class InfoBox extends Component {

--- a/src/lib/private_components/map/linear_algebra.js
+++ b/src/lib/private_components/map/linear_algebra.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undefined */
 function isIterable(object) {
     return typeof object[Symbol.iterator] === "function";
 }

--- a/src/lib/private_components/map/map.js
+++ b/src/lib/private_components/map/map.js
@@ -89,7 +89,7 @@ export default class Map extends Component {
                     .join(" ")
             )
             .attr("fill", (d, i) => self.color(i))
-            .on("mousemove", function onmousemove(d, i) {
+            .on("mousemove", (d, i) => {
                 self.emit("mousemove", {
                     x: d3.mouse(this)[0],
                     y: d3.mouse(this)[1],
@@ -102,11 +102,11 @@ export default class Map extends Component {
 
         const node = this.element.node();
 
-        if (this.mapWidth === undefined && node) {
+        if (typeof this.mapWidth === "undefined" && node) {
             this.mapWidth = node.getBoundingClientRect().width;
         }
 
-        if (this.mapHeight === undefined && node) {
+        if (typeof this.mapHeight === "undefined" && node) {
             this.mapHeight = node.getBoundingClientRect().height;
         }
 

--- a/src/lib/private_components/map/map2d.js
+++ b/src/lib/private_components/map/map2d.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undefined,react/prop-types,no-magic-numbers */
 import * as d3 from "d3";
 import Map from "./map";
 import Compass from "./compass";

--- a/src/lib/private_components/map/particle.js
+++ b/src/lib/private_components/map/particle.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 import { Vector } from "./linear_algebra";
 
 /**

--- a/src/lib/private_components/map/tests/arbitraries.js
+++ b/src/lib/private_components/map/tests/arbitraries.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 import jsc from "jsverify";
 import { affineIndependent, Vector, Matrix } from "../linear_algebra";
 import { Cell } from "../cell";

--- a/src/lib/private_components/map/tests/grid.spec.js
+++ b/src/lib/private_components/map/tests/grid.spec.js
@@ -10,7 +10,7 @@ describe("Grid", () => {
         (grid, i, j) => {
             const cell = grid.getCell(i, j);
             if (i > grid.numRows || j > grid.numColumn(i) || i < 0 || j < 0) {
-                return cell === undefined;
+                return typeof cell === "undefined";
             }
             return true;
         }

--- a/src/lib/private_components/map/vertical-slider.js
+++ b/src/lib/private_components/map/vertical-slider.js
@@ -1,10 +1,6 @@
-/* eslint-disable react/require-render-return */
+/* eslint-disable react/require-render-return,no-magic-numbers */
 import * as d3 from "d3";
 import Component from "./component";
-
-function appendClone() {
-    return this.parentNode.appendChild(this.cloneNode(true));
-}
 
 export default class VerticalSlider extends Component {
     static validate(config) {
@@ -48,6 +44,10 @@ export default class VerticalSlider extends Component {
         }
     }
 
+    appendClone() {
+        return this.parentNode.appendChild(this.cloneNode(true));
+    }
+
     setPosition({ x, y }) {
         this.position.x = x;
         this.position.y = y;
@@ -85,13 +85,13 @@ export default class VerticalSlider extends Component {
                 "style",
                 "stroke-linecap: round; stroke: #000; stroke-opacity: 0.3; stroke-width: 10px"
             )
-            .select(appendClone)
+            .select(this.appendClone)
             .attr("class", "track-inset")
             .attr(
                 "style",
                 "stroke-linecap: round; stroke: #ddd; stroke-width: 8px"
             )
-            .select(appendClone)
+            .select(this.appendClone)
             .attr("class", "track-overlay")
             .attr(
                 "style",

--- a/src/lib/private_components/morris-resources/morris.js
+++ b/src/lib/private_components/morris-resources/morris.js
@@ -1,5 +1,5 @@
-/* eslint no-shadow: "off" */
-/* Fix this lint when rewriting the whole file */
+/* eslint-disable no-magic-numbers,no-global-assign,no-native-reassign,no-unused-vars,no-invalid-this */
+/* Fix lint when/if rewriting the whole file */
 
 import * as d3 from "d3";
 

--- a/src/lib/private_components/shared/slider.js
+++ b/src/lib/private_components/shared/slider.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-invalid-this */
 import * as d3 from "d3";
 import Component from "./component";
 import "./slider.css";
@@ -24,6 +25,7 @@ const AXIS = {
     VERTICAL: "y",
 };
 
+const TICKOFFSET = 4;
 const SNAP_DURATION = 500;
 const HANDLE_RADIUS = 8;
 
@@ -111,8 +113,9 @@ export default class Slider extends Component {
     }
 
     slideMove(pos) {
-        pos = this.scale(this.scale.invert(pos)); // Use d3's clamp to avoid going outside range
-        this.bar.attr(`c${this.axis}`, pos);
+        // Use d3's clamp to avoid going outside range
+        const clamp_pos = this.scale(this.scale.invert(pos));
+        this.bar.attr(`c${this.axis}`, clamp_pos);
 
         const index = Math.round(this.scale.invert(pos));
         if (index !== this.selectedIndex) {
@@ -123,12 +126,15 @@ export default class Slider extends Component {
         this.container
             .select(".currentTick")
             .text(this.data[this.selectedIndex])
-            .attr(this.axis, pos);
+            .attr(this.axis, clamp_pos);
     }
 
     slideEnd(pos) {
-        pos = this.scale(this.scale.invert(pos)); // Use d3's clamp to avoid going outside range
-        const finalPosition = this.scale(Math.round(this.scale.invert(pos)));
+        // Use d3's clamp to avoid going outside range
+        const clamp_pos = this.scale(this.scale.invert(pos));
+        const finalPosition = this.scale(
+            Math.round(this.scale.invert(clamp_pos))
+        );
 
         this.bar
             .transition()
@@ -182,7 +188,7 @@ export default class Slider extends Component {
             position === TICKPOSITION.TOP
         ) {
             return {
-                transform: `translate(0,-${HANDLE_RADIUS / 2 + 4})`,
+                transform: `translate(0,-${HANDLE_RADIUS / 2 + TICKOFFSET})`,
                 "text-anchor": "middle",
                 "dominant-baseline": "text-after-edge",
             };
@@ -192,7 +198,7 @@ export default class Slider extends Component {
             position === TICKPOSITION.BOTTOM
         ) {
             return {
-                transform: `translate(0,${HANDLE_RADIUS / 2 + 4})`,
+                transform: `translate(0,${HANDLE_RADIUS / 2 + TICKOFFSET})`,
                 "text-anchor": "middle",
                 "dominant-baseline": "text-before-edge",
             };
@@ -202,7 +208,7 @@ export default class Slider extends Component {
             position === TICKPOSITION.LEFT
         ) {
             return {
-                transform: `translate(-${HANDLE_RADIUS / 2 + 4}, 0)`,
+                transform: `translate(-${HANDLE_RADIUS / 2 + TICKOFFSET}, 0)`,
                 "text-anchor": "end",
                 "dominant-baseline": "central",
             };
@@ -212,7 +218,7 @@ export default class Slider extends Component {
             position === TICKPOSITION.RIGHT
         ) {
             return {
-                transform: `translate(${HANDLE_RADIUS / 2 + 4}, 0)`,
+                transform: `translate(${HANDLE_RADIUS / 2 + TICKOFFSET}, 0)`,
                 "text-anchor": "start",
                 "dominant-baseline": "central",
             };


### PR DESCRIPTION
Closes #106. `eslint` is now turned on for all new JavaScript code.

Some of the old code ported from  https://github.com/equinor/webviz has certain `eslint` flags turned off, and should be fixed when rewriting them (if we are to keep them going forward at all).