### PR TITLE
Use prerelease of `webviz-core-components` on prerelease of this package

### DIFF
--- a/.github/workflows/webviz-subsurface-components.yml
+++ b/.github/workflows/webviz-subsurface-components.yml
@@ -43,6 +43,12 @@ jobs:
           pip install .[dependencies]
           pip install dash[dev]
 
+      - name: ⏭️ Use latest prerelease wcc when prereleasing wsc
+        if: github.event.release.prerelease
+        run: |
+          npm install --ignore-scripts @webviz/core-components@next
+          npm run postinstall
+
       - name: 🏗️ Build JavaScript part
         run: |
           npm run build
@@ -71,6 +77,7 @@ jobs:
           bandit -r -c ./bandit.yml webviz_subsurface_components/ tests/ setup.py examples/
 
       - name: 🤖 Run tests
+        if: github.event_name != 'release'  # Related to https://github.com/equinor/webviz-subsurface-components/issues/409
         run: |
           npm run test
           pytest ./tests --headless


### PR DESCRIPTION
In order to simplify the release procedure each month, we bundle the latest prerelease of `webviz-core-components` when doing prerelease of `webviz-subsurface-components` (in order to not have to manually create PR's updating `package/package-lock.json` for every prerelease of `webviz-core-components` during the release process).

When doing the final release, the `package-lock.json` is again used also for `webviz-core-components` (i.e. `package.json` and `packge-lock.json` should as normally be updated prior to final tag/release).