### PR TITLE
Re-enable Python tests

### DIFF
--- a/.github/workflows/webviz-subsurface-components.yml
+++ b/.github/workflows/webviz-subsurface-components.yml
@@ -80,8 +80,7 @@ jobs:
         if: github.event_name != 'release'  # Related to https://github.com/equinor/webviz-subsurface-components/issues/409
         run: |
           npm run test --prefix ./react
-        # TODO: fix the python tests
-        # pytest ./tests --headless
+          pytest ./tests --headless
 
       - name: 🚢 Build and deploy Python package
         if: github.event_name == 'release' && matrix.python-version == '3.6'

--- a/react/package.json
+++ b/react/package.json
@@ -12,11 +12,11 @@
     "main": "build/index.js",
     "scripts": {
         "start": "webpack serve --mode development --devtool inline-source-map --entry ./src/demo/index.js --open",
-        "postinstall": "cp ./package.json ../webviz_subsurface_components/package.json && npm run setup_deckgl_types",
+        "postinstall": "cp ./package.json ../webviz_subsurface_components/ && npm run setup_deckgl_types",
         "build:js": "webpack --mode production",
         "build:js-dev": "webpack --mode development",
         "build:js-demo": "webpack --mode production --entry ./src/demo/index.js",
-        "build:py": "dash-generate-components ./src/lib/components ../webviz_subsurface_components -p package-info.json --ignore \"(.js|.stories.jsx)$\"",
+        "build:py": "mv ../webviz_subsurface_components . && dash-generate-components ./src/lib/components webviz_subsurface_components -p package-info.json --ignore \"(.js|.stories.jsx)$\" && mv webviz_subsurface_components ..",
         "build": "npm run build:js && npm run build:js-dev && npm run build:py",
         "typecheck": "tsc --noEmit",
         "format": "eslint --fix *.js *json \"src/**/*.+(ts|tsx|js|jsx|json|css)\"",


### PR DESCRIPTION
Closes #425.

Looks like Dash wants its components to be built
1) in the same folder as `node_modules` (it needs to find `react-docgen`).
2) uses the second argument to `dash-generate-components` as both a folder and as namespace in its JavaScript-Python integration (the latter not playing nicely with `./`, `../` etc.)