### PR TITLE
🚘 Refactored TileWebGLLayer to use canvases instead of images

### DIFF
--- a/src/demo/NewLayeredMapDemo.js
+++ b/src/demo/NewLayeredMapDemo.js
@@ -17,7 +17,7 @@ const NewLayeredMapDemo = () => {
         }
     }
 
-    const layer = exampleData.layers.slice(1);
+    const layer = exampleData.layers.slice(0, 1);
     const layer2 = JSON.parse(JSON.stringify(layer));
     layer2[0].data[0].colorScale = null;
     const layer3 = JSON.parse(JSON.stringify(layer2));
@@ -31,15 +31,15 @@ const NewLayeredMapDemo = () => {
                     syncedMaps={["NewLayeredMap-2"]}
                     layers={layer}
                     // center={[0, 0]}
-                    center={[432205, 6475078], [432205, 6475078]}
-                    bounds={[[432205, 6475078], [437720, 6481113]] /* [[432205, 6475078], [437720, 6481113]] */}
-                    minZoom={-5}
-                    scaleY={{
+                    //center={[432205, 6475078], [432205, 6475078]}
+                    //bounds={[[432205, 6475078], [437720, 6481113]] /* [[432205, 6475078], [437720, 6481113]] */}
+                    //minZoom={-5}
+                    /* scaleY={{
                         scaleY: 1,
                         minScaleY: 1,
                         maxScaleY: 10,
                         position: 'topleft',
-                    }}
+                    }} */
                     drawTools = {{
                         drawMarker: true,
                         drawPolygon: true,
@@ -60,19 +60,19 @@ const NewLayeredMapDemo = () => {
                     id={"NewLayeredMap-2"}
                     syncedMaps={["NewLayeredMap-1"]}
                     layers={layer2}
-                    center={[432205, 6475078], [432205, 6475078]}
-                    bounds={[[432205, 6475078], [437720, 6481113]] /* [[432205, 6475078], [437720, 6481113]] */}
+                    //center={[432205, 6475078], [432205, 6475078]}
+                    //bounds={[[432205, 6475078], [437720, 6481113]] /* [[432205, 6475078], [437720, 6481113]] */}
                     // crs="earth"
                     // crs="simple"
-                    minZoom={-5}
-                    zoom = {-5} 
+                   // minZoom={-5}
+                    //zoom = {-5} 
                     // setProps={e => console.log(e)}
-                    scaleY={{
+                   /*  scaleY={{
                         scaleY: 1,
                         minScaleY: 1,
                         maxScaleY: 10,
                         position: 'topleft',
-                    }}
+                    }} */
                     drawTools = {{
                         drawMarker: true,
                         drawPolygon: true,
@@ -94,15 +94,15 @@ const NewLayeredMapDemo = () => {
                     syncedMaps={["NewLayeredMap-2"]}
                     layers={layer3}
                     // center={[0, 0]}
-                    center={[432205, 6475078], [432205, 6475078]}
-                    bounds={[[432205, 6475078], [437720, 6481113]] /* [[432205, 6475078], [437720, 6481113]] */}
-                    minZoom={-5}
-                    scaleY={{
+                    //center={[432205, 6475078], [432205, 6475078]}
+                    //bounds={[[432205, 6475078], [437720, 6481113]] /* [[432205, 6475078], [437720, 6481113]] */}
+                    //minZoom={-5}
+                    /* scaleY={{
                         scaleY: 1,
                         minScaleY: 1,
                         maxScaleY: 10,
                         position: 'topleft',
-                    }}
+                    }} */
                     drawTools = {{
                         drawMarker: true,
                         drawPolygon: true,

--- a/src/lib/components/NewLayeredMap/layers/L.imageWebGLOverlay.js
+++ b/src/lib/components/NewLayeredMap/layers/L.imageWebGLOverlay.js
@@ -12,6 +12,14 @@ import { loadImage } from '../webgl/webglUtils';
  */
 L.ImageWebGLOverlay = L.Layer.extend({
 
+    options: {
+
+        /**
+		 * @param {Array<String>} - An array of hexcolors for defining the colormap used on the tiles.
+		 */
+		colorScale: ["#FFFFFF", "#000000"],
+    },
+
     initialize: function(url, bounds, options) {
         this._url = url;
         this.setBounds(bounds);
@@ -123,8 +131,7 @@ L.ImageWebGLOverlay = L.Layer.extend({
             /**
              * @type {import('../colorscale/index').ColorScaleConfig}
              */
-            const colorScaleCfg = Object.assign({}, DEFAULT_COLORSCALE_CONFIG, colorScale);
-            console.log("CFG:", colorScaleCfg);
+            const colorScaleCfg = Object.assign({}, DEFAULT_COLORSCALE_CONFIG, colorScale || {});
             const colors = colorScaleCfg.colors;
             this._colormapUrl = buildColormapFromHexColors(colors, colorScaleCfg);
         }

--- a/src/lib/components/NewLayeredMap/layers/L.tileWebGLLayer.js
+++ b/src/lib/components/NewLayeredMap/layers/L.tileWebGLLayer.js
@@ -88,30 +88,24 @@ L.TileWebGLLayer = L.GridLayer.extend({
 		
 		this._initColormap();
 
-        L.GridLayer.prototype.onAdd.call(this, map);
+		L.GridLayer.prototype.onAdd.call(this, map);
     },
 
     createTile: function(coords, done) {
 		// Create image-tag and assign on load- and error-listeners
-		const tile = DomUtil.create('img');
+		const tile = DomUtil.create('canvas');
 		DomEvent.on(tile, 'load', Util.bind(this._tileOnLoad, this, done, tile));
 		DomEvent.on(tile, 'error', Util.bind(this._tileOnError, this, done, tile));
+		tile.width = this.options.tileSize;
+		tile.height = this.options.tileSize;
 
 		// Make sure the image gets the correct crossOrigin attribute, due to CORS-issues.
 		if (this.options.crossOrigin || this.options.crossOrigin === '') {
 			tile.crossOrigin = this.options.crossOrigin === true ? '' : this.options.crossOrigin;
 		}
 
-        drawFunc(this._glContext, this._canvas, this.getTileUrl(coords), this._colormapUrl, {
-			...this.options,
-			crossOrigin: '',
-			shader: this.options.shader,
-		})
-		.then(() => {
-			const image = this._canvas.toDataURL();
-			tile.alt = '';
-			tile.src = image;
-		})
+		this._draw(tile, coords, done);
+        
 
 		return tile;
     },
@@ -130,6 +124,30 @@ L.TileWebGLLayer = L.GridLayer.extend({
     
 
 	// ----------- PRIVATE FUNCTIONS ------------------
+
+	_draw: function(tile, coords, done) {
+		
+		drawFunc(this._glContext, this._canvas, this.getTileUrl(coords), this._colormapUrl, {
+			...this.options,
+			crossOrigin: '',
+			shader: this.options.shader,
+		})
+		.then(() => {
+			const ctx = tile.getContext('2d');
+			ctx.drawImage(this._canvas, 0, 0);
+			
+			if(done) {
+				done(null, tile);
+			}
+		})
+	},
+
+	_redrawAllTiles: function() {
+
+		for(let { el, coords } of Object.values(this._tiles)) {
+			this._draw(el, coords, null);
+		}
+	},
 
     _getZoomForUrl: function () {
 		let zoom =          this._tileZoom;
@@ -191,12 +209,12 @@ L.TileWebGLLayer = L.GridLayer.extend({
             const colors = colorScale;
             this._colormapUrl = buildColormapFromHexColors(colors);
         } 
-        else if(typeof colorScale === 'object' && colorScale !== null) {
+        else if(typeof colorScale === 'object' || !colorScale) {
             // The given colorScale is an object
             /**
              * @type {import('../colorscale/index').ColorScaleConfig}
              */
-            const colorScaleCfg = Object.assign({}, DEFAULT_COLORSCALE_CONFIG, colorScale);
+            const colorScaleCfg = Object.assign({}, DEFAULT_COLORSCALE_CONFIG, colorScale || {});
             const colors = colorScaleCfg.colors;
             this._colormapUrl = buildColormapFromHexColors(colors, colorScaleCfg);
         }

--- a/src/lib/components/NewLayeredMap/shaders/baseFragmentShader.fs.glsl
+++ b/src/lib/components/NewLayeredMap/shaders/baseFragmentShader.fs.glsl
@@ -6,7 +6,21 @@ uniform float u_colormap_length;
 
 varying vec2 v_texCoord;
 
+// Global min max: https://www.gamedev.net/forums/topic/559942-glsl--find-global-min-and-max-in-texture/
+
+// Maps a value from a given interval to a target interval
+float map(float value, float from1, float to1, float from2, float to2) {
+    return ((value - from1)/(to1 - from1))*(to2 - from2) + from2;
+}
+
+// See: https://stackoverflow.com/questions/28125439/algorithm-to-map-values-to-unit-scale-with-logarithmic-spacing
+float map_log(float value, float from1, float to1, float from2, float to2) {
+    return (log(value/from1) / log(to1/from1))*(to1 - from2) + from2;
+}
+
 void main() {
-    float map_array = texture2D(u_image, v_texCoord).r;
-    gl_FragColor = texture2D(u_colormap_frame, vec2((map_array * (u_colormap_length - 1.0) + 0.5) / u_colormap_length, 0.5));
+    float color_value = texture2D(u_image, v_texCoord).r;
+    float mapped_color_value = map(color_value, 0.0, 1.0, 0.0, u_colormap_length - 1.0);
+    vec2 colormap_coord = vec2((mapped_color_value) / u_colormap_length, 0.0);
+    gl_FragColor = texture2D(u_colormap_frame, colormap_coord);
 }

--- a/src/lib/components/NewLayeredMap/webgl/commands/drawWithColormap.js
+++ b/src/lib/components/NewLayeredMap/webgl/commands/drawWithColormap.js
@@ -28,7 +28,5 @@ export default (gl, canvas, loadedImage, loadedColorMap) => {
         .setVertexCount(6)
         .build();
 
-    
-
     drawCommand(gl, canvas, drawCmd);
 }


### PR DESCRIPTION
Refactored the TileWebGLLayer to use canvases instead of image-tags to avoid flickering on update.