### PR TITLE
Fixed crash when trajectory contains only one point

### DIFF
--- a/react/src/lib/components/DeckGLMap/components/InfoCard.tsx
+++ b/react/src/lib/components/DeckGLMap/components/InfoCard.tsx
@@ -74,6 +74,7 @@ function Row(props: { layer_data: InfoCardDataType }) {
     const [open, setOpen] = React.useState(true);
     const classes = useStyles();
 
+    if (layer_data.properties?.length == 0) return null;
     return (
         <React.Fragment>
             <TableRow className={classes.table_row}>


### PR DESCRIPTION
Fixed crash when trajectory contains only one point Closes #771 
It will allow loading of wells if trajectory data is not available (LineString geometry)

