### PR TITLE
Minor fix Dash WellCompletion build and example

### DIFF
--- a/examples/example_well_completions.py
+++ b/examples/example_well_completions.py
@@ -11,7 +11,7 @@ import dash_html_components as html
 
 import webviz_subsurface_components
 
-with open("../src/demo/example-data/well-completions.json", "r") as json_file:
+with open("../src/demo/example-data/well-completions-with-attr.json", "r") as json_file:
     data = json.load(json_file)
 
 app = dash.Dash(__name__)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "build:js": "webpack --mode production",
         "build:js-dev": "webpack --mode development",
         "build:js-demo": "webpack --mode production --entry ./src/demo/index.js",
-        "build:py_and_r": "dash-generate-components ./src/lib/components webviz_subsurface_components -p package-info.json --r-prefix '' --ignore .*.js$",
+        "build:py_and_r": "dash-generate-components ./src/lib/components webviz_subsurface_components -p package-info.json --r-prefix '' --ignore '(.js|.stories.jsx)$'",
         "build": "npm run build:js && npm run build:js-dev && npm run build:py_and_r",
         "typecheck": "tsc --noEmit",
         "format": "eslint --fix *.js *json 'src/**/*.+(ts|tsx|js|jsx|json|css)'",


### PR DESCRIPTION
- [X] Filter out `*.stories.jsx` (used by Storybook) such that Dash does not try to build components from those files.
- [X] Update Python `WellCompletion` example with new filename for the test data.