### PR TITLE
Added `lineBreakAfterTag` property to `VectorSelector` component

### DIFF
--- a/src/lib/components/VectorSelector/VectorSelector.jsx
+++ b/src/lib/components/VectorSelector/VectorSelector.jsx
@@ -18,6 +18,7 @@ const VectorSelector = (props) => {
             numSecondsUntilSuggestionsAreShown={
                 props.numSecondsUntilSuggestionsAreShown
             }
+            lineBreakAfterTag={props.lineBreakAfterTag}
             persistence={props.persistence}
         />
     );
@@ -30,7 +31,8 @@ VectorSelector.defaultProps = {
     showSuggestions: true,
     selectedTags: [],
     placeholder: "Add new tag...",
-    numSecondsUntilSuggestionsAreShown: 1.5,
+    numSecondsUntilSuggestionsAreShown: 0.5,
+    lineBreakAfterTag: false,
     persisted_props: ["selectedNodes", "selectedTags", "selectedIds"],
     persistence_type: "local",
 };
@@ -92,6 +94,11 @@ VectorSelector.propTypes = {
      * Number of seconds until suggestions are shown.
      */
     numSecondsUntilSuggestionsAreShown: PropTypes.number,
+
+    /**
+     * If set to true, tags will be separated by a line break.
+     */
+    lineBreakAfterTag: PropTypes.bool,
 
     /**
      * Used to allow user interactions in this component to be persisted when

--- a/src/lib/components/VectorSelector/components/VectorSelectorComponent.tsx
+++ b/src/lib/components/VectorSelector/components/VectorSelectorComponent.tsx
@@ -42,6 +42,7 @@ type VectorSelectorPropType = {
     selectedTags?: string[];
     placeholder?: string;
     numSecondsUntilSuggestionsAreShown: number;
+    lineBreakAfterTag?: boolean;
     persistence: boolean | string | number;
     persisted_props: "selectedTags"[];
     persistence_type: "local" | "session" | "memory";


### PR DESCRIPTION
This PR makes the new `lineBreakAfterTag` property from `SmartNodeSelector` available in `VectorSelector`.

Also changed default `numSecondsUntilSuggestionsAreShown` to 0.5s.