### PR TITLE
fix WellsLayer.onClick to allow generating of onMouseEvent

### DIFF
--- a/react/src/lib/components/DeckGLMap/layers/wells/wellsLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/wells/wellsLayer.ts
@@ -226,7 +226,7 @@ export default class WellsLayer extends CompositeLayer<
                 selectedWell: (info.object as Feature).properties?.["name"],
                 multiSelectedWells: this.state.multipleSelectionWells,
             });
-            return true;
+            return false; // do not return true to allow DeckGL props.onClick to be called
         }
     }
 


### PR DESCRIPTION
Fix a bug described in https://github.com/equinor/webviz-subsurface-components/issues/1163