### PR TITLE
Add `resources` prop to the map component

### DIFF
--- a/examples/example_deckgl_map.py
+++ b/examples/example_deckgl_map.py
@@ -82,6 +82,9 @@ if __name__ == "__main__":
 
     deckgl_map_left = webviz_subsurface_components.DeckGLMap(
         id="DeckGL-Map-Left",
+        resources={
+            "propertyMap": map_data,
+        },
         deckglSpec={
             "initialViewState": {
                 "target": [bounds[0] + width / 2, bounds[1] + height / 2, 0],
@@ -92,7 +95,7 @@ if __name__ == "__main__":
                     "@@type": "ColormapLayer",
                     "id": "colormap-layer",
                     "bounds": bounds,
-                    "image": map_data,
+                    "image": "@@#resources.propertyMap",
                     "colormap": COLORMAP,
                     "valueRange": [min_value, max_value],
                     "pickable": True,
@@ -103,7 +106,7 @@ if __name__ == "__main__":
                     "bounds": bounds,
                     "opacity": 1.0,
                     "valueRange": [min_value, max_value],
-                    "image": map_data,
+                    "image": "@@#resources.propertyMap",
                 },
                 {
                     "@@type": "DrawingLayer",
@@ -139,7 +142,7 @@ if __name__ == "__main__":
                     "@@type": "ColormapLayer",
                     "id": "colormap-layer",
                     "bounds": bounds,
-                    "image": map_data,
+                    "image": "@@#resources.propertyMap",
                     "colormap": COLORMAP,
                     "valueRange": [min_value, max_value],
                     "pickable": True,
@@ -150,7 +153,7 @@ if __name__ == "__main__":
                     "bounds": bounds,
                     "opacity": 1.0,
                     "valueRange": [min_value, max_value],
-                    "image": map_data,
+                    "image": "@@#resources.propertyMap",
                 },
                 {
                     "@@type": "DrawingLayer",

--- a/src/demo/example-data/deckgl-map.json
+++ b/src/demo/example-data/deckgl-map.json
@@ -1,5 +1,8 @@
 [
   {
+    "resources": {
+      "propertyMap": "https://i.imgur.com/Dx8eseE.png"
+    },
     "deckglSpec": {
       "initialViewState": {
         "target": [
@@ -19,7 +22,7 @@
             437720,
             6481113
           ],
-          "image": "https://i.imgur.com/Dx8eseE.png",
+          "image": "@@#resources.propertyMap",
           "colormap": "https://cdn.jsdelivr.net/gh/kylebarron/deck.gl-raster/assets/colormaps/plasma.png",
           "valueRange": [
             2782,
@@ -41,7 +44,7 @@
             3513
           ],
           "opacity": 1.0,
-          "image": "https://i.imgur.com/Dx8eseE.png"
+          "image": "@@#resources.propertyMap"
         },
         {
           "@@type": "WellsLayer",

--- a/src/lib/components/DeckGLMap/DeckGLMap.jsx
+++ b/src/lib/components/DeckGLMap/DeckGLMap.jsx
@@ -22,6 +22,14 @@ DeckGLMap.propTypes = {
     deckglSpec: PropTypes.object,
 
     /**
+     * Resource dictionary made available in the DeckGL specification as an enum.
+     * The values can be accessed like this: `"@@#resources.resourceId"`, where
+     * `resourceId` is the key in the `resources` dict. For more information,
+     * see the DeckGL documentation on enums in the json spec: https://deck.gl/docs/api-reference/json/conversion-reference#enumerations-and-using-the--prefix
+     */
+    resources: PropTypes.object,
+
+    /**
      * Show or hide the coordinates component. True by default.
      */
     showCoords: PropTypes.bool,

--- a/src/lib/components/DeckGLMap/Map.tsx
+++ b/src/lib/components/DeckGLMap/Map.tsx
@@ -4,7 +4,7 @@ import { JSONConfiguration, JSONConverter } from "@deck.gl/json";
 import DeckGL from "@deck.gl/react";
 
 import Coords, { CoordsInfo } from "./components/Coords";
-import JSON_CONVERTER_CONFIGURATION from "./configuration";
+import JSON_CONVERTER_CONFIG from "./configuration";
 import { PickInfo } from "deck.gl";
 
 import { WellDataType } from "./layers/wells/wellsLayer";
@@ -13,6 +13,7 @@ import { PropertyMapPickInfo } from "./layers/utils/propertyMapTools";
 export interface MapProps {
     id: string;
     deckglSpec: Record<string, unknown>;
+    resources: Record<string, string>;
     showCoords: boolean;
     setProps: (props: Record<string, unknown>) => void;
 }
@@ -20,9 +21,10 @@ export interface MapProps {
 const Map: React.FC<MapProps> = (props: MapProps) => {
     const [deckglSpec, setDeckglSpec] = React.useState(null);
     React.useEffect(() => {
-        const configuration = new JSONConfiguration(
-            JSON_CONVERTER_CONFIGURATION
-        );
+        if (props.resources) {
+            JSON_CONVERTER_CONFIG.enumerations["resources"] = props.resources;
+        }
+        const configuration = new JSONConfiguration(JSON_CONVERTER_CONFIG);
         const jsonConverter = new JSONConverter({ configuration });
 
         const setLayerProps = (layerId, newLayerProps) => {

--- a/src/lib/components/DeckGLMap/Map.tsx
+++ b/src/lib/components/DeckGLMap/Map.tsx
@@ -13,7 +13,7 @@ import { PropertyMapPickInfo } from "./layers/utils/propertyMapTools";
 export interface MapProps {
     id: string;
     deckglSpec: Record<string, unknown>;
-    resources: Record<string, string>;
+    resources: Record<string, unknown>;
     showCoords: boolean;
     setProps: (props: Record<string, unknown>) => void;
 }


### PR DESCRIPTION
Data can be specified in the `resources` dict and referenced from the DeckGL spec with the following syntax: `"@@#resources.resourceId"`.