### PR TITLE
Remove assert from fit bouns calculation if bound is negative

### DIFF
--- a/react/src/lib/components/DeckGLMap/__snapshots__/DeckGLMap.test.tsx.snap
+++ b/react/src/lib/components/DeckGLMap/__snapshots__/DeckGLMap.test.tsx.snap
@@ -18,17 +18,6 @@ exports[`Test Map component snapshot test 1`] = `
       style="left: 0px; top: 0px; width: 100%; position: absolute; height: 100%;"
     />
   </div>
-  <div
-    style="position: absolute; left: 10px; top: 10px;"
-  >
-    <label>
-      100
-      m
-    </label>
-    <div
-      style="width: 99.27470534904805px; height: 4px; border: 2px solid gray; display: inline-block; margin-left: 3px;"
-    />
-  </div>
   <div>
     <svg
       aria-valuemax="100"
@@ -86,17 +75,6 @@ exports[`Test Map component snapshot test with edited data 1`] = `
     <canvas
       id="DeckGL-Map"
       style="left: 0px; top: 0px; width: 100%; position: absolute; height: 100%;"
-    />
-  </div>
-  <div
-    style="position: absolute; left: 10px; top: 10px;"
-  >
-    <label>
-      100
-      m
-    </label>
-    <div
-      style="width: 99.27470534904805px; height: 4px; border: 2px solid gray; display: inline-block; margin-left: 3px;"
     />
   </div>
   <div>

--- a/react/src/lib/components/DeckGLMap/components/Map.tsx
+++ b/react/src/lib/components/DeckGLMap/components/Map.tsx
@@ -602,8 +602,7 @@ function getViewState(
         height = deck.height;
     }
 
-    const padding = 20;
-    const fitted_bound = fitBounds({ width, height, bounds, padding });
+    const fitted_bound = fitBounds({ width, height, bounds });
     const view_state: ViewStateType = {
         target: [fitted_bound.x, fitted_bound.y, 0],
         zoom: zoom ?? fitted_bound.zoom,

--- a/react/src/lib/components/DeckGLMap/components/__snapshots__/Map.test.tsx.snap
+++ b/react/src/lib/components/DeckGLMap/components/__snapshots__/Map.test.tsx.snap
@@ -18,17 +18,6 @@ exports[`Test Map component snapshot test 1`] = `
       style="left: 0px; top: 0px; width: 100%; position: absolute; height: 100%;"
     />
   </div>
-  <div
-    style="position: absolute; left: 10px; top: 10px;"
-  >
-    <label>
-      100
-      m
-    </label>
-    <div
-      style="width: 99.27470534904805px; height: 4px; border: 2px solid gray; display: inline-block; margin-left: 3px;"
-    />
-  </div>
   <div>
     <svg
       aria-valuemax="100"
@@ -86,17 +75,6 @@ exports[`Test Map component snapshot test with edited data 1`] = `
     <canvas
       id="DeckGL-Map"
       style="left: 0px; top: 0px; width: 100%; position: absolute; height: 100%;"
-    />
-  </div>
-  <div
-    style="position: absolute; left: 10px; top: 10px;"
-  >
-    <label>
-      100
-      m
-    </label>
-    <div
-      style="width: 99.27470534904805px; height: 4px; border: 2px solid gray; display: inline-block; margin-left: 3px;"
     />
   </div>
   <div>

--- a/react/src/lib/components/DeckGLMap/utils/fit-bounds.js
+++ b/react/src/lib/components/DeckGLMap/utils/fit-bounds.js
@@ -57,7 +57,6 @@ export default function fitBounds({
         width - padding.left - padding.right - Math.abs(offset[0]) * 2,
         height - padding.top - padding.bottom - Math.abs(offset[1]) * 2,
     ];
-    console.assert(targetSize[0] > 0 && targetSize[1] > 0);
 
     // scale = screen pixels per unit on the Web Mercator plane
     const scaleX = targetSize[0] / size[0];


### PR DESCRIPTION
Negative bound is possible when position is supplied as longitude and latitude.
Also removed padding from fitbound calculation, let it be responsibility of the consumer to pass proper bound with enough spacing at the border.