### PR TITLE
Adjusted to new `SmartNodeSelector`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@types/react-dom": "^17.0.3",
                 "@types/react-redux": "^7.1.15",
                 "@types/react-resize-detector": "^5.0.0",
-                "@webviz/core-components": "^0.4.1",
+                "@webviz/core-components": "^0.5.0",
                 "ajv": "^7.2.1",
                 "clsx": "^1.1.1",
                 "d3": "^5.11.0",
@@ -10103,8 +10103,9 @@
             }
         },
         "node_modules/@webviz/core-components": {
-            "version": "0.4.1",
-            "license": "MIT",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@webviz/core-components/-/core-components-0.5.0.tgz",
+            "integrity": "sha512-aH9xtwN/QfbJtfhVnCmf6VF0YVpbFik6pZo9P3BQijhhSA21J4+GznDDx5Oah6y9W1NpsTPLJhvLYv0MDBlOjQ==",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^1.2.35",
                 "@fortawesome/free-solid-svg-icons": "^5.15.3",
@@ -12107,10 +12108,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/chokidar/node_modules/fsevents": {
-            "dev": true,
-            "optional": true
         },
         "node_modules/chokidar/node_modules/glob-parent": {
             "version": "3.1.0",
@@ -16787,10 +16784,6 @@
             "version": "1.0.0",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/fsevents": {
-            "dev": true,
-            "optional": true
         },
         "node_modules/function-bind": {
             "version": "1.1.1",
@@ -32454,7 +32447,6 @@
             "version": "6.2.9",
             "dev": true,
             "requires": {
-                "@babel/core": "^7.12.10",
                 "@babel/generator": "^7.12.11",
                 "@babel/parser": "^7.12.11",
                 "@babel/plugin-transform-react-jsx": "^7.12.12",
@@ -37333,7 +37325,9 @@
             "requires": {}
         },
         "@webviz/core-components": {
-            "version": "0.4.1",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@webviz/core-components/-/core-components-0.5.0.tgz",
+            "integrity": "sha512-aH9xtwN/QfbJtfhVnCmf6VF0YVpbFik6pZo9P3BQijhhSA21J4+GznDDx5Oah6y9W1NpsTPLJhvLYv0MDBlOjQ==",
             "requires": {
                 "@fortawesome/fontawesome-svg-core": "^1.2.35",
                 "@fortawesome/free-solid-svg-icons": "^5.15.3",
@@ -38713,10 +38707,6 @@
                             }
                         }
                     }
-                },
-                "fsevents": {
-                    "dev": true,
-                    "optional": true
                 },
                 "glob-parent": {
                     "version": "3.1.0",
@@ -42035,10 +42025,6 @@
             "version": "1.0.0",
             "dev": true
         },
-        "fsevents": {
-            "dev": true,
-            "optional": true
-        },
         "function-bind": {
             "version": "1.1.1"
         },
@@ -45296,7 +45282,6 @@
         "nebula.gl": {
             "version": "0.22.3",
             "requires": {
-                "@luma.gl/constants": "^8.0.1",
                 "@nebula.gl/layers": "0.22.3",
                 "@turf/bbox": ">=4.0.0",
                 "@turf/bbox-polygon": ">=4.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "@types/react-dom": "^17.0.3",
         "@types/react-redux": "^7.1.15",
         "@types/react-resize-detector": "^5.0.0",
-        "@webviz/core-components": "^0.4.1",
+        "@webviz/core-components": "^0.5.0",
         "ajv": "^7.2.1",
         "clsx": "^1.1.1",
         "d3": "^5.11.0",

--- a/src/lib/components/VectorSelector/components/VectorSelectorComponent.tsx
+++ b/src/lib/components/VectorSelector/components/VectorSelectorComponent.tsx
@@ -133,7 +133,7 @@ export default class VectorSelectorComponent extends SmartNodeSelectorComponent 
             selected: false,
             delimiter: this.props.delimiter,
             numMetaNodes: this.props.numMetaNodes + 1,
-            treeData: this.treeData,
+            treeData: this.treeData as TreeData,
         });
     }
 

--- a/src/lib/components/VectorSelector/utils/VectorSelection.ts
+++ b/src/lib/components/VectorSelector/utils/VectorSelection.ts
@@ -129,7 +129,8 @@ export default class VectorSelection extends TreeNodeSelection {
 
     exactlyMatchedNodePaths(): Array<string> {
         const selections = this.myTreeData.findNodes(
-            super.getNodePath()
+            super.getNodePath(),
+            true
         ).nodePaths;
         const nodePaths: string[] = [];
         for (const selection of selections) {


### PR DESCRIPTION
Adjusted `VectorSelection` according to changes in `SmartNodeSelector`'s `TreeData`. 

This fixes the issue where several nodes got selected when selecting a node whose name is partly contained in other names. E.g.:

Selected: `NodeName1`
Returns: `NodeName1` `NodeName12` `NodeName123` ...

This depends on newest version of `webviz-core-components` and the dependency must be adjusted.