### PR TITLE
Fix streamline animation regression

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -1,0 +1,15 @@
+{
+    "presets": [
+     ["@babel/preset-env",
+      {
+        "targets": {
+          "esmodules": true
+        }
+     }] ,
+      "@babel/preset-react",
+      "@babel/preset-typescript"
+    ],
+    "plugins": [
+      "@babel/plugin-proposal-class-properties"
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,363 @@
                 "@babel/highlight": "^7.10.4"
             }
         },
+        "@babel/compat-data": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.11.0.tgz",
+            "integrity": "sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==",
+            "dev": true,
+            "requires": {
+                "browserslist": "^4.12.0",
+                "invariant": "^2.2.4",
+                "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/core": {
+            "version": "7.11.6",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+            "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.11.6",
+                "@babel/helper-module-transforms": "^7.11.0",
+                "@babel/helpers": "^7.10.4",
+                "@babel/parser": "^7.11.5",
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.11.5",
+                "@babel/types": "^7.11.5",
+                "convert-source-map": "^1.7.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.1",
+                "json5": "^2.1.2",
+                "lodash": "^4.17.19",
+                "resolve": "^1.3.2",
+                "semver": "^5.4.1",
+                "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "json5": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+                    "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/generator": {
+            "version": "7.11.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+            "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.11.5",
+                "jsesc": "^2.5.1",
+                "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-annotate-as-pure": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+            "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+            "integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-explode-assignable-expression": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-builder-react-jsx": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
+            "integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-builder-react-jsx-experimental": {
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.11.5.tgz",
+            "integrity": "sha512-Vc4aPJnRZKWfzeCBsqTBnzulVNjABVdahSPhtdMD3Vs80ykx4a87jTHtF/VR+alSrDmNvat7l13yrRHauGcHVw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/types": "^7.11.5"
+            }
+        },
+        "@babel/helper-compilation-targets": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz",
+            "integrity": "sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.10.4",
+                "browserslist": "^4.12.0",
+                "invariant": "^2.2.4",
+                "levenary": "^1.1.1",
+                "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-create-class-features-plugin": {
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
+            "integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-member-expression-to-functions": "^7.10.5",
+                "@babel/helper-optimise-call-expression": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.10.4"
+            }
+        },
+        "@babel/helper-create-regexp-features-plugin": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
+            "integrity": "sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-regex": "^7.10.4",
+                "regexpu-core": "^4.7.0"
+            }
+        },
+        "@babel/helper-define-map": {
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+            "integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/types": "^7.10.5",
+                "lodash": "^4.17.19"
+            }
+        },
+        "@babel/helper-explode-assignable-expression": {
+            "version": "7.11.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz",
+            "integrity": "sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+            "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+            "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-hoist-variables": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
+            "integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-member-expression-to-functions": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+            "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.11.0"
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+            "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+            "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.10.4",
+                "@babel/helper-simple-access": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.11.0",
+                "lodash": "^4.17.19"
+            }
+        },
+        "@babel/helper-optimise-call-expression": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+            "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-plugin-utils": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+            "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+            "dev": true
+        },
+        "@babel/helper-regex": {
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+            "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.19"
+            }
+        },
+        "@babel/helper-remap-async-to-generator": {
+            "version": "7.11.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz",
+            "integrity": "sha512-tR5vJ/vBa9wFy3m5LLv2faapJLnDFxNWff2SAYkSE4rLUdbp7CdObYFgI7wK4T/Mj4UzpjPwzR8Pzmr5m7MHGA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-wrap-function": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-replace-supers": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+            "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-member-expression-to-functions": "^7.10.4",
+                "@babel/helper-optimise-call-expression": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-simple-access": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+            "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-skip-transparent-expression-wrappers": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz",
+            "integrity": "sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.11.0"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+            "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.11.0"
+            }
+        },
         "@babel/helper-validator-identifier": {
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
             "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
             "dev": true
+        },
+        "@babel/helper-wrap-function": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
+            "integrity": "sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helpers": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+            "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
         },
         "@babel/highlight": {
             "version": "7.10.4",
@@ -29,12 +381,842 @@
                 "js-tokens": "^4.0.0"
             }
         },
+        "@babel/parser": {
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+            "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+            "dev": true
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
+            "integrity": "sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-remap-async-to-generator": "^7.10.4",
+                "@babel/plugin-syntax-async-generators": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-class-properties": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
+            "integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-proposal-dynamic-import": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz",
+            "integrity": "sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-export-namespace-from": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.10.4.tgz",
+            "integrity": "sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+            }
+        },
+        "@babel/plugin-proposal-json-strings": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
+            "integrity": "sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-json-strings": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-logical-assignment-operators": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.11.0.tgz",
+            "integrity": "sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+            }
+        },
+        "@babel/plugin-proposal-nullish-coalescing-operator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
+            "integrity": "sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-numeric-separator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz",
+            "integrity": "sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+            }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
+            "integrity": "sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+                "@babel/plugin-transform-parameters": "^7.10.4"
+            }
+        },
+        "@babel/plugin-proposal-optional-catch-binding": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz",
+            "integrity": "sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-optional-chaining": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz",
+            "integrity": "sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-private-methods": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.4.tgz",
+            "integrity": "sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
+            "integrity": "sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-async-generators": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-class-properties": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
+            "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-dynamic-import": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+            "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-export-namespace-from": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+            "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-syntax-json-strings": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-jsx": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
+            "integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-logical-assignment-operators": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+            "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-numeric-separator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+            "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+            "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-chaining": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-top-level-await": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
+            "integrity": "sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-typescript": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.10.4.tgz",
+            "integrity": "sha512-oSAEz1YkBCAKr5Yiq8/BNtvSAPwkp/IyUnwZogd8p+F0RuYQQrLeRUzIQhueQTTBy/F+a40uS7OFKxnkRvmvFQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
+            "integrity": "sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
+            "integrity": "sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-remap-async-to-generator": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
+            "integrity": "sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-block-scoping": {
+            "version": "7.11.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz",
+            "integrity": "sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-classes": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
+            "integrity": "sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-define-map": "^7.10.4",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-optimise-call-expression": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.10.4",
+                "globals": "^11.1.0"
+            },
+            "dependencies": {
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-transform-computed-properties": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
+            "integrity": "sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-destructuring": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
+            "integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz",
+            "integrity": "sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz",
+            "integrity": "sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz",
+            "integrity": "sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-for-of": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
+            "integrity": "sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-function-name": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
+            "integrity": "sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-literals": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
+            "integrity": "sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-member-expression-literals": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz",
+            "integrity": "sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-modules-amd": {
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
+            "integrity": "sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.10.5",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
+            }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz",
+            "integrity": "sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-simple-access": "^7.10.4",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
+            }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
+            "integrity": "sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-hoist-variables": "^7.10.4",
+                "@babel/helper-module-transforms": "^7.10.5",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
+            }
+        },
+        "@babel/plugin-transform-modules-umd": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz",
+            "integrity": "sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-named-capturing-groups-regex": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz",
+            "integrity": "sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-new-target": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz",
+            "integrity": "sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-object-super": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
+            "integrity": "sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-parameters": {
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
+            "integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-property-literals": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz",
+            "integrity": "sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-react-display-name": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.10.4.tgz",
+            "integrity": "sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-react-jsx": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz",
+            "integrity": "sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-builder-react-jsx": "^7.10.4",
+                "@babel/helper-builder-react-jsx-experimental": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-react-jsx-development": {
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.11.5.tgz",
+            "integrity": "sha512-cImAmIlKJ84sDmpQzm4/0q/2xrXlDezQoixy3qoz1NJeZL/8PRon6xZtluvr4H4FzwlDGI5tCcFupMnXGtr+qw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-builder-react-jsx-experimental": "^7.11.5",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-react-jsx-self": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.10.4.tgz",
+            "integrity": "sha512-yOvxY2pDiVJi0axdTWHSMi5T0DILN+H+SaeJeACHKjQLezEzhLx9nEF9xgpBLPtkZsks9cnb5P9iBEi21En3gg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-react-jsx-source": {
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.10.5.tgz",
+            "integrity": "sha512-wTeqHVkN1lfPLubRiZH3o73f4rfon42HpgxUSs86Nc+8QIcm/B9s8NNVXu/gwGcOyd7yDib9ikxoDLxJP0UiDA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-react-pure-annotations": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.10.4.tgz",
+            "integrity": "sha512-+njZkqcOuS8RaPakrnR9KvxjoG1ASJWpoIv/doyWngId88JoFlPlISenGXjrVacZUIALGUr6eodRs1vmPnF23A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-regenerator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
+            "integrity": "sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==",
+            "dev": true,
+            "requires": {
+                "regenerator-transform": "^0.14.2"
+            }
+        },
+        "@babel/plugin-transform-reserved-words": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz",
+            "integrity": "sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
+            "integrity": "sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-spread": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz",
+            "integrity": "sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0"
+            }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz",
+            "integrity": "sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-regex": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-template-literals": {
+            "version": "7.10.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
+            "integrity": "sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz",
+            "integrity": "sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-typescript": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.11.0.tgz",
+            "integrity": "sha512-edJsNzTtvb3MaXQwj8403B7mZoGu9ElDJQZOKjGUnvilquxBA3IQoEIOvkX/1O8xfAsnHS/oQhe2w/IXrr+w0w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.10.5",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-typescript": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-unicode-escapes": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.4.tgz",
+            "integrity": "sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz",
+            "integrity": "sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/preset-env": {
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.5.tgz",
+            "integrity": "sha512-kXqmW1jVcnB2cdueV+fyBM8estd5mlNfaQi6lwLgRwCby4edpavgbFhiBNjmWA3JpB/yZGSISa7Srf+TwxDQoA==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.11.0",
+                "@babel/helper-compilation-targets": "^7.10.4",
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-proposal-async-generator-functions": "^7.10.4",
+                "@babel/plugin-proposal-class-properties": "^7.10.4",
+                "@babel/plugin-proposal-dynamic-import": "^7.10.4",
+                "@babel/plugin-proposal-export-namespace-from": "^7.10.4",
+                "@babel/plugin-proposal-json-strings": "^7.10.4",
+                "@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
+                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
+                "@babel/plugin-proposal-numeric-separator": "^7.10.4",
+                "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
+                "@babel/plugin-proposal-optional-chaining": "^7.11.0",
+                "@babel/plugin-proposal-private-methods": "^7.10.4",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
+                "@babel/plugin-syntax-async-generators": "^7.8.0",
+                "@babel/plugin-syntax-class-properties": "^7.10.4",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+                "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.0",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+                "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+                "@babel/plugin-syntax-top-level-await": "^7.10.4",
+                "@babel/plugin-transform-arrow-functions": "^7.10.4",
+                "@babel/plugin-transform-async-to-generator": "^7.10.4",
+                "@babel/plugin-transform-block-scoped-functions": "^7.10.4",
+                "@babel/plugin-transform-block-scoping": "^7.10.4",
+                "@babel/plugin-transform-classes": "^7.10.4",
+                "@babel/plugin-transform-computed-properties": "^7.10.4",
+                "@babel/plugin-transform-destructuring": "^7.10.4",
+                "@babel/plugin-transform-dotall-regex": "^7.10.4",
+                "@babel/plugin-transform-duplicate-keys": "^7.10.4",
+                "@babel/plugin-transform-exponentiation-operator": "^7.10.4",
+                "@babel/plugin-transform-for-of": "^7.10.4",
+                "@babel/plugin-transform-function-name": "^7.10.4",
+                "@babel/plugin-transform-literals": "^7.10.4",
+                "@babel/plugin-transform-member-expression-literals": "^7.10.4",
+                "@babel/plugin-transform-modules-amd": "^7.10.4",
+                "@babel/plugin-transform-modules-commonjs": "^7.10.4",
+                "@babel/plugin-transform-modules-systemjs": "^7.10.4",
+                "@babel/plugin-transform-modules-umd": "^7.10.4",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
+                "@babel/plugin-transform-new-target": "^7.10.4",
+                "@babel/plugin-transform-object-super": "^7.10.4",
+                "@babel/plugin-transform-parameters": "^7.10.4",
+                "@babel/plugin-transform-property-literals": "^7.10.4",
+                "@babel/plugin-transform-regenerator": "^7.10.4",
+                "@babel/plugin-transform-reserved-words": "^7.10.4",
+                "@babel/plugin-transform-shorthand-properties": "^7.10.4",
+                "@babel/plugin-transform-spread": "^7.11.0",
+                "@babel/plugin-transform-sticky-regex": "^7.10.4",
+                "@babel/plugin-transform-template-literals": "^7.10.4",
+                "@babel/plugin-transform-typeof-symbol": "^7.10.4",
+                "@babel/plugin-transform-unicode-escapes": "^7.10.4",
+                "@babel/plugin-transform-unicode-regex": "^7.10.4",
+                "@babel/preset-modules": "^0.1.3",
+                "@babel/types": "^7.11.5",
+                "browserslist": "^4.12.0",
+                "core-js-compat": "^3.6.2",
+                "invariant": "^2.2.2",
+                "levenary": "^1.1.1",
+                "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/preset-modules": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+            "integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+                "@babel/plugin-transform-dotall-regex": "^7.4.4",
+                "@babel/types": "^7.4.4",
+                "esutils": "^2.0.2"
+            }
+        },
+        "@babel/preset-react": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.10.4.tgz",
+            "integrity": "sha512-BrHp4TgOIy4M19JAfO1LhycVXOPWdDbTRep7eVyatf174Hff+6Uk53sDyajqZPu8W1qXRBiYOfIamek6jA7YVw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-transform-react-display-name": "^7.10.4",
+                "@babel/plugin-transform-react-jsx": "^7.10.4",
+                "@babel/plugin-transform-react-jsx-development": "^7.10.4",
+                "@babel/plugin-transform-react-jsx-self": "^7.10.4",
+                "@babel/plugin-transform-react-jsx-source": "^7.10.4",
+                "@babel/plugin-transform-react-pure-annotations": "^7.10.4"
+            }
+        },
+        "@babel/preset-typescript": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.10.4.tgz",
+            "integrity": "sha512-SdYnvGPv+bLlwkF2VkJnaX/ni1sMNetcGI1+nThF1gyv6Ph8Qucc4ZZAjM5yZcE/AKRXIOTZz7eSRDWOEjPyRQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-transform-typescript": "^7.10.4"
+            }
+        },
         "@babel/runtime": {
             "version": "7.11.0",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.0.tgz",
             "integrity": "sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==",
             "requires": {
                 "regenerator-runtime": "^0.13.4"
+            }
+        },
+        "@babel/template": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+            "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/parser": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+            "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.11.5",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/parser": "^7.11.5",
+                "@babel/types": "^7.11.5",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.19"
+            },
+            "dependencies": {
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/types": {
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+            "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
             }
         },
         "@emotion/hash": {
@@ -711,6 +1893,68 @@
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
         },
+        "babel-loader": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
+            "integrity": "sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==",
+            "dev": true,
+            "requires": {
+                "find-cache-dir": "^2.1.0",
+                "loader-utils": "^1.4.0",
+                "mkdirp": "^0.5.3",
+                "pify": "^4.0.1",
+                "schema-utils": "^2.6.5"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.4",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+                    "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.5",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+                    "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                },
+                "schema-utils": {
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+                    "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.5",
+                        "ajv": "^6.12.4",
+                        "ajv-keywords": "^3.5.2"
+                    }
+                }
+            }
+        },
+        "babel-plugin-dynamic-import-node": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+            "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+            "dev": true,
+            "requires": {
+                "object.assign": "^4.1.0"
+            }
+        },
         "babel-runtime": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -909,6 +2153,7 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "fill-range": "^7.0.1"
             }
@@ -1543,6 +2788,15 @@
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
             "dev": true
         },
+        "convert-source-map": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
         "cookie": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
@@ -1605,6 +2859,24 @@
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
             "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
             "dev": true
+        },
+        "core-js-compat": {
+            "version": "3.6.5",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
+            "integrity": "sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==",
+            "dev": true,
+            "requires": {
+                "browserslist": "^4.8.5",
+                "semver": "7.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+                    "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+                    "dev": true
+                }
+            }
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -3332,6 +4604,7 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -3720,6 +4993,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
+        "gensync": {
+            "version": "1.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+            "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
             "dev": true
         },
         "get-caller-file": {
@@ -4430,6 +5709,15 @@
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "dev": true
         },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
         "ip": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -4609,7 +5897,8 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "is-obj": {
             "version": "2.0.0",
@@ -4745,6 +6034,12 @@
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
             }
+        },
+        "jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true
         },
         "json-parse-better-errors": {
             "version": "1.0.2",
@@ -4904,6 +6199,21 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
             "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ=="
+        },
+        "leven": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+            "dev": true
+        },
+        "levenary": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
+            "integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
+            "dev": true,
+            "requires": {
+                "leven": "^3.1.0"
+            }
         },
         "levn": {
             "version": "0.4.1",
@@ -5114,16 +6424,6 @@
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
             "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
             "dev": true
-        },
-        "micromatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-            "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-            "dev": true,
-            "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.0.5"
-            }
         },
         "miller-rabin": {
             "version": "4.0.1",
@@ -5950,7 +7250,8 @@
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
             "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "pify": {
             "version": "2.3.0",
@@ -6934,10 +8235,34 @@
                 "source-map": "~0.6.1"
             }
         },
+        "regenerate": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
+            "integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==",
+            "dev": true
+        },
+        "regenerate-unicode-properties": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+            "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.4.0"
+            }
+        },
         "regenerator-runtime": {
             "version": "0.13.7",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
             "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        },
+        "regenerator-transform": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+            "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.8.4"
+            }
         },
         "regex-not": {
             "version": "1.0.2",
@@ -6964,6 +8289,43 @@
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
             "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
             "dev": true
+        },
+        "regexpu-core": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
+            "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.4.0",
+                "regenerate-unicode-properties": "^8.2.0",
+                "regjsgen": "^0.5.1",
+                "regjsparser": "^0.6.4",
+                "unicode-match-property-ecmascript": "^1.0.4",
+                "unicode-match-property-value-ecmascript": "^1.2.0"
+            }
+        },
+        "regjsgen": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+            "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
+            "dev": true
+        },
+        "regjsparser": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
+            "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+            "dev": true,
+            "requires": {
+                "jsesc": "~0.5.0"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
+                }
+            }
         },
         "remove-trailing-separator": {
             "version": "1.1.0",
@@ -8253,6 +9615,12 @@
             "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
             "dev": true
         },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+            "dev": true
+        },
         "to-object-path": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -8290,6 +9658,7 @@
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "is-number": "^7.0.0"
             }
@@ -8299,27 +9668,6 @@
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
             "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
             "dev": true
-        },
-        "ts-loader": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-7.0.5.tgz",
-            "integrity": "sha512-zXypEIT6k3oTc+OZNx/cqElrsbBtYqDknf48OZos0NQ3RTt045fBIU8RRSu+suObBzYB355aIPGOe/3kj9h7Ig==",
-            "dev": true,
-            "requires": {
-                "chalk": "^2.3.0",
-                "enhanced-resolve": "^4.0.0",
-                "loader-utils": "^1.0.2",
-                "micromatch": "^4.0.0",
-                "semver": "^6.0.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
-            }
         },
         "tsconfig-paths": {
             "version": "3.9.0",
@@ -8389,6 +9737,34 @@
             "version": "3.9.7",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
             "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+            "dev": true
+        },
+        "unicode-canonical-property-names-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+            "dev": true
+        },
+        "unicode-match-property-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+            "dev": true,
+            "requires": {
+                "unicode-canonical-property-names-ecmascript": "^1.0.4",
+                "unicode-property-aliases-ecmascript": "^1.0.4"
+            }
+        },
+        "unicode-match-property-value-ecmascript": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+            "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
+            "dev": true
+        },
+        "unicode-property-aliases-ecmascript": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+            "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
             "dev": true
         },
         "union-value": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,14 @@
         "react-leaflet-draw": "^0.19.0"
     },
     "devDependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/plugin-proposal-class-properties": "^7.10.4",
+        "@babel/preset-env": "^7.11.5",
+        "@babel/preset-react": "^7.10.4",
+        "@babel/preset-typescript": "^7.10.4",
         "@typescript-eslint/eslint-plugin": "^2.32.0",
         "@typescript-eslint/parser": "^2.32.0",
+        "babel-loader": "^8.1.0",
         "copyfiles": "^2.0.0",
         "css-loader": "^2.1.1",
         "eslint": "^7.0.0",
@@ -53,7 +59,6 @@
         "react-docgen": "^2.20.1",
         "react-dom": "^16.9.0",
         "source-map-loader": "^0.2.4",
-        "ts-loader": "^7.0.3",
         "typescript": "^3.8.3",
         "url-loader": "^2.1.0",
         "webpack": "^4.41.2",

--- a/src/lib/components/Map/utils/map.js
+++ b/src/lib/components/Map/utils/map.js
@@ -89,7 +89,7 @@ export default class Map extends Component {
                     .join(" ")
             )
             .attr("fill", (d, i) => self.color(i))
-            .on("mousemove", (d, i) => {
+            .on("mousemove", function(d, i) {
                 self.emit("mousemove", {
                     x: d3.mouse(this)[0],
                     y: d3.mouse(this)[1],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,9 +66,9 @@ module.exports = (env, argv) => {
         module: {
             rules: [
                 {
-                    test: /\.(t|j)s?x?$/,
+                    test: /\.(ts|js)x?$/,
                     exclude: /node_modules/,
-                    use: { loader: "ts-loader" },
+                    loader: "babel-loader",
                 },
                 {
                     test: /\.css$/,


### PR DESCRIPTION
Closes #235.

For some reason, using `babel` to compile `javascript` + `typescript` instead of `ts-loader` (which [sometimes is recommended](https://iamturns.com/typescript-babel/) anyway due to e.g. faster compiling speed during development), the streamline animation works again.