### PR TITLE
Fixed issue: Unexpected cutoff opacity behavior

### DIFF
--- a/react/src/lib/components/DeckGLMap/layers/terrain/map3DLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/terrain/map3DLayer.ts
@@ -6,7 +6,7 @@ import TerrainMapLayer, {
     Material,
 } from "./terrainMapLayer";
 import { ExtendedLayerProps } from "../utils/layerTools";
-import { RGBAColor } from "@deck.gl/core/utils/color";
+import { RGBColor } from "@deck.gl/core/utils/color";
 import { layersDefaultProps } from "../layersDefaultProps";
 import { TerrainLoader } from "@loaders.gl/terrain";
 import { ImageLoader } from "@loaders.gl/images";
@@ -221,9 +221,10 @@ export interface Map3DLayerProps<D> extends ExtendedLayerProps<D> {
     colorMapRange: [number, number];
 
     // Clamp colormap to this color at ends.
+    // Given as array of three values (r,g,b) e.g: [255, 0, 0]
     // If not set it will clamp to color map min and max values.
-    // Given as array of four values (r,g,b,a) e.g: [255, 0, 0, 0]
-    colorMapClampColor: RGBAColor | undefined;
+    // If set to false the clamp color will be completely transparent.
+    colorMapClampColor: RGBColor | undefined | false;
 
     // If true readout will be z value (depth). Otherwise it is the texture property value.
     isReadoutDepth: boolean;

--- a/react/src/lib/components/DeckGLMap/layers/terrain/map3DLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/terrain/map3DLayer.ts
@@ -222,9 +222,9 @@ export interface Map3DLayerProps<D> extends ExtendedLayerProps<D> {
 
     // Clamp colormap to this color at ends.
     // Given as array of three values (r,g,b) e.g: [255, 0, 0]
-    // If not set it will clamp to color map min and max values.
+    // If not set or set to true, it will clamp to color map min and max values.
     // If set to false the clamp color will be completely transparent.
-    colorMapClampColor: RGBColor | undefined | false;
+    colorMapClampColor: RGBColor | undefined | boolean;
 
     // If true readout will be z value (depth). Otherwise it is the texture property value.
     isReadoutDepth: boolean;

--- a/react/src/lib/components/DeckGLMap/layers/terrain/terrainMapLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/terrain/terrainMapLayer.ts
@@ -137,7 +137,7 @@ export default class TerrainMapLayer extends SimpleMeshLayer<
         );
 
         const isColorMapClampColorTransparent: boolean =
-            this.props.colorMapClampColor as boolean === false;
+            (this.props.colorMapClampColor as boolean) === false;
 
         super.draw({
             uniforms: {

--- a/react/src/lib/components/DeckGLMap/layers/terrain/terrainMapLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/terrain/terrainMapLayer.ts
@@ -79,9 +79,10 @@ export interface TerrainMapLayerProps<D> extends SimpleMeshLayerProps<D> {
     colorMapRange: [number, number];
 
     // Clamp colormap to this color at ends.
-    // If not set it will clamp to color map min and max values.
+    // Given as array of three values (r,g,b) e.g: [255, 0, 0]
+    // If not set or set to true, it will clamp to color map min and max values.
     // If set to false the clamp color will be completely transparent.
-    colorMapClampColor: RGBColor | undefined | false;
+    colorMapClampColor: RGBColor | undefined | boolean;
 
     //If true readout will be z value (depth). Otherwise it is the texture property value.
     isReadoutDepth: boolean;
@@ -126,6 +127,7 @@ export default class TerrainMapLayer extends SimpleMeshLayer<
 
         const isClampColor: boolean =
             this.props.colorMapClampColor !== undefined &&
+            this.props.colorMapClampColor !== true &&
             this.props.colorMapClampColor !== false;
         let colorMapClampColor = isClampColor
             ? this.props.colorMapClampColor

--- a/react/src/lib/components/DeckGLMap/layers/terrain/terrainMapLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/terrain/terrainMapLayer.ts
@@ -1,7 +1,7 @@
 import { SimpleMeshLayer } from "@deck.gl/mesh-layers";
 import { SimpleMeshLayerProps } from "@deck.gl/mesh-layers/simple-mesh-layer/simple-mesh-layer";
 import { COORDINATE_SYSTEM } from "@deck.gl/core";
-import { RGBAColor } from "@deck.gl/core/utils/color";
+import { RGBColor } from "@deck.gl/core/utils/color";
 import fsShader from "./terrainmap.fs.glsl";
 import GL from "@luma.gl/constants";
 import { Texture2D } from "@luma.gl/core";
@@ -80,7 +80,8 @@ export interface TerrainMapLayerProps<D> extends SimpleMeshLayerProps<D> {
 
     // Clamp colormap to this color at ends.
     // If not set it will clamp to color map min and max values.
-    colorMapClampColor: RGBAColor | undefined;
+    // If set to false the clamp color will be completely transparent.
+    colorMapClampColor: RGBColor | undefined | false;
 
     //If true readout will be z value (depth). Otherwise it is the texture property value.
     isReadoutDepth: boolean;
@@ -124,15 +125,19 @@ export default class TerrainMapLayer extends SimpleMeshLayer<
         const colorMapRangeMax = this.props.colorMapRange?.[1] ?? valueRangeMax;
 
         const isClampColor: boolean =
-            this.props.colorMapClampColor !== undefined;
+            this.props.colorMapClampColor !== undefined &&
+            this.props.colorMapClampColor !== false;
         let colorMapClampColor = isClampColor
             ? this.props.colorMapClampColor
-            : [0, 0, 0, 0];
+            : [0, 0, 0];
 
         // Normalize to [0,1] range.
-        colorMapClampColor = (colorMapClampColor as RGBAColor).map(
+        colorMapClampColor = (colorMapClampColor as RGBColor).map(
             (x) => (x ?? 0) / 255
         );
+
+        const isColorMapClampColorTransparent: boolean =
+            this.props.colorMapClampColor as boolean === false;
 
         super.draw({
             uniforms: {
@@ -157,6 +162,7 @@ export default class TerrainMapLayer extends SimpleMeshLayer<
                 isReadoutDepth,
                 isContoursDepth,
                 colorMapClampColor,
+                isColorMapClampColorTransparent,
                 isClampColor,
             },
         });

--- a/react/src/lib/components/DeckGLMap/layers/terrain/terrainmap.fs.glsl.ts
+++ b/react/src/lib/components/DeckGLMap/layers/terrain/terrainmap.fs.glsl.ts
@@ -32,8 +32,9 @@ uniform float valueRangeMax;
 uniform float colorMapRangeMin;
 uniform float colorMapRangeMax;
 
-uniform vec4 colorMapClampColor;
+uniform vec3 colorMapClampColor;
 uniform bool isClampColor;
+uniform bool isColorMapClampColorTransparent;
 
 
 void main(void) {
@@ -106,17 +107,15 @@ void main(void) {
       if (x < 0.0 || x > 1.0) {
          // Out of range. Use clampcolor.
          if (isClampColor) {
-            if (colorMapClampColor.w < 1.0) {
-               // Transparency in clampcolor.
-               discard;
-               return;
-            }
-            else {
-               color = colorMapClampColor;
-            }
+            color = vec4(colorMapClampColor.rgb, 1.0);
+
+         }
+         else if (isColorMapClampColorTransparent) {
+            discard;
+            return;
          }
          else {
-            // Use min/max coilor to clamp.
+            // Use min/max color to clamp.
             x = max(0.0, x);
             x = min(1.0, x);
 

--- a/react/src/lib/components/DeckGLMap/storybook/DeckGLMap.stories.jsx
+++ b/react/src/lib/components/DeckGLMap/storybook/DeckGLMap.stories.jsx
@@ -276,8 +276,8 @@ const meshMapLayer = {
     meshValueRange: [2782, 3513],
     propertyTexture: "kh_netmap_25_m_normalized_margin.png",
     propertyValueRange: [2782, 3513],
-    colorMapRange: [2815, 3513],
-    colorMapClampColor: [0, 100, 0, 0],
+    colorMapRange: [3000, 3513],
+    colorMapClampColor: [0, 255, 0], //  a color e.g. [0, 255, 0],  false or undefined.
     rotDeg: 0,
     contours: [0, 50.0],
     isContoursDepth: false,

--- a/react/src/lib/components/DeckGLMap/storybook/DeckGLMap.stories.jsx
+++ b/react/src/lib/components/DeckGLMap/storybook/DeckGLMap.stories.jsx
@@ -382,7 +382,7 @@ MapClampColor.args = {
 MapClampColor.parameters = {
     docs: {
         description: {
-            story: "An example usage of ....",
+            story: 'An example usage of map property `"colorMapClampColor"',
         },
         inlineStories: false,
         iframeHeight: 500,

--- a/react/src/lib/components/DeckGLMap/storybook/DeckGLMap.stories.jsx
+++ b/react/src/lib/components/DeckGLMap/storybook/DeckGLMap.stories.jsx
@@ -350,11 +350,11 @@ MapMaterial.parameters = {
 // Exapmple of using "colorMapClampColor" property.
 // Clamps colormap to this color at ends.
 // Given as array of three values (r,g,b) e.g: [255, 0, 0]
-// If not set (undefined) it will clamp to color map min and max values.
+// If not set (undefined) or set to true, it will clamp to color map min and max values.
 // If set to false the clamp color will be completely transparent.
 const propertyValueRange = [2782, 3513];
 const colorMapRange = [3000, 3513];
-const colorMapClampColor = [0, 255, 0]; //  a color e.g. [0, 255, 0],  false or undefined.
+const colorMapClampColor = [0, 255, 0]; // a color e.g. [0, 255, 0],  false, true or undefined.
 
 export const MapClampColor = MinimalTemplate.bind({});
 MapClampColor.args = {

--- a/react/src/lib/components/DeckGLMap/storybook/DeckGLMap.stories.jsx
+++ b/react/src/lib/components/DeckGLMap/storybook/DeckGLMap.stories.jsx
@@ -276,8 +276,6 @@ const meshMapLayer = {
     meshValueRange: [2782, 3513],
     propertyTexture: "kh_netmap_25_m_normalized_margin.png",
     propertyValueRange: [2782, 3513],
-    colorMapRange: [3000, 3513],
-    colorMapClampColor: [0, 255, 0], //  a color e.g. [0, 255, 0],  false or undefined.
     rotDeg: 0,
     contours: [0, 50.0],
     isContoursDepth: false,
@@ -343,6 +341,48 @@ MapMaterial.parameters = {
     docs: {
         description: {
             story: "An example showing example usage of Map3D material property.",
+        },
+        inlineStories: false,
+        iframeHeight: 500,
+    },
+};
+
+// Exapmple of using "colorMapClampColor" property.
+// Clamps colormap to this color at ends.
+// Given as array of three values (r,g,b) e.g: [255, 0, 0]
+// If not set (undefined) it will clamp to color map min and max values.
+// If set to false the clamp color will be completely transparent.
+const propertyValueRange = [2782, 3513];
+const colorMapRange = [3000, 3513];
+const colorMapClampColor = [0, 255, 0]; //  a color e.g. [0, 255, 0],  false or undefined.
+
+export const MapClampColor = MinimalTemplate.bind({});
+MapClampColor.args = {
+    id: "clampcolor",
+    layers: [
+        {
+            ...meshMapLayer,
+            propertyValueRange,
+            colorMapRange,
+            colorMapClampColor,
+        },
+    ],
+    bounds: [432150, 6475800, 439400, 6481500],
+    views: {
+        layout: [1, 1],
+        viewports: [
+            {
+                id: "view_1",
+                show3D: false,
+                layerIds: [],
+            },
+        ],
+    },
+};
+MapClampColor.parameters = {
+    docs: {
+        description: {
+            story: "An example usage of ....",
         },
         inlineStories: false,
         iframeHeight: 500,


### PR DESCRIPTION
  setting colorMapClampColor to false will now make this color completely transparent.