### PR TITLE
Add demo examples to eslint ignore

### DIFF
--- a/react/.eslintignore
+++ b/react/.eslintignore
@@ -1,3 +1,4 @@
 *.css
 registerServiceWorker.js
 output.js
+src/demo/example-data/


### PR DESCRIPTION
The example input files (jsons) can be very large, so they can slow down lining quite a bit.
Not linting those is a 2x faster on my computer.