### PR TITLE
Map component affects global style 

### DIFF
--- a/react/src/lib/components/DeckGLMap/components/InfoCard.tsx
+++ b/react/src/lib/components/DeckGLMap/components/InfoCard.tsx
@@ -6,8 +6,6 @@ import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableRow from "@material-ui/core/TableRow";
-import Paper from "@material-ui/core/Paper";
-
 import { Button, Icon } from "@equinor/eds-core-react";
 import { arrow_drop_up, arrow_drop_down } from "@equinor/eds-icons";
 
@@ -237,7 +235,7 @@ const InfoCard: React.FC<InfoCardProps> = (props: InfoCardProps) => {
     const classes = useStyles();
     return (
         infoCardData && (
-            <TableContainer component={Paper}>
+            <TableContainer>
                 <Table aria-label="info-card" className={classes.table}>
                     <TableBody>
                         {infoCardData.map(

--- a/react/src/lib/components/DeckGLMap/components/__snapshots__/InfoCard.test.tsx.snap
+++ b/react/src/lib/components/DeckGLMap/components/__snapshots__/InfoCard.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`Test Info Card snapshot test with no props 1`] = `
 }
 
 <div
-  class="MuiPaper-root MuiTableContainer-root MuiPaper-elevation1 MuiPaper-rounded"
+  class="MuiTableContainer-root"
 >
   <table
     aria-label="info-card"


### PR DESCRIPTION
Removing use of MuiPaper component as it affects global style (https://mui.com/material-ui/api/paper/).
Fix #763

