### PR TITLE
Better align bin `x` positions with input data in `PriorPosteriorDistribution`

### DIFF
--- a/src/lib/components/PriorPosteriorDistribution/utils/prior_posterior_distribution.js
+++ b/src/lib/components/PriorPosteriorDistribution/utils/prior_posterior_distribution.js
@@ -56,14 +56,9 @@ class D3PriorPosterior {
             ...this.data.values.map((values) => Math.max(...values))
         );
 
-        this.xscale_addition = (this.global_max - this.global_min) * 0.05;
-
         this.x_scale = d3
             .scaleLinear()
-            .domain([
-                this.global_min - this.xscale_addition,
-                this.global_max + this.xscale_addition,
-            ])
+            .domain([this.global_min, this.global_max])
             .range([0, this.width_plot]);
 
         this.color_scale = d3
@@ -96,7 +91,13 @@ class D3PriorPosterior {
         const histogram = d3
             .histogram()
             .domain(this.x_scale.domain())
-            .thresholds(this.x_scale.ticks(this.number_bins));
+            .thresholds(
+                d3.range(
+                    this.global_min,
+                    this.global_max,
+                    (this.global_max - this.global_min) / this.number_bins
+                )
+            );
 
         this.bins = this.data.values.map((values) => histogram(values));
 

--- a/src/lib/components/PriorPosteriorDistribution/utils/prior_posterior_distribution.js
+++ b/src/lib/components/PriorPosteriorDistribution/utils/prior_posterior_distribution.js
@@ -56,9 +56,14 @@ class D3PriorPosterior {
             ...this.data.values.map((values) => Math.max(...values))
         );
 
+        this.xscale_addition = (this.global_max - this.global_min) * 0.05;
+
         this.x_scale = d3
             .scaleLinear()
-            .domain([this.global_min, this.global_max])
+            .domain([
+                this.global_min - this.xscale_addition,
+                this.global_max + this.xscale_addition,
+            ])
             .range([0, this.width_plot]);
 
         this.color_scale = d3


### PR DESCRIPTION
Bug fix to avoid that histogram bins are cut off in the PriorPosteriorDistribution component.  This is easiest accomplished by increasing the plots x range compared to the data range. 

Closes #274 