### PR TITLE
Make typescript linter use a temporary folder for js output files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "build:js-demo": "webpack --mode production --entry ./src/demo/index.js",
         "build:py_and_r": "dash-generate-components ./src/lib/components webviz_subsurface_components -p package-info.json --r-prefix '' --ignore .*.js$",
         "build": "npm run build:js && npm run build:js-dev && npm run build:py_and_r",
-        "typecheck": "tsc",
+        "typecheck": "tsc --noEmit",
         "format": "eslint --fix *.js *json 'src/**/*.+(ts|tsx|js|jsx|json|css)'",
         "linting": "eslint *.js *.json 'src/**/*.+(ts|tsx|js|jsx|json|css)'",
         "validate": "npm run typecheck && npm run linting"


### PR DESCRIPTION
Place the javascript output files from the typescript linter in a `js_output` folder instead of `dist` as this causes problems when creating the python distribution.