### PR TITLE
Renamed deckglmap storybook example

### DIFF
--- a/react/src/lib/components/DeckGLMap/storybook/DeckGLMap.stories.jsx
+++ b/react/src/lib/components/DeckGLMap/storybook/DeckGLMap.stories.jsx
@@ -121,16 +121,16 @@ Default.args = {
 };
 
 // Storybook example 2
-export const CustomLayer = Template.bind({});
-CustomLayer.args = {
+export const UserDefinedLayer1 = Template.bind({});
+UserDefinedLayer1.args = {
     id: exampleData[0].id,
     bounds: exampleData[0].bounds,
     layers: layersData1,
 };
 
 // Storybook example 3
-export const CustomLayerWithColormap = Template.bind({});
-CustomLayerWithColormap.args = {
+export const UserDefinedLayer2 = Template.bind({});
+UserDefinedLayer2.args = {
     id: exampleData[0].id,
     resources: exampleData[0].resources,
     bounds: exampleData[0].bounds,


### PR DESCRIPTION
This will correct the order of storybook examples for DeckGLMap componet