### PR TITLE
Fixed infocard issue for multiple key in table

### DIFF
--- a/react/src/lib/components/DeckGLMap/components/InfoCard.tsx
+++ b/react/src/lib/components/DeckGLMap/components/InfoCard.tsx
@@ -171,7 +171,14 @@ const InfoCard: React.FC<InfoCardProps> = (props: InfoCardProps) => {
 
             const zValue = (info as PropertyMapPickInfo).propertyValue;
             if (zValue) {
-                xy_properties.push({ name: info.layer.id, value: zValue });
+                const property = xy_properties.find(
+                    (item) => item.name === info.layer.id
+                );
+                if (property) {
+                    property.value = zValue;
+                } else {
+                    xy_properties.push({ name: info.layer.id, value: zValue });
+                }
             }
         });
 


### PR DESCRIPTION
On the edges of the map component, I was getting errors for the infocard table "multiple keys with the same name exists".
It should update the value if the key exists instead of adding a new entry for the table.