### PR TITLE
Add missing props to `VectorSelector`

### DIFF
--- a/react/src/demo/VectorSelectorDemo.js
+++ b/react/src/demo/VectorSelectorDemo.js
@@ -23,6 +23,8 @@ class WellCompletionsDemo extends Component {
                 <VectorSelector
                     id="vector_selector"
                     delimiter=":"
+                    caseInsensitiveMatching={true}
+                    useBetaFeatures={true}
                     selectedTags={["iter-0:WGOR:OP_1"]}
                     numMetaNodes={1}
                     customVectorDefinitions={{

--- a/react/src/lib/components/VectorSelector/VectorSelector.jsx
+++ b/react/src/lib/components/VectorSelector/VectorSelector.jsx
@@ -84,6 +84,16 @@ VectorSelector.propTypes = {
     lineBreakAfterTag: PropTypes.bool,
 
     /**
+     * Set to true if case-wise incorrect values should be accepted anyways.
+     */
+    caseInsensitiveMatching: PropTypes.bool,
+
+    /**
+     * Set to true to enable beta features.
+     */
+    useBetaFeatures: PropTypes.bool,
+
+    /**
      * An object containing custom vector type definitions.
      */
     customVectorDefinitions: PropTypes.objectOf(


### PR DESCRIPTION
Add missing forward declared props for `SmartNodeSelector`

- Add missing props to .jsx file
- Add usage of props in demo for testing purpose

---

Closing:
* https://github.com/equinor/webviz-subsurface-components/issues/820