### PR TITLE
Use inline loaders for .scss, .glsl and .css files.

### DIFF
--- a/react/src/lib/components/GroupTree/components/GroupTreeViewer.tsx
+++ b/react/src/lib/components/GroupTree/components/GroupTreeViewer.tsx
@@ -4,7 +4,7 @@ import React, { useContext, useEffect, useRef } from "react";
 import { useSelector } from "react-redux";
 import { GroupTreeState } from "../redux/store";
 import { DataContext } from "./DataLoader";
-import "./Plot/dynamic_tree.css";
+import "!style-loader!css-loader!./Plot/dynamic_tree.css";
 import GroupTree from "./Plot/group_tree";
 import SettingsBar from "./Settings/SettingsBar";
 import { DataInfos } from "../redux/types";

--- a/react/src/lib/components/LayeredMap/LayeredMap.jsx
+++ b/react/src/lib/components/LayeredMap/LayeredMap.jsx
@@ -7,7 +7,7 @@
 /* eslint no-inline-comments: 0 */
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
-import "leaflet/dist/leaflet.css";
+import "!style-loader!css-loader!leaflet/dist/leaflet.css";
 import { CRS } from "leaflet";
 import {
     LayersControl,
@@ -22,7 +22,7 @@ import OptionalLayerControl from "./components/OptionalLayerControl.react";
 import CompositeMapLayer from "./components/CompositeMapLayer.react";
 import DrawControls from "./components/DrawControls.react";
 import VerticalZoom from "./components/VerticalZoom.react";
-import "./layered-map.css";
+import "!style-loader!css-loader!./layered-map.css";
 
 const { BaseLayer, Overlay } = LayersControl;
 const yx = ([x, y]) => {

--- a/react/src/lib/components/LayeredMap/components/DrawControls.react.js
+++ b/react/src/lib/components/LayeredMap/components/DrawControls.react.js
@@ -8,7 +8,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { withLeaflet } from "react-leaflet";
 import { EditControl } from "react-leaflet-draw";
-import "leaflet-draw/dist/leaflet.draw.css";
+import "!style-loader!css-loader!leaflet-draw/dist/leaflet.draw.css";
 import L from "leaflet";
 
 // work around broken icons when using webpack, see https://github.com/PaulLeCam/react-leaflet/issues/255

--- a/react/src/lib/components/LayeredMap/webgl/alter_image.js
+++ b/react/src/lib/components/LayeredMap/webgl/alter_image.js
@@ -4,9 +4,9 @@
  *
  * Copyright (C) 2020 - Equinor ASA. */
 
-import vertexShaderSource from "../shaders/vertexShader.vs.glsl";
-import fragmentShaderSourceWithHillshading from "../shaders/fragmentShaderWithHillshading.fs.glsl";
-import fragmentShaderSourceWithoutHillshading from "../shaders/fragmentShaderWithoutHillshading.fs.glsl";
+import vertexShaderSource from "!!raw-loader!../shaders/vertexShader.vs.glsl";
+import fragmentShaderSourceWithHillshading from "!!raw-loader!../shaders/fragmentShaderWithHillshading.fs.glsl";
+import fragmentShaderSourceWithoutHillshading from "!!raw-loader!../shaders/fragmentShaderWithoutHillshading.fs.glsl";
 
 function alter_image(
     canvas,

--- a/react/src/lib/components/LeafletMap/components/Controls/components/DrawControls.js
+++ b/react/src/lib/components/LeafletMap/components/Controls/components/DrawControls.js
@@ -6,7 +6,7 @@
 
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import "leaflet-draw/dist/leaflet.draw.css";
+import "!style-loader!css-loader!leaflet-draw/dist/leaflet.draw.css";
 import L from "leaflet";
 import Context from "../../../utils/context";
 

--- a/react/src/lib/components/LeafletMap/components/Controls/components/MousePosition.js
+++ b/react/src/lib/components/LeafletMap/components/Controls/components/MousePosition.js
@@ -6,7 +6,7 @@
 
 import { useEffect, useContext, useRef } from "react";
 import PropTypes from "prop-types";
-import "leaflet-draw/dist/leaflet.draw.css";
+import "!style-loader!css-loader!leaflet-draw/dist/leaflet.draw.css";
 import L from "leaflet";
 
 // Context

--- a/react/src/lib/components/LeafletMap/webgl/commands/drawWithTerrainRGB.js
+++ b/react/src/lib/components/LeafletMap/webgl/commands/drawWithTerrainRGB.js
@@ -8,8 +8,8 @@ import EQGL from "../eqGL";
 import vec3 from "../vec3";
 
 // Shaders
-import positionVShader from "../../shaders/position.vs.glsl";
-import terrainRGBFSShader from "../../shaders/terrainRGB.fs.glsl";
+import positionVShader from "!!raw-loader!../../shaders/position.vs.glsl";
+import terrainRGBFSShader from "!!raw-loader!../../shaders/terrainRGB.fs.glsl";
 
 // CONSTANTS
 const DEFAULT_ELEVATION_SCALE = -1.0;

--- a/react/src/lib/components/Morris/Morris.jsx
+++ b/react/src/lib/components/Morris/Morris.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import MorrisMethod from "./utils/morris";
-import "./morris.css";
+import "!style-loader!css-loader!./morris.css";
 
 const parseData = (data) =>
     typeof data === "string" ? JSON.parse(data) : data;

--- a/react/src/lib/components/PriorPosteriorDistribution/PriorPosteriorDistribution.jsx
+++ b/react/src/lib/components/PriorPosteriorDistribution/PriorPosteriorDistribution.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import "./prior_posterior_distribution.css";
+import "!style-loader!css-loader!./prior_posterior_distribution.css";
 import D3PriorPosterior from "./utils/prior_posterior_distribution";
 
 class PriorPosteriorDistribution extends Component {

--- a/react/src/lib/components/VectorCalculator/VectorCalculator.jsx
+++ b/react/src/lib/components/VectorCalculator/VectorCalculator.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import { VectorCalculatorComponent } from "./components/VectorCalculatorComponent";
 import { string } from "jsverify";
-import "./VectorCalculator.css";
+import "!style-loader!css-loader!./VectorCalculator.css";
 
 /**
  * VectorCalculator is a component that allows to calculate new vectors by creating a mathematical expression

--- a/react/src/lib/components/VectorCalculator/components/ExpressionDescriptionTextField.tsx
+++ b/react/src/lib/components/VectorCalculator/components/ExpressionDescriptionTextField.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { MaxLengthTextField } from "./MaxLengthTextField";
 
-import "../VectorCalculator.css";
+import "!style-loader!css-loader!../VectorCalculator.css";
 
 interface ExpressionDescriptionTextFieldProps {
     maxLength: number;

--- a/react/src/lib/components/VectorCalculator/components/ExpressionInputComponent.tsx
+++ b/react/src/lib/components/VectorCalculator/components/ExpressionInputComponent.tsx
@@ -25,7 +25,7 @@ import {
 } from "../utils/VectorCalculatorHelperFunctions";
 import { getExpressionParseData } from "../utils/ExpressionParser";
 
-import "../VectorCalculator.css";
+import "!style-loader!css-loader!../VectorCalculator.css";
 
 interface ExpressionInputComponent {
     activeExpression: ExpressionType;

--- a/react/src/lib/components/VectorCalculator/components/ExpressionInputTextField.tsx
+++ b/react/src/lib/components/VectorCalculator/components/ExpressionInputTextField.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Icon, TextField, Progress } from "@equinor/eds-core-react";
 import { error_filled, thumbs_up } from "@equinor/eds-icons";
 
-import "../VectorCalculator.css";
+import "!style-loader!css-loader!../VectorCalculator.css";
 
 export enum ExpressionStatus {
     Valid = 1,

--- a/react/src/lib/components/VectorCalculator/components/ExpressionNameTextField.tsx
+++ b/react/src/lib/components/VectorCalculator/components/ExpressionNameTextField.tsx
@@ -11,7 +11,7 @@ import {
     expressionNameValidationMessage,
 } from "../utils/VectorCalculatorHelperFunctions";
 
-import "../VectorCalculator.css";
+import "!style-loader!css-loader!../VectorCalculator.css";
 
 type ExpressionNameTextFieldVariantType =
     | "success"

--- a/react/src/lib/components/VectorCalculator/components/ExpressionsTable.tsx
+++ b/react/src/lib/components/VectorCalculator/components/ExpressionsTable.tsx
@@ -14,7 +14,7 @@ import { ExpressionType } from "../utils/VectorCalculatorTypes";
 import { BlinkingTableRow } from "../utils/BlinkingTableRow";
 import { EnhancedTableHead } from "../utils/EnhancedTableHead";
 
-import "../VectorCalculator.css";
+import "!style-loader!css-loader!../VectorCalculator.css";
 
 interface ExpressionsTableProps {
     expressions: ExpressionType[];

--- a/react/src/lib/components/VectorCalculator/components/ExpressionsTableComponent.tsx
+++ b/react/src/lib/components/VectorCalculator/components/ExpressionsTableComponent.tsx
@@ -13,7 +13,7 @@ import {
     getDefaultExpression,
 } from "../utils/VectorCalculatorHelperFunctions";
 
-import "../VectorCalculator.css";
+import "!style-loader!css-loader!../VectorCalculator.css";
 
 interface ExpressionsTableComponentProps {
     expressions: ExpressionType[];

--- a/react/src/lib/components/VectorCalculator/components/VariablesTable.tsx
+++ b/react/src/lib/components/VectorCalculator/components/VariablesTable.tsx
@@ -13,7 +13,7 @@ import cloneDeep from "lodash/cloneDeep";
 import { VariableVectorMapType } from "../utils/VectorCalculatorTypes";
 import VectorSelector from "../../VectorSelector";
 
-import "../VectorCalculator.css";
+import "!style-loader!css-loader!../VectorCalculator.css";
 
 interface VariablesTableProps {
     variableVectorMap: VariableVectorMapType[];

--- a/react/src/lib/components/VectorCalculator/utils/BlinkingTableRow.tsx
+++ b/react/src/lib/components/VectorCalculator/utils/BlinkingTableRow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { TableRow, TableRowProps } from "@material-ui/core";
 
-import "../VectorCalculator.css";
+import "!style-loader!css-loader!../VectorCalculator.css";
 
 interface BlinkingTableRowProps extends TableRowProps {
     blinking: boolean;

--- a/react/src/lib/components/WellCompletions/components/Settings/ZoneSelector.tsx
+++ b/react/src/lib/components/WellCompletions/components/Settings/ZoneSelector.tsx
@@ -1,7 +1,7 @@
 import { createStyles, makeStyles, Theme } from "@material-ui/core";
 import React, { useCallback, useContext, useMemo } from "react";
 import DropdownTreeSelect, { TreeNodeProps } from "react-dropdown-tree-select";
-import "react-dropdown-tree-select/dist/styles.css";
+import "!style-loader!css-loader!react-dropdown-tree-select/dist/styles.css";
 import { useDispatch } from "react-redux";
 import { updateFilteredZones } from "../../redux/actions";
 import { Zone } from "../../redux/types";

--- a/react/src/lib/components/WellLogViewer/components/WellLogView.tsx
+++ b/react/src/lib/components/WellLogViewer/components/WellLogView.tsx
@@ -16,7 +16,7 @@ import {
     OverlayRescaleEvent,
 } from "@equinor/videx-wellog/dist/ui/interfaces";
 
-import "./styles.scss";
+import "!vue-style-loader!css-loader!sass-loader!./styles.scss";
 
 import { select } from "d3";
 

--- a/react/webpack.config.js
+++ b/react/webpack.config.js
@@ -86,11 +86,6 @@ module.exports = (env, argv) => {
                     loader: "babel-loader",
                 },
                 {
-                    test: /\.scss$/,
-                    use: ["vue-style-loader", "css-loader", "sass-loader"],
-                },
-
-                {
                     test: /\.css$/,
                     use: [
                         {
@@ -112,10 +107,6 @@ module.exports = (env, argv) => {
                     test: /\.js$/,
                     exclude: /node_modules/,
                     loader: "source-map-loader",
-                },
-                {
-                    test: /\.(fs|vs).glsl$/i,
-                    use: ["raw-loader"],
                 },
             ],
         },


### PR DESCRIPTION
Allows using react components as 3rd party libraries where consumers have not configured loaders for said files.

Fixes #717, #718 