### PR TITLE
Escape `copyfiles` argument in order to work on Linux/Mac

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -35,7 +35,7 @@
         "test": "jest --coverage",
         "test:watch": "npm test -- --watch",
         "build:npm": "rimraf dist && tsc --declaration && npm run copy-files",
-        "copy-files": "copyfiles package.json dist && copyfiles --up 1 ../README.md dist && copyfiles --up 2 src/lib/**/*.css src/lib/**/*.glsl src/lib/**/*.svg src/lib/inputSchema/*.json dist/",
+        "copy-files": "copyfiles package.json dist && copyfiles --up 1 ../README.md dist && copyfiles --up 2 \"src/lib/**/*.{css, glsl, svg}\" src/lib/inputSchema/*.json dist/",
         "prepare": "npm run build:npm",
         "postpack": "npm run tidy-up",
         "prepublishOnly": "npm test && npm run lint",


### PR DESCRIPTION
Followup after #498 (apparently input paths needs to be within quotes on Linux/Mac see [`copyfiles` documentation](https://www.npmjs.com/package/copyfiles)).

Closes #522.