### PR TITLE
Fixed docstring for "layers".

### DIFF
--- a/react/src/lib/components/DeckGLMap/DeckGLMap.jsx
+++ b/react/src/lib/components/DeckGLMap/DeckGLMap.jsx
@@ -113,9 +113,12 @@ DeckGLMap.propTypes = {
      */
     zoom: PropTypes.number,
 
-    /* List of JSON object containing layer specific data.
+    /** List of JSON object containing layer specific data.
      * Each JSON object will consist of layer type with key as "@@type" and
      * layer specific data, if any.
+     * Supports both upstream Deck.gl layers and custom WebViz layers.
+     * See Storybook examples for example layer stacks.
+     * See also: https://deck.gl/docs/api-reference/core/deck#layers
      */
     layers: PropTypes.arrayOf(PropTypes.object),
 


### PR DESCRIPTION
Docstring was not showing for the "layers" prop.

Also added reference to deck.gl documentation.

Partial fix for #292.