### PR TITLE
Pin `werkzeug` while waiting for upstream fix

### DIFF
--- a/.github/workflows/webviz-subsurface-components.yml
+++ b/.github/workflows/webviz-subsurface-components.yml
@@ -52,6 +52,7 @@ jobs:
           npm ci --ignore-scripts --prefix ./react
           npm run setup-deckgl-types --prefix ./react
           npm run copy-package-json --prefix ./react
+          pip install "werkzeug<2.1"  # ...while waiting for https://github.com/plotly/dash/issues/1992
           pip install .[dependencies]
           pip install dash[dev]
 


### PR DESCRIPTION
CI workaround for https://github.com/plotly/dash/issues/1992.