### PR TITLE
Multiple synced views in DeckGL map

### DIFF
--- a/examples/example_deckgl_map.py
+++ b/examples/example_deckgl_map.py
@@ -170,6 +170,7 @@ if __name__ == "__main__":
         coords={"visible": True, "multiPicking": True, "pickDepth": 10},
         scale={"visible": True},
         coordinateUnit="m",
+        views={"count": 1, "layout": [1, 1]},
         deckglSpecBase={
             "initialViewState": {
                 "target": [bounds[0] + WIDTH / 2, bounds[1] + HEIGHT / 2, 0],
@@ -205,19 +206,7 @@ if __name__ == "__main__":
                     "logrunName": "BLOCKING",
                     "logName": "ZONELOG",
                 },
-            ],
-            "views": [
-                {
-                    "@@type": "OrthographicView",
-                    "id": "main",
-                    "controller": {"doubleClickZoom": False},
-                    "x": "0%",
-                    "y": "0%",
-                    "width": "100%",
-                    "height": "100%",
-                    "flipY": False,
-                }
-            ],
+            ]
         },
     )
 

--- a/examples/example_deckgl_map.py
+++ b/examples/example_deckgl_map.py
@@ -206,7 +206,7 @@ if __name__ == "__main__":
                     "logrunName": "BLOCKING",
                     "logName": "ZONELOG",
                 },
-            ]
+            ],
         },
     )
 

--- a/react/src/demo/example-data/deckgl-map-spec.json
+++ b/react/src/demo/example-data/deckgl-map-spec.json
@@ -17,6 +17,10 @@
     },
     "legendVisible": true,
     "coordinateUnit": "m",
+    "views": {
+      "count": 1,
+      "layout": [1, 1]
+    },
     "resources": {
       "propertyMap": "https://raw.githubusercontent.com/equinor/webviz-subsurface-components/master/react/src/demo/example-data/propertyMap.png"
     },
@@ -91,20 +95,6 @@
             "type": "FeatureCollection",
             "features": []
           }
-        }
-      ],
-      "views": [
-        {
-          "@@type": "OrthographicView",
-          "id": "main",
-          "controller": {
-            "doubleClickZoom": false
-          },
-          "x": "0%",
-          "y": "0%",
-          "width": "100%",
-          "height": "100%",
-          "flipY": false
         }
       ]
     }

--- a/react/src/demo/example-data/deckgl-map.json
+++ b/react/src/demo/example-data/deckgl-map.json
@@ -17,6 +17,10 @@
     },
     "legendVisible": true,
     "coordinateUnit": "m",
+    "views": {
+      "count": 1,
+      "layout": [1, 1]
+    },
     "resources": {
       "propertyMap": "https://raw.githubusercontent.com/equinor/webviz-subsurface-components/master/react/src/demo/example-data/propertyMap.png"
     },
@@ -95,20 +99,6 @@
             "type": "FeatureCollection",
             "features": []
           }
-        }
-      ],
-      "views": [
-        {
-          "@@type": "OrthographicView",
-          "id": "main",
-          "controller": {
-            "doubleClickZoom": false
-          },
-          "x": "0%",
-          "y": "0%",
-          "width": "100%",
-          "height": "100%",
-          "flipY": false
         }
       ]
     }

--- a/react/src/lib/components/DeckGLMap/DeckGLMap.jsx
+++ b/react/src/lib/components/DeckGLMap/DeckGLMap.jsx
@@ -72,6 +72,10 @@ DeckGLMap.defaultProps = {
         position: [10, 10],
     },
     legendVisible: true,
+    views: {
+        count: 1,
+        layout: [1, 1],
+    },
 };
 
 function DeckGLMap({
@@ -82,6 +86,7 @@ function DeckGLMap({
     coords,
     scale,
     legendVisible,
+    views,
     coordinateUnit,
     setProps,
 }) {
@@ -144,6 +149,7 @@ function DeckGLMap({
                 deckglSpec={patchedSpec}
                 setSpecPatch={setSpecPatch}
                 coords={coords}
+                views={views}
                 scale={scale}
                 legendVisible={legendVisible}
                 coordinateUnit={coordinateUnit}
@@ -168,6 +174,11 @@ DeckGLMap.propTypes = {
      * https://deck.gl/docs/api-reference/json/conversion-reference#enumerations-and-using-the--prefix
      */
     resources: PropTypes.object,
+
+    /**
+     * Object defining view count and layout for displaying multiple maps.
+     */
+    views: PropTypes.object,
 
     /**
      * JSON object describing the map structure to which deckglSpecPatch will be

--- a/react/src/lib/components/DeckGLMap/components/Map.tsx
+++ b/react/src/lib/components/DeckGLMap/components/Map.tsx
@@ -150,11 +150,6 @@ export interface MapProps {
         layout: [number, number];
     };
 
-    /**
-     * Number of maps views to be displayed.
-     */
-    count: number;
-
     coordinateUnit: string;
 
     legendVisible: boolean;


### PR DESCRIPTION
1. Removed views from deckGlSpecBase
2. Added syncedView prop to toggle between single and dual view
3. Updated example_deckgl_map.py to incorporate changes