### PR TITLE
Cleanup warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13655,6 +13655,16 @@
                 "ssri": "^6.0.1",
                 "unique-filename": "^1.1.1",
                 "y18n": "^4.0.0"
+            },
+            "dependencies": {
+                "ssri": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+                    "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
+                    "requires": {
+                        "figgy-pudding": "^3.5.1"
+                    }
+                }
             }
         },
         "cache-base": {
@@ -32028,14 +32038,6 @@
                 "tweetnacl": "~0.14.0"
             }
         },
-        "ssri": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-            "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
-            "requires": {
-                "figgy-pudding": "^3.5.1"
-            }
-        },
         "stable": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -35439,9 +35441,9 @@
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         },
         "y18n": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
         },
         "yallist": {
             "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30016,7 +30016,7 @@
         },
         "react-leaflet-draw": {
             "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/react-leaflet-draw/-/react-leaflet-draw-0.19.7.tgz",
+            "resolved": "https://registry.npmjs.org/react-leaflet-draw/-/react-leaflet-draw-0.19.0.tgz",
             "integrity": "sha512-aOB7Nqgl79l62L7vHxhdyKJD6ep+1Q+qTfnrYfmcgF+yK0A1lQA2fUv9N4C0HCbejcyiqx1XYchSCw9Q+Vtc3A==",
             "requires": {
                 "lodash-es": "^4.17.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3325,9 +3325,9 @@
             }
         },
         "@danmarshall/deckgl-typings": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@danmarshall/deckgl-typings/-/deckgl-typings-4.7.0.tgz",
-            "integrity": "sha512-s+4XuacALk61nLzENlyt/z9QX6H+IXo3hdeySFYiTM9tyqkKUL4Y8739NCvDLaub7vY+h1J7WVSCHhBdzkr9Fg==",
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/@danmarshall/deckgl-typings/-/deckgl-typings-4.7.2.tgz",
+            "integrity": "sha512-SxwZy3eOZl71fEGBZZkCQM5+eMy86kAAs/1PGHgxQrTPmIE80kZnX1THz0Lmmil5ugp5OnysZN5C1WUYFrIcAQ==",
             "requires": {
                 "@types/hammerjs": "^2.0.36",
                 "@types/react": "*",
@@ -3335,9 +3335,9 @@
             }
         },
         "@deck.gl/aggregation-layers": {
-            "version": "8.4.9",
-            "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-8.4.9.tgz",
-            "integrity": "sha512-wYCgP3xM9MpSki4yr3Zc6TaZeiTvuX4yyuRh+FR2k77IU60Y89TiPqS8Cz54p2kbZnKm/LvpypC2sHvJCaxIDQ==",
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-8.4.12.tgz",
+            "integrity": "sha512-t5Ws3MYjJJJc5rx4fxdOu1nQX1fg+sYGj7AkfruMtVetZpX00wMI1Gfl3c3duaFb33TFZKKTJcT4sPZ+BuszKw==",
             "requires": {
                 "@luma.gl/shadertools": "^8.4.1",
                 "@math.gl/web-mercator": "^3.4.2",
@@ -3345,30 +3345,30 @@
             }
         },
         "@deck.gl/carto": {
-            "version": "8.4.9",
-            "resolved": "https://registry.npmjs.org/@deck.gl/carto/-/carto-8.4.9.tgz",
-            "integrity": "sha512-aE837gecIE9CRNpc+05xME5Pl5n2kQVLsLaRwQ4M3DF3HK2/WbPJKk8v+0O+0GuPR+QbXTkDoF/iu7voqi8rfA==",
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/carto/-/carto-8.4.12.tgz",
+            "integrity": "sha512-XaPpqy9/SiXxVHLEkotIpNA+yJ16kVKU5Pl9A7aCRaifk8V9P67VRyfFn90ji4IOSro1arfE8AcKupLriQLt0w==",
             "requires": {
-                "@loaders.gl/loader-utils": "^2.3.9",
-                "@loaders.gl/mvt": "^2.3.9",
-                "@loaders.gl/tiles": "^2.3.9",
+                "@loaders.gl/loader-utils": "^2.3.13",
+                "@loaders.gl/mvt": "^2.3.13",
+                "@loaders.gl/tiles": "^2.3.13",
                 "@math.gl/web-mercator": "^3.4.2",
                 "cartocolor": "^4.0.2",
                 "d3-scale": "^3.2.3"
             },
             "dependencies": {
                 "d3-array": {
-                    "version": "2.11.0",
-                    "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.11.0.tgz",
-                    "integrity": "sha512-26clcwmHQEdsLv34oNKq5Ia9tQ26Y/4HqS3dQzF42QBUqymZJ+9PORcN1G52bt37NsL2ABoX4lvyYZc+A9Y0zw==",
+                    "version": "2.12.1",
+                    "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+                    "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
                     "requires": {
                         "internmap": "^1.0.0"
                     }
                 },
                 "d3-scale": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
-                    "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+                    "version": "3.2.4",
+                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.4.tgz",
+                    "integrity": "sha512-PG6gtpbPCFqKbvdBEswQcJcTzHC8VEd/XzezF5e68KlkT4/ggELw/nR1tv863jY6ufKTvDlzCMZvhe06codbbA==",
                     "requires": {
                         "d3-array": "^2.3.0",
                         "d3-format": "1 - 2",
@@ -3380,12 +3380,12 @@
             }
         },
         "@deck.gl/core": {
-            "version": "8.4.9",
-            "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.4.9.tgz",
-            "integrity": "sha512-qw++bJ2yoQIYq0iKr8YL0CzWHdiFxRITjgyRdp7I4b0WdFWqw7n4lz+r/07pJPuxXPs4qM/fpXQML+Ts6N38cg==",
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.4.12.tgz",
+            "integrity": "sha512-h0l/JzpNa3MlZTu+weQvlLWz0I0efJr8bNCFbbZnBDYxF5PKa+posChjABSAoPWYGotrpk4g1sv5JUBml54Dpw==",
             "requires": {
-                "@loaders.gl/core": "^2.3.9",
-                "@loaders.gl/images": "^2.3.9",
+                "@loaders.gl/core": "^2.3.13",
+                "@loaders.gl/images": "^2.3.13",
                 "@luma.gl/core": "^8.4.1",
                 "@math.gl/web-mercator": "^3.4.2",
                 "gl-matrix": "^3.0.0",
@@ -3395,24 +3395,24 @@
             }
         },
         "@deck.gl/extensions": {
-            "version": "8.4.9",
-            "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-8.4.9.tgz",
-            "integrity": "sha512-H6BwjKc3HeLF7K0DL3CLog4HRuEvvIJ/qzBRxq1rYMv6oGfLOTc9Bf9g9dqCRNp49Rku+xEaY6/5RWVsUSeq1A==",
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-8.4.12.tgz",
+            "integrity": "sha512-Z6TzFCNvVhZy0ME94auboVEk6P82TtPsl40RR9/FXfZ+M4Q/3wAlr13sryNrwSW0aL99MPYpCeBQSbbmLOVWrQ==",
             "requires": {
                 "@luma.gl/shadertools": "^8.4.1"
             }
         },
         "@deck.gl/geo-layers": {
-            "version": "8.4.9",
-            "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.4.9.tgz",
-            "integrity": "sha512-Z8qvbrHdEGSUthnJlH21938AryZDmmGmNAWi1SO/9WYuNLZgQA9NPmae4x/HD22ZnDBwuszz3RR7bzwHHLXsxQ==",
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.4.12.tgz",
+            "integrity": "sha512-w/I2dtX1pc85pWqeDhWwSLWVua4qKfpsxNShZWeTbwoW4E8hhUqLHNpRRdtyVJVOuTIN6ag2uvIHCJvRUE7/yA==",
             "requires": {
-                "@loaders.gl/3d-tiles": "^2.3.9",
-                "@loaders.gl/gis": "^2.3.9",
-                "@loaders.gl/loader-utils": "^2.3.9",
-                "@loaders.gl/mvt": "^2.3.9",
-                "@loaders.gl/terrain": "^2.3.9",
-                "@loaders.gl/tiles": "^2.3.9",
+                "@loaders.gl/3d-tiles": "^2.3.13",
+                "@loaders.gl/gis": "^2.3.13",
+                "@loaders.gl/loader-utils": "^2.3.13",
+                "@loaders.gl/mvt": "^2.3.13",
+                "@loaders.gl/terrain": "^2.3.13",
+                "@loaders.gl/tiles": "^2.3.13",
                 "@math.gl/culling": "^3.4.2",
                 "@math.gl/web-mercator": "^3.4.2",
                 "h3-js": "^3.6.0",
@@ -3421,49 +3421,49 @@
             }
         },
         "@deck.gl/google-maps": {
-            "version": "8.4.9",
-            "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-8.4.9.tgz",
-            "integrity": "sha512-pNKPavjrBIA02Dy4Q8iBIQ/tHwTeoGS3lHhlh+HJAE6CIQthNlhUF53aHtqEA/qBntb7GoreFqURK648gcbNjg=="
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-8.4.12.tgz",
+            "integrity": "sha512-YFbjqzBiCVm9FdGBDy20Ua2rQlUU9LdSd8Nu3lw39HC+LrvKSE32iLT0BkpeOmsqIA/uvSDPwmmQLkmOaZyTog=="
         },
         "@deck.gl/json": {
-            "version": "8.4.9",
-            "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-8.4.9.tgz",
-            "integrity": "sha512-gjv1P607MPsa5v6BiXIEg0JCs5VrLVNk4fXleiuuvxTpHVFr4/V4dRj2araTwLcGDZnP9kYH2/2xCsONCla86A==",
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-8.4.12.tgz",
+            "integrity": "sha512-aQU7bqAYV6qxg/COpwYN363tOvfxhiNw8GUBa03697ypt/BU3umfrLzZUA8BYW51MdjpECT+rLYjyHNCM/1RoA==",
             "requires": {
                 "d3-dsv": "^1.0.8",
                 "expression-eval": "^2.0.0"
             }
         },
         "@deck.gl/layers": {
-            "version": "8.4.9",
-            "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.4.9.tgz",
-            "integrity": "sha512-+zW26yaFZRfZuP+0HPlO+jeXmmhdE/h9fDDe777HOOw63xnu5MpaGmNIoAiyxjMkDX28WvN/9goy5S/ZbkBtPw==",
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.4.12.tgz",
+            "integrity": "sha512-Wmqwj1NMDyqM0Ip8RMCkjsLgiZx5nAcpbEklWRU1RXP5KGxM8nLqVkwphKzUXerCVNTrZB7DKxO+7+heubMzTg==",
             "requires": {
-                "@loaders.gl/images": "^2.3.9",
+                "@loaders.gl/images": "^2.3.13",
                 "@mapbox/tiny-sdf": "^1.1.0",
                 "@math.gl/polygon": "^3.4.2",
                 "earcut": "^2.0.6"
             }
         },
         "@deck.gl/mapbox": {
-            "version": "8.4.9",
-            "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-8.4.9.tgz",
-            "integrity": "sha512-ZQ9/T15ho6aD9d1mJkHP6fEQ39JpKtyplRlvMmbt3Nv2LiENqtbOR+45/o2f/D4vRRmGGCuIzj2q/D1gH8t68w=="
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-8.4.12.tgz",
+            "integrity": "sha512-hEXyGlHoLaCb1pXf+Ya0VHMleLy9ZEahXa8arUCw1wjQJe8ci4JJzOoxRDcsrac/pKSVtusWHGvCCgMLQTa8LA=="
         },
         "@deck.gl/mesh-layers": {
-            "version": "8.4.9",
-            "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.4.9.tgz",
-            "integrity": "sha512-pbwCJGGCm5KaC+o2cHubLf50SrZMqFplQyWtsSLS8Qgo2+iU50gZX20bLuv3LXQtu8ShoAMZmNVzYlRSovccAQ==",
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.4.12.tgz",
+            "integrity": "sha512-5l02mi754gs6Qhl/DNffNtAmiSh4D7THmnA5y9mmmNXOy4MnFjUJMv2D+x+iLUsUd1ZCN3dOE/rpPT1XzefhIQ==",
             "requires": {
-                "@loaders.gl/gltf": "^2.3.9",
+                "@loaders.gl/gltf": "^2.3.13",
                 "@luma.gl/experimental": "^8.4.1",
                 "@luma.gl/shadertools": "^8.4.1"
             }
         },
         "@deck.gl/react": {
-            "version": "8.4.9",
-            "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.4.9.tgz",
-            "integrity": "sha512-psm0rLZtUhm3CLT2Yz6QUYW2yv+AauuEAL9XaJLr8wU7y7CM00q/aHMVtCdSWRiPEHx6QZSs3hJlqxdBmo3VTA==",
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.4.12.tgz",
+            "integrity": "sha512-EzBkKbjGq1+HpzWqsr103X1hD5Z10pR3tne+MFAU0CtgRoGMCVjwVNfNVq8dGYnp8y/M3iE2AZ0pBt65pvvufw==",
             "requires": {
                 "prop-types": "^15.6.0"
             }
@@ -4218,118 +4218,118 @@
             }
         },
         "@loaders.gl/3d-tiles": {
-            "version": "2.3.12",
-            "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-2.3.12.tgz",
-            "integrity": "sha512-BetO25a6blfLjbuMHNga5kcyGIgvO39dtAtz+x4NOvA1uMGYYRHS4moSSkZ/K8bhKSy1RNUFB+fJ2zCTOSbyIw==",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-2.3.13.tgz",
+            "integrity": "sha512-WccDTlv/AJo5GJFEa6MIjk1H0294hTs8zhmEDq5mmdQ4B7la+4aWKmIfJmgCcIv8vWUkzQIuRIHTgxi0ShmUTw==",
             "requires": {
-                "@loaders.gl/core": "2.3.12",
-                "@loaders.gl/draco": "2.3.12",
-                "@loaders.gl/gltf": "2.3.12",
-                "@loaders.gl/loader-utils": "2.3.12",
-                "@loaders.gl/math": "2.3.12",
-                "@loaders.gl/tiles": "2.3.12",
+                "@loaders.gl/core": "2.3.13",
+                "@loaders.gl/draco": "2.3.13",
+                "@loaders.gl/gltf": "2.3.13",
+                "@loaders.gl/loader-utils": "2.3.13",
+                "@loaders.gl/math": "2.3.13",
+                "@loaders.gl/tiles": "2.3.13",
                 "@math.gl/core": "^3.3.0",
                 "@math.gl/geospatial": "^3.3.0",
                 "@probe.gl/stats": "^3.3.0"
             }
         },
         "@loaders.gl/core": {
-            "version": "2.3.12",
-            "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-2.3.12.tgz",
-            "integrity": "sha512-4BXsXVSuDwntp04FzUbrOCGY4XIBk+qH3/mFAvJnaUx8Vw37ug1OKJh+8OuSBBF08H0NFSD1hygZlLXdzLV9Pg==",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-2.3.13.tgz",
+            "integrity": "sha512-Hjm8eJjS/OUnaHrOSgXtE+qDg5V4Do0jIpp2u0Dv3CMxPrtd2TpwkDfAyZWmmbZew9rzqPoAVMINejS/ItWUeg==",
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "@loaders.gl/loader-utils": "2.3.12"
+                "@loaders.gl/loader-utils": "2.3.13"
             }
         },
         "@loaders.gl/draco": {
-            "version": "2.3.12",
-            "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-2.3.12.tgz",
-            "integrity": "sha512-CSNQ1ozn2AlF1geM4F6eHtHODFJzM9Uhrx9rYghoAv23N25h2DYqSzBKSET+z32IYmh0HY7VcvAgx1A/9R212Q==",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-2.3.13.tgz",
+            "integrity": "sha512-rePkoM/xpvNyjO2vvBRQ39Aa3tCpBFCWf/jheka4bFXnLJzy8X7ZGNXojZEsrdT0lAiHM+QrCeAWvtyDEujURA==",
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "@loaders.gl/loader-utils": "2.3.12",
+                "@loaders.gl/loader-utils": "2.3.13",
                 "draco3d": "^1.3.6"
             }
         },
         "@loaders.gl/gis": {
-            "version": "2.3.12",
-            "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-2.3.12.tgz",
-            "integrity": "sha512-hXYQJpQgcDCyK+4NhKz1NxhWyuz+4uTkmeAkhA5DK4Gie/3AAvesFOsS4VPl+jthGBFwSJxw/ElqE5CHnznRjg==",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-2.3.13.tgz",
+            "integrity": "sha512-i+hot7QeW53GhRwnvF5H65lsZYv4/ESbFuGtNy5TKivPaTIqn1oIFtLOku9Ntw5xTfky9qNNlbMPcsDMoniavQ==",
             "requires": {
-                "@loaders.gl/loader-utils": "2.3.12",
+                "@loaders.gl/loader-utils": "2.3.13",
                 "@mapbox/vector-tile": "^1.3.1",
                 "pbf": "^3.2.1"
             }
         },
         "@loaders.gl/gltf": {
-            "version": "2.3.12",
-            "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-2.3.12.tgz",
-            "integrity": "sha512-b1YUbuh7r6yr37RzUhRE/+qedPHKBcfHHPDdDNZvgFBmkYm6/dE/ZpFfywsZ4oSreHF+14lJeaAdzPU4Jw9Syw==",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-2.3.13.tgz",
+            "integrity": "sha512-V/GUMe1Gm8cEfKnp899l0Nu6rKycEbLidO9WYhlwbB5avcwrxltWRqoWvQKFKNCqJyH5neJbl8vDmaaeeELD3w==",
             "requires": {
-                "@loaders.gl/core": "2.3.12",
-                "@loaders.gl/draco": "2.3.12",
-                "@loaders.gl/images": "2.3.12",
-                "@loaders.gl/loader-utils": "2.3.12"
+                "@loaders.gl/core": "2.3.13",
+                "@loaders.gl/draco": "2.3.13",
+                "@loaders.gl/images": "2.3.13",
+                "@loaders.gl/loader-utils": "2.3.13"
             }
         },
         "@loaders.gl/images": {
-            "version": "2.3.12",
-            "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-2.3.12.tgz",
-            "integrity": "sha512-frqqt42+ZKcR6BHcHG6v0pzOO8DM9UcWHTK6iKpa2SdDYKWS2WAt3SAmspPOI33nJ8w0OA8DnYiF/2FalzuGqg==",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-2.3.13.tgz",
+            "integrity": "sha512-BBgLf17udhRnYwvsObAOM7jEeLBaeU3di1NyLhpTMa7WbG3jAnDlmy1BRue8wYfgVpWnmk18YubZtX6vCRrJnA==",
             "requires": {
-                "@loaders.gl/loader-utils": "2.3.12"
+                "@loaders.gl/loader-utils": "2.3.13"
             }
         },
         "@loaders.gl/loader-utils": {
-            "version": "2.3.12",
-            "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-2.3.12.tgz",
-            "integrity": "sha512-DBDEgqMMxRfOX8XguyzCTpUt1Bz1y+q41KHZ6S+896VXVGicb22LKWIYIwGKNtC9pb77JTbWjcSux2GPBVThkw==",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-2.3.13.tgz",
+            "integrity": "sha512-vXzH5CWG8pWjUEb7hUr6CM4ERj4NVRpA60OxvVv/OaZZ7hNN63+9/tSUA5IXD9QArWPWrFBnKnvE+5gg4WNqTg==",
             "requires": {
                 "@babel/runtime": "^7.3.1",
                 "@probe.gl/stats": "^3.3.0"
             }
         },
         "@loaders.gl/math": {
-            "version": "2.3.12",
-            "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-2.3.12.tgz",
-            "integrity": "sha512-SSOtH3l1bcTGOEIfPQhilCfAZUGQhjTaiUbnp4X7SVwp2C71lOy4sa2C5N0ZQMIfiHupW+sVG9t/5sq8bA5YYg==",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-2.3.13.tgz",
+            "integrity": "sha512-ewlpk+5NR+DWSDx7OIptcd+KaPRmwgOlSg/54p+pjw1oO0rqs7y8tv7s+KfYJX66rN7i9MiBaJ0JwfC0lrB09A==",
             "requires": {
-                "@loaders.gl/images": "2.3.12",
-                "@loaders.gl/loader-utils": "2.3.12",
+                "@loaders.gl/images": "2.3.13",
+                "@loaders.gl/loader-utils": "2.3.13",
                 "@math.gl/core": "^3.3.0"
             }
         },
         "@loaders.gl/mvt": {
-            "version": "2.3.12",
-            "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-2.3.12.tgz",
-            "integrity": "sha512-Px/XNP1wjzD4cIJBPewuveyhSh3CB5RMxSOoQEXO76NBhB2Gj/AYmVOYX2IcNbyKe3/YI31Zg/MDDxEleCisRg==",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-2.3.13.tgz",
+            "integrity": "sha512-Zi1Gc6XzxTY05tVbxMITvy6zUiBhMpMWvhPkaCcOfktblDMnhQTkIb9fVnhv7ioe4hId4rvuXDIUXhtrBTJEKQ==",
             "requires": {
-                "@loaders.gl/gis": "2.3.12",
-                "@loaders.gl/loader-utils": "2.3.12",
+                "@loaders.gl/gis": "2.3.13",
+                "@loaders.gl/loader-utils": "2.3.13",
                 "@mapbox/point-geometry": "~0.1.0",
                 "@mapbox/vector-tile": "^1.3.1",
                 "pbf": "^3.2.1"
             }
         },
         "@loaders.gl/terrain": {
-            "version": "2.3.12",
-            "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-2.3.12.tgz",
-            "integrity": "sha512-+G+HEXYUJe7QVhYBPr2nrlPPQddwLnoyJb2sv5LuSg6rXr71Da/kR57wxjaD1EG1kmbEL1katKR1w5D0XHkxeg==",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-2.3.13.tgz",
+            "integrity": "sha512-sZi/CMcNxKbcv7F8pk0PLX5P0o11Sy8DzOk4MB0mRe4XM1ITeiaXf8L6JZkOC3HBdBOzNlId6N3f32fK9OHPnw==",
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "@loaders.gl/loader-utils": "2.3.12",
+                "@loaders.gl/loader-utils": "2.3.13",
                 "@mapbox/martini": "^0.2.0"
             }
         },
         "@loaders.gl/tiles": {
-            "version": "2.3.12",
-            "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-2.3.12.tgz",
-            "integrity": "sha512-SiF726dTDZPS97+BiSLlA780hIKMV0zpB5Ch29NMFZC37G0YIuInQS8YhAFANK+MjEPZjrhpjiAF/bTLmknAOw==",
+            "version": "2.3.13",
+            "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-2.3.13.tgz",
+            "integrity": "sha512-3ZSlMgcPTo5lCnvKw/is5dvTayzvX+wi6n1u4lEe4gt8Ml9KYp/e45hOqp6qXR6SckO2+ohBXOzQP2e8ZhRxXQ==",
             "requires": {
-                "@loaders.gl/core": "2.3.12",
-                "@loaders.gl/loader-utils": "2.3.12",
-                "@loaders.gl/math": "2.3.12",
+                "@loaders.gl/core": "2.3.13",
+                "@loaders.gl/loader-utils": "2.3.13",
+                "@loaders.gl/math": "2.3.13",
                 "@math.gl/core": "^3.3.0",
                 "@math.gl/culling": "^3.3.0",
                 "@math.gl/geospatial": "^3.3.0",
@@ -4519,16 +4519,6 @@
             "requires": {
                 "@babel/runtime": "^7.12.0",
                 "gl-matrix": "^3.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime": {
-                    "version": "7.13.9",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
-                    "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
-                    "requires": {
-                        "regenerator-runtime": "^0.13.4"
-                    }
-                }
             }
         },
         "@math.gl/culling": {
@@ -4539,16 +4529,6 @@
                 "@babel/runtime": "^7.12.0",
                 "@math.gl/core": "3.4.2",
                 "gl-matrix": "^3.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime": {
-                    "version": "7.13.9",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
-                    "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
-                    "requires": {
-                        "regenerator-runtime": "^0.13.4"
-                    }
-                }
             }
         },
         "@math.gl/geospatial": {
@@ -4559,16 +4539,6 @@
                 "@babel/runtime": "^7.12.0",
                 "@math.gl/core": "3.4.2",
                 "gl-matrix": "^3.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime": {
-                    "version": "7.13.9",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
-                    "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
-                    "requires": {
-                        "regenerator-runtime": "^0.13.4"
-                    }
-                }
             }
         },
         "@math.gl/polygon": {
@@ -4586,16 +4556,6 @@
             "requires": {
                 "@babel/runtime": "^7.12.0",
                 "gl-matrix": "^3.0.0"
-            },
-            "dependencies": {
-                "@babel/runtime": {
-                    "version": "7.13.9",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
-                    "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
-                    "requires": {
-                        "regenerator-runtime": "^0.13.4"
-                    }
-                }
             }
         },
         "@mdx-js/loader": {
@@ -5014,11 +4974,11 @@
             }
         },
         "@reduxjs/toolkit": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.5.0.tgz",
-            "integrity": "sha512-E/FUraRx+8guw9Hlg/Ja8jI/hwCrmIKed8Annt9YsZw3BQp+F24t5I5b2OWR6pkEHY4hn1BgP08FrTZFRKsdaQ==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.5.1.tgz",
+            "integrity": "sha512-PngZKuwVZsd+mimnmhiOQzoD0FiMjqVks6ituO1//Ft5UEX5Ca9of13NEjo//pU22Jk7z/mdXVsmDfgsig1osA==",
             "requires": {
-                "immer": "^8.0.0",
+                "immer": "^8.0.1",
                 "redux": "^4.0.0",
                 "redux-thunk": "^2.3.0",
                 "reselect": "^4.0.0"
@@ -11912,9 +11872,9 @@
             }
         },
         "ajv": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.1.tgz",
-            "integrity": "sha512-+nu0HDv7kNSOua9apAVc979qd932rrZeb3WOvoiD31A/p1mIE5/9bN2027pE2rOPYEdS3UHzsvof4hY+lM9/WQ==",
+            "version": "7.2.4",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
+            "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -14698,13 +14658,6 @@
                 "camelize": "^1.0.0",
                 "css-color-keywords": "^1.0.0",
                 "postcss-value-parser": "^4.0.2"
-            },
-            "dependencies": {
-                "postcss-value-parser": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-                    "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
-                }
             }
         },
         "css-tree": {
@@ -15197,21 +15150,21 @@
             "dev": true
         },
         "deck.gl": {
-            "version": "8.4.9",
-            "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-8.4.9.tgz",
-            "integrity": "sha512-HstzNbKby7paKGlOIpFNa7Jl9+l0DGoxbswIL/amljlGrj7I7bRfeA7yLGFQNqVio/2SHg71lQd7LXrq4JToPQ==",
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-8.4.12.tgz",
+            "integrity": "sha512-noom3PkUlCgSnOJB3Li4ev2E5ISPLaYmNa1nG0r8yvUcWYHTk6mzNPx8eaw7V1ZORJnCslNsSn24W0zkIsLGOA==",
             "requires": {
-                "@deck.gl/aggregation-layers": "8.4.9",
-                "@deck.gl/carto": "8.4.9",
-                "@deck.gl/core": "8.4.9",
-                "@deck.gl/extensions": "8.4.9",
-                "@deck.gl/geo-layers": "8.4.9",
-                "@deck.gl/google-maps": "8.4.9",
-                "@deck.gl/json": "8.4.9",
-                "@deck.gl/layers": "8.4.9",
-                "@deck.gl/mapbox": "8.4.9",
-                "@deck.gl/mesh-layers": "8.4.9",
-                "@deck.gl/react": "8.4.9"
+                "@deck.gl/aggregation-layers": "8.4.12",
+                "@deck.gl/carto": "8.4.12",
+                "@deck.gl/core": "8.4.12",
+                "@deck.gl/extensions": "8.4.12",
+                "@deck.gl/geo-layers": "8.4.12",
+                "@deck.gl/google-maps": "8.4.12",
+                "@deck.gl/json": "8.4.12",
+                "@deck.gl/layers": "8.4.12",
+                "@deck.gl/mapbox": "8.4.12",
+                "@deck.gl/mesh-layers": "8.4.12",
+                "@deck.gl/react": "8.4.12"
             }
         },
         "decode-uri-component": {
@@ -23149,9 +23102,9 @@
             }
         },
         "h3-js": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-3.7.0.tgz",
-            "integrity": "sha512-EcH/qGU4khZsAEG39Uu8MvaCing0JFcuoe3K4Xmg5MofDIu1cNJl7z2AQS8ggvXGxboiLJqsGirhEqFKdd2gAA=="
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-3.7.1.tgz",
+            "integrity": "sha512-EManlaXSd8BKiuw7hnkg4grpzEjvf+aGkw33upVrO+iGenPHz+tVurgx5ZMTVBSV8lkbSUm44tHrs5biX7UTlQ=="
         },
         "hammerjs": {
             "version": "2.0.8",
@@ -23944,9 +23897,9 @@
             }
         },
         "internmap": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.0.tgz",
-            "integrity": "sha512-SdoDWwNOTE2n4JWUsLn4KXZGuZPjPF9yyOGc8bnfWnBQh7BD/l80rzSznKc/r4Y0aQ7z3RTk9X+tV4tHBpu+dA=="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+            "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
         },
         "interpret": {
             "version": "1.4.0",
@@ -30062,11 +30015,19 @@
             }
         },
         "react-leaflet-draw": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/react-leaflet-draw/-/react-leaflet-draw-0.19.0.tgz",
-            "integrity": "sha512-aOB7Nqgl79l62L7vHxhdyKJD6ep+1Q+qTfnrYfmcgF+yK0A1lQA2fUv9N4C0HCbejcyiqx1XYchSCw9Q+Vtc3A==",
+            "version": "0.19.7",
+            "resolved": "https://registry.npmjs.org/react-leaflet-draw/-/react-leaflet-draw-0.19.7.tgz",
+            "integrity": "sha512-wPjsoUYUrdwKX6zLcVdJmmqs18Nsdqy0VhsI5fvYvmTPTp5ZE4MSU9Zdyeion6lUaP8pEkWRizmLHCwbt1b5Mg==",
             "requires": {
-                "lodash-es": "^4.17.10"
+                "fast-deep-equal": "^2.0.1",
+                "lodash-es": "^4.17.15"
+            },
+            "dependencies": {
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+                }
             }
         },
         "react-lifecycles-compat": {
@@ -30104,25 +30065,16 @@
             }
         },
         "react-redux": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.2.tgz",
-            "integrity": "sha512-8+CQ1EvIVFkYL/vu6Olo7JFLWop1qRUeb46sGtIMDCSpgwPQq8fPLpirIB0iTqFe9XYEFPHssdX8/UwN6pAkEA==",
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.3.tgz",
+            "integrity": "sha512-ZhAmQ1lrK+Pyi0ZXNMUZuYxYAZd59wFuVDGUt536kSGdD0ya9Q7BfsE95E3TsFLE3kOSFp5m6G5qbatE+Ic1+w==",
             "requires": {
                 "@babel/runtime": "^7.12.1",
+                "@types/react-redux": "^7.1.16",
                 "hoist-non-react-statics": "^3.3.2",
                 "loose-envify": "^1.4.0",
                 "prop-types": "^15.7.2",
                 "react-is": "^16.13.1"
-            },
-            "dependencies": {
-                "@babel/runtime": {
-                    "version": "7.12.13",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
-                    "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
-                    "requires": {
-                        "regenerator-runtime": "^0.13.4"
-                    }
-                }
             }
         },
         "react-refresh": {
@@ -30132,9 +30084,9 @@
             "dev": true
         },
         "react-resize-detector": {
-            "version": "6.3.2",
-            "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-6.3.2.tgz",
-            "integrity": "sha512-Lji17RPaSz81ycOC50WF2Tz8GFAXImR8qRnZ5oGO7aZoGS9vcgyou5F8QBswZTF2mcTJU3QmVzipiOiEWKr59Q==",
+            "version": "6.6.4",
+            "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-6.6.4.tgz",
+            "integrity": "sha512-sAAh8TmOp59MFs2HR7D1VGbAq+zL+2klQhFbkXOH5Gy/EBEyHGiWXWMStoB+axSYr/Xw54owg6QRGSFj3z0dew==",
             "requires": {
                 "@types/resize-observer-browser": "^0.1.5",
                 "lodash.debounce": "^4.0.8",
@@ -32569,16 +32521,16 @@
             }
         },
         "styled-components": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.2.1.tgz",
-            "integrity": "sha512-sBdgLWrCFTKtmZm/9x7jkIabjFNVzCUeKfoQsM6R3saImkUnjx0QYdLwJHBjY9ifEcmjDamJDVfknWm1yxZPxQ==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.2.3.tgz",
+            "integrity": "sha512-BlR+KrLW3NL1yhvEB+9Nu9Dt51CuOnHoxd+Hj+rYPdtyR8X11uIW9rvhpy3Dk4dXXBsiW1u5U78f00Lf/afGoA==",
             "requires": {
                 "@babel/helper-module-imports": "^7.0.0",
                 "@babel/traverse": "^7.4.5",
                 "@emotion/is-prop-valid": "^0.8.8",
                 "@emotion/stylis": "^0.8.4",
                 "@emotion/unitless": "^0.7.4",
-                "babel-plugin-styled-components": ">= 1",
+                "babel-plugin-styled-components": ">= 1.12.0",
                 "css-to-react-native": "^3.0.0",
                 "hoist-non-react-statics": "^3.0.0",
                 "shallowequal": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30015,19 +30015,11 @@
             }
         },
         "react-leaflet-draw": {
-            "version": "0.19.7",
+            "version": "0.19.0",
             "resolved": "https://registry.npmjs.org/react-leaflet-draw/-/react-leaflet-draw-0.19.7.tgz",
-            "integrity": "sha512-wPjsoUYUrdwKX6zLcVdJmmqs18Nsdqy0VhsI5fvYvmTPTp5ZE4MSU9Zdyeion6lUaP8pEkWRizmLHCwbt1b5Mg==",
+            "integrity": "sha512-aOB7Nqgl79l62L7vHxhdyKJD6ep+1Q+qTfnrYfmcgF+yK0A1lQA2fUv9N4C0HCbejcyiqx1XYchSCw9Q+Vtc3A==",
             "requires": {
-                "fast-deep-equal": "^2.0.1",
-                "lodash-es": "^4.17.15"
-            },
-            "dependencies": {
-                "fast-deep-equal": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-                }
+                "lodash-es": "^4.17.10"
             }
         },
         "react-lifecycles-compat": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
         "build": "npm run build:js && npm run build:js-dev && npm run build:py_and_r",
         "typecheck": "tsc --noEmit",
         "format": "eslint --fix *.js *json 'src/**/*.+(ts|tsx|js|jsx|json|css)'",
-        "linting": "eslint *.js *.json 'src/**/*.+(ts|tsx|js|jsx|json|css)'",
-        "validate": "npm run typecheck && npm run linting",
+        "lint": "eslint *.js *.json 'src/**/*.+(ts|tsx|js|jsx|json|css)'",
+        "validate": "npm run typecheck && npm run lint",
         "setup_deckgl_types": "cd ./node_modules/@danmarshall/deckgl-typings/ && indefinitely-typed --folder deck.gl__aggregation-layers --folder deck.gl__core --folder deck.gl__extensions --folder deck.gl__geo-layers --folder deck.gl__google-maps --folder deck.gl__json --folder deck.gl__layers --folder deck.gl__mapbox --folder deck.gl__mesh-layers --folder deck.gl__react --folder deck.gl --folder luma.gl__constants --folder luma.gl__core --folder luma.gl__gltools --folder luma.gl__webgl-state-tracker --folder luma.gl__webgl --folder math.gl__core --folder math.gl",
         "storybook": "start-storybook -p 6006",
         "build-storybook": "build-storybook",
@@ -107,7 +107,8 @@
         "url-loader": "^4.1.1",
         "webpack": "^4.41.2",
         "webpack-cli": "^3.3.7",
-        "webpack-dev-server": "^3.11.0"
+        "webpack-dev-server": "^3.11.0",
+        "y18n": "^4.0.1"
     },
     "engines": {
         "node": ">=14.16.0",

--- a/package.json
+++ b/package.json
@@ -107,8 +107,7 @@
         "url-loader": "^4.1.1",
         "webpack": "^4.41.2",
         "webpack-cli": "^3.3.7",
-        "webpack-dev-server": "^3.11.0",
-        "y18n": "^4.0.1"
+        "webpack-dev-server": "^3.11.0"
     },
     "engines": {
         "node": ">=14.16.0",

--- a/src/lib/components/DeckGLMap/Map.tsx
+++ b/src/lib/components/DeckGLMap/Map.tsx
@@ -5,6 +5,10 @@ import DeckGL from "@deck.gl/react";
 
 import Coords, { CoordsInfo } from "./components/Coords";
 import JSON_CONVERTER_CONFIGURATION from "./configuration";
+import { PickInfo } from "deck.gl";
+
+import { WellDataType } from "./layers/wells/wellsLayer";
+import { PropertyMapPickInfo } from "./layers/utils/propertyMapTools";
 
 export interface MapProps {
     id: string;
@@ -24,7 +28,7 @@ const Map: React.FC<MapProps> = (props: MapProps) => {
     }, [props.deckglSpec]);
 
     const [coordsInfo, setCoordsInfo] = React.useState<CoordsInfo | null>(null);
-    const extractCoords = React.useCallback((pickInfo) => {
+    const extractCoords = React.useCallback((pickInfo: PickInfo<unknown>) => {
         const xy = pickInfo.coordinate;
         if (!xy) {
             setCoordsInfo(null);
@@ -37,10 +41,9 @@ const Map: React.FC<MapProps> = (props: MapProps) => {
 
         // TODO: modify this to support multiple property layers, once this issue is fixed:
         // https://github.com/visgl/deck.gl/issues/5576
-        const zValue = pickInfo?.propertyValue;
-        const zLayerId = pickInfo?.layer?.id;
+        const zValue = (pickInfo as PropertyMapPickInfo).propertyValue;
         if (zValue) {
-            coords.z = [{ value: zValue, layerId: zLayerId }];
+            coords.z = [{ value: zValue, layerId: pickInfo.layer.id }];
         }
         setCoordsInfo(coords);
     }, []);
@@ -54,10 +57,10 @@ const Map: React.FC<MapProps> = (props: MapProps) => {
                     getCursor={({ isDragging }): string =>
                         isDragging ? "grabbing" : "default"
                     }
-                    getTooltip={(pickInfo: any): string | undefined => {
-                        return pickInfo?.object?.properties?.name;
+                    getTooltip={(info: PickInfo<unknown>): string | null => {
+                        return (info.object as WellDataType)?.properties.name;
                     }}
-                    onHover={(pickInfo: any): void => {
+                    onHover={(pickInfo: PickInfo<unknown>): void => {
                         extractCoords(pickInfo);
                     }}
                 >

--- a/src/lib/components/DeckGLMap/layers/wells/wellsLayer.ts
+++ b/src/lib/components/DeckGLMap/layers/wells/wellsLayer.ts
@@ -1,6 +1,7 @@
 import { CompositeLayer } from "@deck.gl/core";
-import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
 import { GeoJsonLayer, GeoJsonLayerProps } from "@deck.gl/layers";
+
+import { CompositeLayerProps } from "@deck.gl/core/lib/composite-layer";
 import { RGBAColor } from "@deck.gl/core/utils/color";
 
 export interface WellsLayerProps<D> extends CompositeLayerProps<D> {
@@ -9,7 +10,7 @@ export interface WellsLayerProps<D> extends CompositeLayerProps<D> {
     outline: boolean;
 }
 
-interface WellDataType {
+export interface WellDataType {
     type: string;
     geometry: Record<string, unknown>;
     properties: {

--- a/src/lib/components/WellCompletions/components/Settings/__snapshots__/HideZeroCompletionsSwitch.test.tsx.snap
+++ b/src/lib/components/WellCompletions/components/Settings/__snapshots__/HideZeroCompletionsSwitch.test.tsx.snap
@@ -2,26 +2,26 @@
 
 exports[`test hide zero completions switch snapshot test 1`] = `
 <label
-  className="sc-dUrnRO eauNHr"
+  className="sc-dUbuoE byrORV"
 >
   <input
     checked={false}
-    className="sc-fXoxut sc-Fyfyc gyilmq bWImoY"
+    className="sc-fXEqXD sc-FNZbm fgxrku frkXXs"
     onChange={[Function]}
     type="checkbox"
   />
   <span
-    className="sc-dWdcrH sc-bQdQlF fYDgBx fYcyWn"
+    className="sc-dVNiOx sc-bQtJOP MToBH eWpThv"
   >
     <span
-      className="sc-eFubAy eAScPd"
+      className="sc-eFehXo dQSnKG"
     />
     <span
-      className="sc-fmlJLJ iDQfFa"
+      className="sc-fmBDoT boDmd"
     />
   </span>
   <span
-    className="sc-httYMd bQQtEf"
+    className="sc-htJSpn dxxpaC"
   >
     Filter by completions
   </span>

--- a/src/lib/components/WellCompletions/components/Settings/__snapshots__/RangeDisplayModeSelector.test.tsx.snap
+++ b/src/lib/components/WellCompletions/components/Settings/__snapshots__/RangeDisplayModeSelector.test.tsx.snap
@@ -2,20 +2,20 @@
 
 exports[`test range display mode selector snapshot test 1`] = `
 <div
-  className="sc-iWFSnp hjdvhV makeStyles-root-1"
+  className="sc-iWVLQz eCHTEl makeStyles-root-1"
 >
   <label
-    className="sc-fFubgz hrDuXp"
+    className="sc-fFehDp jthYlw"
     htmlFor="range-display-mode-selector"
   >
     <span
-      className="sc-bkzZxe fEPEPX"
+      className="sc-bkkfTU bgnqzc"
     >
       Range Display Mode
     </span>
   </label>
   <select
-    className="sc-fybufo ekzYQN"
+    className="sc-fyrnIy hsTrOV"
     disabled={false}
     id="range-display-mode-selector"
     multiple={false}

--- a/src/lib/components/WellCompletions/utils/dataUtil.ts
+++ b/src/lib/components/WellCompletions/utils/dataUtil.ts
@@ -1,5 +1,5 @@
 import { Data, RangeMode, RangeModes, Well, Zone } from "../redux/types";
-export const preprocessData = (data: any): Data => {
+export const preprocessData = (data: Data): Data => {
     return {
         ...data,
         wells: data.wells.map((well) => {


### PR DESCRIPTION
* Cleanup last few eslint warnings
* Rename `linting` to `lint`, for consistency with the other commands
* Run `npm update` to update `y18n` and get rid of the security vulnerability