### PR TITLE
Replace `eds` Tooltip with `Material-ui` Tooltip

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -3307,7 +3307,6 @@
                 "jest-resolve": "^26.6.2",
                 "jest-util": "^26.6.2",
                 "jest-worker": "^26.6.2",
-                "node-notifier": "^8.0.0",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.0",
                 "string-length": "^4.0.1",
@@ -6285,10 +6284,8 @@
             "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
             "dev": true,
             "dependencies": {
-                "chokidar": "^3.4.1",
                 "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0",
-                "watchpack-chokidar2": "^2.0.1"
+                "neo-async": "^2.5.0"
             },
             "optionalDependencies": {
                 "chokidar": "^3.4.1",
@@ -7944,10 +7941,8 @@
             "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
             "dev": true,
             "dependencies": {
-                "chokidar": "^3.4.1",
                 "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0",
-                "watchpack-chokidar2": "^2.0.1"
+                "neo-async": "^2.5.0"
             },
             "optionalDependencies": {
                 "chokidar": "^3.4.1",
@@ -8798,10 +8793,8 @@
             "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
             "dev": true,
             "dependencies": {
-                "chokidar": "^3.4.1",
                 "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0",
-                "watchpack-chokidar2": "^2.0.1"
+                "neo-async": "^2.5.0"
             },
             "optionalDependencies": {
                 "chokidar": "^3.4.1",
@@ -9892,10 +9885,8 @@
             "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
             "dev": true,
             "dependencies": {
-                "chokidar": "^3.4.1",
                 "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0",
-                "watchpack-chokidar2": "^2.0.1"
+                "neo-async": "^2.5.0"
             },
             "optionalDependencies": {
                 "chokidar": "^3.4.1",
@@ -11206,10 +11197,8 @@
             "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
             "dev": true,
             "dependencies": {
-                "chokidar": "^3.4.1",
                 "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0",
-                "watchpack-chokidar2": "^2.0.1"
+                "neo-async": "^2.5.0"
             },
             "optionalDependencies": {
                 "chokidar": "^3.4.1",
@@ -14283,6 +14272,8 @@
             "version": "8.10.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
             "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -15585,7 +15576,6 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
             "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "file-uri-to-path": "1.0.0"
@@ -16341,7 +16331,6 @@
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
-                "fsevents": "~2.3.2",
                 "glob-parent": "~5.1.2",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -16542,7 +16531,6 @@
             "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
             "dev": true,
             "dependencies": {
-                "colors": "1.4.0",
                 "string-width": "^4.2.0"
             },
             "engines": {
@@ -19552,8 +19540,7 @@
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
                 "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
+                "optionator": "^0.8.1"
             },
             "bin": {
                 "escodegen": "bin/escodegen.js",
@@ -21020,9 +21007,6 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
             "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
             "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.1.6"
-            },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -21043,7 +21027,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true,
             "optional": true
         },
         "node_modules/filelist": {
@@ -22100,7 +22083,6 @@
                 "minimist": "^1.2.5",
                 "neo-async": "^2.6.0",
                 "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4",
                 "wordwrap": "^1.0.0"
             },
             "bin": {
@@ -23237,9 +23219,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-            "dependencies": {
-                "graceful-fs": "^4.1.6"
-            },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -24517,7 +24496,6 @@
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
-                "fsevents": "^2.3.2",
                 "graceful-fs": "^4.2.9",
                 "jest-regex-util": "^27.5.1",
                 "jest-serializer": "^27.5.1",
@@ -25234,7 +25212,6 @@
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
-                "fsevents": "^2.1.2",
                 "graceful-fs": "^4.2.4",
                 "jest-regex-util": "^26.0.0",
                 "jest-serializer": "^26.6.2",
@@ -26886,7 +26863,6 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dependencies": {
-                "graceful-fs": "^4.1.6",
                 "universalify": "^2.0.0"
             },
             "optionalDependencies": {
@@ -27073,9 +27049,6 @@
             "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
             "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
             "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.1.9"
-            },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.9"
             }
@@ -32304,7 +32277,6 @@
                 "eslint-webpack-plugin": "^3.1.1",
                 "file-loader": "^6.2.0",
                 "fs-extra": "^10.0.0",
-                "fsevents": "^2.3.2",
                 "html-webpack-plugin": "^5.5.0",
                 "identity-obj-proxy": "^3.0.0",
                 "jest": "^27.4.3",
@@ -33338,7 +33310,6 @@
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
-                "fsevents": "^2.3.2",
                 "graceful-fs": "^4.2.9",
                 "jest-regex-util": "^27.5.1",
                 "jest-serializer": "^27.5.1",
@@ -34982,9 +34953,6 @@
             "version": "2.67.2",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.2.tgz",
             "integrity": "sha512-hoEiBWwZtf1QdK3jZIq59L0FJj4Fiv4RplCO4pvCRC86qsoFurWB4hKQIjoRf3WvJmk5UZ9b0y5ton+62fC7Tw==",
-            "dependencies": {
-                "fsevents": "~2.3.2"
-            },
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -39032,7 +39000,6 @@
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
                 "braces": "^2.3.2",
-                "fsevents": "^1.2.7",
                 "glob-parent": "^3.1.0",
                 "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",
@@ -39631,7 +39598,6 @@
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
                 "braces": "^2.3.2",
-                "fsevents": "^1.2.7",
                 "glob-parent": "^3.1.0",
                 "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",
@@ -39727,7 +39693,6 @@
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
             "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
             "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
-            "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "os": [
@@ -51805,14 +51770,13 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-            "requires": {
-                "ajv": "^8.0.0"
-            },
+            "requires": {},
             "dependencies": {
                 "ajv": {
-                    "version": "8.10.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+                    "version": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
                     "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -52804,7 +52768,6 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
             "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "file-uri-to-path": "1.0.0"
@@ -57123,7 +57086,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true,
             "optional": true
         },
         "filelist": {
@@ -62639,7 +62601,6 @@
             "resolved": "https://registry.npmjs.org/nebula.gl/-/nebula.gl-0.22.3.tgz",
             "integrity": "sha512-aYQqBpMWxTz85b8ytsBmhbiZIBwIbNfPAIFKsY7zMeHQJyPJAeeaoDGP3SwF0bBpGUkza8KR9VeGIWz0zGhGdw==",
             "requires": {
-                "@luma.gl/constants": "^8.0.1",
                 "@nebula.gl/layers": "0.22.3",
                 "@turf/bbox": ">=4.0.0",
                 "@turf/bbox-polygon": ">=4.0.0",
@@ -71364,7 +71325,6 @@
                     "version": "1.2.13",
                     "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "bindings": "^1.5.0",

--- a/react/src/lib/components/VectorCalculator/components/ExpressionsTable.tsx
+++ b/react/src/lib/components/VectorCalculator/components/ExpressionsTable.tsx
@@ -6,8 +6,8 @@ import {
     TableBody,
     TableCell,
     TableContainer,
+    Tooltip,
 } from "@material-ui/core";
-import { Tooltip } from "@equinor/eds-core-react";
 
 import { getDetailedExpression } from "../utils/VectorCalculatorHelperFunctions";
 import { ExpressionType } from "../utils/VectorCalculatorTypes";
@@ -170,8 +170,13 @@ export const ExpressionsTable: React.FC<ExpressionsTableProps> = (
                                     <Tooltip
                                         key={row.name}
                                         placement="top"
-                                        title={row.description}
+                                        title={
+                                            row.description
+                                                ? row.description
+                                                : ""
+                                        }
                                         enterDelay={1000}
+                                        enterNextDelay={1000}
                                         hidden={
                                             !row.description ||
                                             row.description.length <= 0
@@ -191,6 +196,7 @@ export const ExpressionsTable: React.FC<ExpressionsTableProps> = (
                                         placement="top"
                                         title={expressionFromMap}
                                         enterDelay={1000}
+                                        enterNextDelay={1000}
                                     >
                                         <div className={"ExpressionsTableCell"}>
                                             {expressionFromMap}


### PR DESCRIPTION
Replaced Tooltip component from `eds` in ExpressionsTable with Tooltip component from `material-ui`

Fixed issue with tooltip not showing when utilizing the `VectorCalculator` in a modal in Dash-plugin.

---

####Resolves:
* https://github.com/equinor/webviz-subsurface-components/issues/607