### PR TITLE
add a prop for customized camera postion in the deckgl component

### DIFF
--- a/react/src/lib/components/DeckGLMap/DeckGLMap.stories.tsx
+++ b/react/src/lib/components/DeckGLMap/DeckGLMap.stories.tsx
@@ -160,8 +160,6 @@ const getCameraPosition = {
 };
 const CustomTemplate: ComponentStory<typeof DeckGLMap> = (args) => {
     const [state, setState] = React.useState(getCameraPosition);
-    console.log(state);
-    console.log("==========");
     return (
         <>
             <DeckGLMap

--- a/react/src/lib/components/DeckGLMap/DeckGLMap.stories.tsx
+++ b/react/src/lib/components/DeckGLMap/DeckGLMap.stories.tsx
@@ -11,8 +11,7 @@ import {
     TerrainMapPickInfo,
     FeatureCollection,
 } from "../..";
-import { createStore } from "redux";
-import { getLayersWithDefaultProps } from "./layers/utils/layerTools";
+
 export default {
     component: DeckGLMap,
     title: "DeckGLMap",

--- a/react/src/lib/components/DeckGLMap/DeckGLMap.stories.tsx
+++ b/react/src/lib/components/DeckGLMap/DeckGLMap.stories.tsx
@@ -153,14 +153,35 @@ TooltipStyle.parameters = {
     },
 };
 
-export const customizedCameraPosition = Template.bind({});
+const getCameraPosition = {
+    target: [396638.95884797024, 6467831.83598219],
+    zoom: -6.28820538480389,
+    rotationX: 90,
+    rotationOrbit: 0,
+};
+const CustomTemplate: ComponentStory<typeof DeckGLMap> = (args) => (
+    <>
+        <DeckGLMap {...args} />
+        <div
+            style={{
+                position: "absolute",
+                marginTop: 100,
+            }}
+        >
+            <div>zoom: {getCameraPosition.zoom}</div>
+            <div>rotationX: {getCameraPosition.rotationX}</div>
+            <div>rotationOrbit: {getCameraPosition.rotationOrbit}</div>
+            <div>
+                targetX: {getCameraPosition.target[0]} targetY:
+                {getCameraPosition.target[1]}
+            </div>
+        </div>
+    </>
+);
+
+export const customizedCameraPosition = CustomTemplate.bind({});
 
 customizedCameraPosition.args = {
     ...defaultProps,
-    getCameraPosition: {
-        target: [396638.95884797024, 6467831.83598219],
-        zoom: -6.28820538480389,
-        rotationX: 90,
-        rotationOrbit: 0,
-    },
+    getCameraPosition: getCameraPosition,
 };

--- a/react/src/lib/components/DeckGLMap/DeckGLMap.stories.tsx
+++ b/react/src/lib/components/DeckGLMap/DeckGLMap.stories.tsx
@@ -11,7 +11,8 @@ import {
     TerrainMapPickInfo,
     FeatureCollection,
 } from "../..";
-
+import { createStore } from "redux";
+import { getLayersWithDefaultProps } from "./layers/utils/layerTools";
 export default {
     component: DeckGLMap,
     title: "DeckGLMap",
@@ -149,5 +150,17 @@ TooltipStyle.parameters = {
         },
         inlineStories: false,
         iframeHeight: 500,
+    },
+};
+
+export const customizedCameraPosition = Template.bind({});
+
+customizedCameraPosition.args = {
+    ...defaultProps,
+    getCameraPosition: {
+        target: [396638.95884797024, 6467831.83598219],
+        zoom: -6.28820538480389,
+        rotationX: 90,
+        rotationOrbit: 0,
     },
 };

--- a/react/src/lib/components/DeckGLMap/DeckGLMap.stories.tsx
+++ b/react/src/lib/components/DeckGLMap/DeckGLMap.stories.tsx
@@ -161,20 +161,6 @@ const getCameraPosition = {
 const CustomTemplate: ComponentStory<typeof DeckGLMap> = (args) => (
     <>
         <DeckGLMap {...args} />
-        <div
-            style={{
-                position: "absolute",
-                marginTop: 100,
-            }}
-        >
-            <div>zoom: {getCameraPosition.zoom}</div>
-            <div>rotationX: {getCameraPosition.rotationX}</div>
-            <div>rotationOrbit: {getCameraPosition.rotationOrbit}</div>
-            <div>
-                targetX: {getCameraPosition.target[0]} targetY:
-                {getCameraPosition.target[1]}
-            </div>
-        </div>
     </>
 );
 
@@ -183,4 +169,5 @@ export const customizedCameraPosition = CustomTemplate.bind({});
 customizedCameraPosition.args = {
     ...defaultProps,
     getCameraPosition: getCameraPosition,
+    isVisible: true,
 };

--- a/react/src/lib/components/DeckGLMap/DeckGLMap.stories.tsx
+++ b/react/src/lib/components/DeckGLMap/DeckGLMap.stories.tsx
@@ -158,16 +158,35 @@ const getCameraPosition = {
     rotationX: 90,
     rotationOrbit: 0,
 };
-const CustomTemplate: ComponentStory<typeof DeckGLMap> = (args) => (
-    <>
-        <DeckGLMap {...args} />
-    </>
-);
+const CustomTemplate: ComponentStory<typeof DeckGLMap> = (args) => {
+    const [state, setState] = React.useState(getCameraPosition);
+    console.log(state);
+    console.log("==========");
+    return (
+        <>
+            <DeckGLMap
+                {...args}
+                getCameraPosition={state}
+                setState={setState}
+            />
+            <div
+                style={{
+                    position: "absolute",
+                    marginLeft: 200,
+                }}
+            >
+                <div>zoom: {state?.zoom}</div>
+                <div>rotationX: {state?.rotationX}</div>
+                <div>rotationOrbit: {state?.rotationOrbit}</div>
+                <div>
+                    targetX: {state?.target[0]} targetY:
+                    {state?.target[1]}
+                </div>
+            </div>
+        </>
+    );
+};
 
 export const customizedCameraPosition = CustomTemplate.bind({});
 
-customizedCameraPosition.args = {
-    ...defaultProps,
-    getCameraPosition: getCameraPosition,
-    isVisible: true,
-};
+customizedCameraPosition.args = defaultProps;

--- a/react/src/lib/components/DeckGLMap/DeckGLMap.tsx
+++ b/react/src/lib/components/DeckGLMap/DeckGLMap.tsx
@@ -65,7 +65,7 @@ export interface DeckGLMapProps {
      */
     getTooltip?: TooltipCallback;
     getCameraPosition?: ViewStateType | undefined;
-    setState: React.Dispatch<
+    setState?: React.Dispatch<
         React.SetStateAction<{
             target: number[];
             zoom: number;
@@ -95,7 +95,7 @@ const DeckGLMap: React.FC<DeckGLMapProps> = ({
     selection,
     getTooltip,
     getCameraPosition,
-    setState
+    setState,
 }: DeckGLMapProps) => {
     // Contains layers data received from map layers by user interaction
     const [layerEditedData, setLayerEditedData] = React.useState(editedData);

--- a/react/src/lib/components/DeckGLMap/DeckGLMap.tsx
+++ b/react/src/lib/components/DeckGLMap/DeckGLMap.tsx
@@ -65,7 +65,14 @@ export interface DeckGLMapProps {
      */
     getTooltip?: TooltipCallback;
     getCameraPosition?: ViewStateType | undefined;
-    isVisible: boolean;
+    setState: React.Dispatch<
+        React.SetStateAction<{
+            target: number[];
+            zoom: number;
+            rotationX: number;
+            rotationOrbit: number;
+        }>
+    >;
 }
 
 const DeckGLMap: React.FC<DeckGLMapProps> = ({
@@ -88,7 +95,7 @@ const DeckGLMap: React.FC<DeckGLMapProps> = ({
     selection,
     getTooltip,
     getCameraPosition,
-    isVisible,
+    setState
 }: DeckGLMapProps) => {
     // Contains layers data received from map layers by user interaction
     const [layerEditedData, setLayerEditedData] = React.useState(editedData);
@@ -151,7 +158,7 @@ const DeckGLMap: React.FC<DeckGLMapProps> = ({
                 selection={selection}
                 getTooltip={getTooltip}
                 getCameraPosition={getCameraPosition}
-                isVisible={isVisible}
+                setState={setState}
             />
         </ReduxProvider>
     );

--- a/react/src/lib/components/DeckGLMap/DeckGLMap.tsx
+++ b/react/src/lib/components/DeckGLMap/DeckGLMap.tsx
@@ -65,6 +65,7 @@ export interface DeckGLMapProps {
      */
     getTooltip?: TooltipCallback;
     getCameraPosition?: ViewStateType | undefined;
+    isVisible: boolean;
 }
 
 const DeckGLMap: React.FC<DeckGLMapProps> = ({
@@ -87,6 +88,7 @@ const DeckGLMap: React.FC<DeckGLMapProps> = ({
     selection,
     getTooltip,
     getCameraPosition,
+    isVisible,
 }: DeckGLMapProps) => {
     // Contains layers data received from map layers by user interaction
     const [layerEditedData, setLayerEditedData] = React.useState(editedData);
@@ -149,6 +151,7 @@ const DeckGLMap: React.FC<DeckGLMapProps> = ({
                 selection={selection}
                 getTooltip={getTooltip}
                 getCameraPosition={getCameraPosition}
+                isVisible={isVisible}
             />
         </ReduxProvider>
     );

--- a/react/src/lib/components/DeckGLMap/DeckGLMap.tsx
+++ b/react/src/lib/components/DeckGLMap/DeckGLMap.tsx
@@ -1,4 +1,8 @@
-import Map, { ViewsType, TooltipCallback, ViewStateType } from "./components/Map";
+import Map, {
+    ViewsType,
+    TooltipCallback,
+    ViewStateType,
+} from "./components/Map";
 import { MapMouseEvent } from "./components/Map";
 import React from "react";
 import PropTypes from "prop-types";

--- a/react/src/lib/components/DeckGLMap/DeckGLMap.tsx
+++ b/react/src/lib/components/DeckGLMap/DeckGLMap.tsx
@@ -1,4 +1,4 @@
-import Map, { ViewsType, TooltipCallback } from "./components/Map";
+import Map, { ViewsType, TooltipCallback, ViewStateType } from "./components/Map";
 import { MapMouseEvent } from "./components/Map";
 import React from "react";
 import PropTypes from "prop-types";
@@ -60,6 +60,7 @@ export interface DeckGLMapProps {
      * Override default tooltip with a callback.
      */
     getTooltip?: TooltipCallback;
+    getCameraPosition?: ViewStateType | undefined;
 }
 
 const DeckGLMap: React.FC<DeckGLMapProps> = ({
@@ -81,6 +82,7 @@ const DeckGLMap: React.FC<DeckGLMapProps> = ({
     onMouseEvent,
     selection,
     getTooltip,
+    getCameraPosition,
 }: DeckGLMapProps) => {
     // Contains layers data received from map layers by user interaction
     const [layerEditedData, setLayerEditedData] = React.useState(editedData);
@@ -142,6 +144,7 @@ const DeckGLMap: React.FC<DeckGLMapProps> = ({
                 onMouseEvent={onMouseEvent}
                 selection={selection}
                 getTooltip={getTooltip}
+                getCameraPosition={getCameraPosition}
             />
         </ReduxProvider>
     );

--- a/react/src/lib/components/DeckGLMap/components/Map.tsx
+++ b/react/src/lib/components/DeckGLMap/components/Map.tsx
@@ -241,9 +241,6 @@ function defaultTooltip(info: PickInfo<unknown>) {
     return feat?.properties?.["name"];
 }
 
-// function defaultCameraPosition() {
-//    return {}
-// }
 const Map: React.FC<MapProps> = ({
     id,
     resources,
@@ -602,22 +599,6 @@ MapProps) => {
             ) : null}
             <StatusIndicator layers={deckGLLayers} isLoaded={isLoaded} />
             {coords?.visible ? <InfoCard pickInfos={hoverInfo} /> : null}
-            {Object.keys(getCameraPosition).length !== 0 ? (
-                <div
-                    style={{
-                        position: "absolute",
-                        marginTop: 100,
-                    }}
-                >
-                    <div>zoom: {getCameraPosition.zoom}</div>
-                    <div>rotationX: {getCameraPosition.rotationX}</div>
-                    <div>rotationOrbit: {getCameraPosition.rotationOrbit}</div>
-                    <div>
-                        targetX: {getCameraPosition.target[0]} targetY:
-                        {getCameraPosition.target[1]}
-                    </div>
-                </div>
-            ) : null}
             {errorText && (
                 <pre
                     style={{

--- a/react/src/lib/components/DeckGLMap/components/Map.tsx
+++ b/react/src/lib/components/DeckGLMap/components/Map.tsx
@@ -206,7 +206,14 @@ export interface MapProps {
 
     getTooltip?: TooltipCallback;
     getCameraPosition?: ViewStateType | undefined;
-    isVisible: boolean;
+    setState: React.Dispatch<
+        React.SetStateAction<{
+            target: number[];
+            zoom: number;
+            rotationX: number;
+            rotationOrbit: number;
+        }>
+    >;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -263,13 +270,14 @@ const Map: React.FC<MapProps> = ({
     children,
     getTooltip = defaultTooltip,
     getCameraPosition = {} as ViewStateType,
-    isVisible = false,
+    setState
 }: MapProps) => {
     const deckRef = useRef<DeckGL>(null);
     // set initial view state based on supplied bounds and zoom in viewState
     const [viewState, setViewState] =
         useState<ViewStateType>(getCameraPosition);
     getCameraPosition = viewState;
+    setState(getCameraPosition);
     // react on zoom prop change
     useEffect(() => {
         const vs = getViewState(bounds, zoom, deckRef.current?.deck);
@@ -588,29 +596,12 @@ const Map: React.FC<MapProps> = ({
                         </DeckGLView>
                     ))}
             </DeckGL>
-
             {scale?.visible ? (
                 <DistanceScale
                     {...scale}
                     zoom={viewState?.zoom}
                     scaleUnit={coordinateUnit}
                 />
-            ) : null}
-            {isVisible ? (
-                <div
-                    style={{
-                        position: "absolute",
-                        marginLeft: 200,
-                    }}
-                >
-                    <div>zoom: {getCameraPosition?.zoom}</div>
-                    <div>rotationX: {getCameraPosition?.rotationX}</div>
-                    <div>rotationOrbit: {getCameraPosition?.rotationOrbit}</div>
-                    <div>
-                        targetX: {getCameraPosition?.target[0]} targetY:
-                        {getCameraPosition?.target[1]}
-                    </div>
-                </div>
             ) : null}
             <StatusIndicator layers={deckGLLayers} isLoaded={isLoaded} />
             {coords?.visible ? <InfoCard pickInfos={hoverInfo} /> : null}

--- a/react/src/lib/components/DeckGLMap/components/Map.tsx
+++ b/react/src/lib/components/DeckGLMap/components/Map.tsx
@@ -206,6 +206,7 @@ export interface MapProps {
 
     getTooltip?: TooltipCallback;
     getCameraPosition?: ViewStateType | undefined;
+    isVisible: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -262,15 +263,13 @@ const Map: React.FC<MapProps> = ({
     children,
     getTooltip = defaultTooltip,
     getCameraPosition = {} as ViewStateType,
-}: 
-MapProps) => {
+    isVisible = false,
+}: MapProps) => {
     const deckRef = useRef<DeckGL>(null);
-    // getViewState(bounds, zoom)
     // set initial view state based on supplied bounds and zoom in viewState
     const [viewState, setViewState] =
         useState<ViewStateType>(getCameraPosition);
     getCameraPosition = viewState;
-    console.log(viewState);
     // react on zoom prop change
     useEffect(() => {
         const vs = getViewState(bounds, zoom, deckRef.current?.deck);
@@ -596,6 +595,22 @@ MapProps) => {
                     zoom={viewState?.zoom}
                     scaleUnit={coordinateUnit}
                 />
+            ) : null}
+            {isVisible ? (
+                <div
+                    style={{
+                        position: "absolute",
+                        marginLeft: 200,
+                    }}
+                >
+                    <div>zoom: {getCameraPosition?.zoom}</div>
+                    <div>rotationX: {getCameraPosition?.rotationX}</div>
+                    <div>rotationOrbit: {getCameraPosition?.rotationOrbit}</div>
+                    <div>
+                        targetX: {getCameraPosition?.target[0]} targetY:
+                        {getCameraPosition?.target[1]}
+                    </div>
+                </div>
             ) : null}
             <StatusIndicator layers={deckGLLayers} isLoaded={isLoaded} />
             {coords?.visible ? <InfoCard pickInfos={hoverInfo} /> : null}

--- a/react/src/lib/components/DeckGLMap/components/Map.tsx
+++ b/react/src/lib/components/DeckGLMap/components/Map.tsx
@@ -206,7 +206,7 @@ export interface MapProps {
 
     getTooltip?: TooltipCallback;
     getCameraPosition?: ViewStateType | undefined;
-    setState: React.Dispatch<
+    setState?: React.Dispatch<
         React.SetStateAction<{
             target: number[];
             zoom: number;
@@ -270,14 +270,18 @@ const Map: React.FC<MapProps> = ({
     children,
     getTooltip = defaultTooltip,
     getCameraPosition = {} as ViewStateType,
-    setState
+    setState,
 }: MapProps) => {
     const deckRef = useRef<DeckGL>(null);
     // set initial view state based on supplied bounds and zoom in viewState
     const [viewState, setViewState] =
         useState<ViewStateType>(getCameraPosition);
     getCameraPosition = viewState;
-    setState(getCameraPosition);
+
+    if (setState) {
+        setState(getCameraPosition);
+    }
+
     // react on zoom prop change
     useEffect(() => {
         const vs = getViewState(bounds, zoom, deckRef.current?.deck);

--- a/react/src/lib/components/DeckGLMap/storybook/components/Map.stories.jsx
+++ b/react/src/lib/components/DeckGLMap/storybook/components/Map.stories.jsx
@@ -27,10 +27,15 @@ const Template = (args) => {
             setEditedData={(updatedProps) => {
                 setEditedData(updatedProps.editedData);
             }}
+            getCameraPosition={{
+                target: [396638.95884797024, 6467831.83598219],
+                zoom: -6.28820538480389,
+                rotationX: 90,
+                rotationOrbit: 0,
+            }}
         />
     );
 };
-
 export const Default = Template.bind({});
 Default.args = {
     ...exampleData[0],

--- a/react/src/lib/components/DeckGLMap/storybook/components/Map.stories.jsx
+++ b/react/src/lib/components/DeckGLMap/storybook/components/Map.stories.jsx
@@ -27,12 +27,6 @@ const Template = (args) => {
             setEditedData={(updatedProps) => {
                 setEditedData(updatedProps.editedData);
             }}
-            getCameraPosition={{
-                target: [396638.95884797024, 6467831.83598219],
-                zoom: -6.28820538480389,
-                rotationX: 90,
-                rotationOrbit: 0,
-            }}
         />
     );
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39239025/180970658-80f76306-29f0-40b1-879b-bc7c22269b9e.png)
With user customer defined camera position

![image](https://user-images.githubusercontent.com/39239025/180970796-d56d30b1-3fd4-461e-96d1-e208e29955f6.png)
With default camera position