### PR TITLE
Round to significant value in `InfoCard`

### DIFF
--- a/react/src/lib/components/DeckGLMap/components/InfoCard.tsx
+++ b/react/src/lib/components/DeckGLMap/components/InfoCard.tsx
@@ -36,6 +36,15 @@ export interface InfoCardProps {
     pickInfos: PickInfo<unknown>[];
 }
 
+const roundToSignificant = function (num: number) {
+    // Returns two significant figures (non-zero) for numbers with an absolute value less
+    // than 1, and two decimal places for numbers with an absolute value greater
+    // than 1.
+    return parseFloat(
+        num.toExponential(Math.max(1, 2 + Math.log10(Math.abs(num))))
+    );
+};
+
 const useStyles = makeStyles({
     table: {
         "& > *": {
@@ -124,7 +133,9 @@ function Row(props: { layer_data: InfoCardDataType }) {
                                         >
                                             {typeof propertyRow.value ==
                                             "number"
-                                                ? propertyRow.value?.toFixed(2)
+                                                ? roundToSignificant(
+                                                      propertyRow.value
+                                                  )
                                                 : propertyRow.value}
                                         </TableCell>
                                     </TableRow>


### PR DESCRIPTION
Currently values in `InfoCard` are displayed with two decimals.
For absolute values < 1 this can often give a 0.00 readout.
This PR will round to two significant (non-zero) figures for those values.
<img width="500" alt="Screenshot 2021-11-28 184801" src="https://user-images.githubusercontent.com/16436291/143779848-9f06b095-2b6f-44ef-98d3-99a44872d9a7.png">
.
