### PR TITLE
reset cameraPosition if cameraPosition is null

### DIFF
--- a/react/src/lib/components/DeckGLMap/DeckGLMap.stories.tsx
+++ b/react/src/lib/components/DeckGLMap/DeckGLMap.stories.tsx
@@ -28,6 +28,12 @@ const defaultProps = {
     resources: {
         wellsData: "./volve_wells.json",
     },
+    bounds: [432150, 6475800, 439400, 6481500] as [
+        number,
+        number,
+        number,
+        number
+    ],
     layers: [defaultWellsLayer],
 };
 

--- a/react/src/lib/components/DeckGLMap/components/Map.tsx
+++ b/react/src/lib/components/DeckGLMap/components/Map.tsx
@@ -321,7 +321,6 @@ const Map: React.FC<MapProps> = ({
             tempViewStates = Object.fromEntries(
                 viewsProps.map((item) => [item.id, cameraPosition])
             );
-            setViewStates(tempViewStates);
         } else {
             tempViewStates = Object.fromEntries(
                 viewsProps.map((item, index) => [
@@ -334,7 +333,6 @@ const Map: React.FC<MapProps> = ({
                     ),
                 ])
             );
-            setViewStates(tempViewStates);
         }
         if (viewsProps[0] !== undefined) {
             setFirstViewStatesId(viewsProps[0].id);
@@ -349,7 +347,6 @@ const Map: React.FC<MapProps> = ({
             tempViewStates = Object.fromEntries(
                 viewsProps.map((item) => [item.id, cameraPosition])
             );
-            setViewStates(tempViewStates);
         } else {
             tempViewStates = Object.fromEntries(
                 viewsProps.map((item, index) => [
@@ -383,9 +380,9 @@ const Map: React.FC<MapProps> = ({
         // If "bounds" or "cameraPosition" is not defined "viewState" will be
         // calculated based on the union of the reported bounding boxes from each layer.
         const isBoundsDefined =
-            typeof bounds !== "undefined" &&
-            typeof cameraPosition !== "undefined";
-
+            (typeof bounds !== "undefined" ||
+                typeof cameraPosition !== "undefined") &&
+            cameraPosition !== null;
         const union_of_reported_bboxes = addBoundingBoxes(
             reportedBoundingBoxAcc,
             reportedBoundingBox
@@ -404,11 +401,11 @@ const Map: React.FC<MapProps> = ({
                 ),
             ])
         );
-
+        console.log("yes")
         if (!isBoundsDefined) {
             setViewStates(tempViewStates);
         }
-    }, [reportedBoundingBox]);
+    }, [reportedBoundingBox, cameraPosition]);
 
     // react on bounds prop change
     useEffect(() => {
@@ -431,7 +428,7 @@ const Map: React.FC<MapProps> = ({
             setViewStates(tempViewStates);
         }
     }, [bounds]);
-
+    console.log(cameraPosition);
     // react on cameraPosition prop change
     useEffect(() => {
         let tempViewStates: Record<string, ViewStateType> = {};
@@ -895,6 +892,7 @@ function getViewState(
     zoom?: number,
     deck?: Deck
 ): ViewStateType {
+    console.log("getCalled");
     let bounds = [0, 0, 1, 1];
     if (typeof bounds_accessor == "function") {
         bounds = bounds_accessor();

--- a/react/src/lib/components/DeckGLMap/components/Map.tsx
+++ b/react/src/lib/components/DeckGLMap/components/Map.tsx
@@ -387,7 +387,7 @@ const Map: React.FC<MapProps> = ({
         // If "bounds" or "cameraPosition" is not defined "viewState" will be
         // calculated based on the union of the reported bounding boxes from each layer.
         const isBoundsDefined =
-            typeof bounds !== "undefined" ||
+            typeof bounds !== "undefined" &&
             typeof cameraPosition !== "undefined";
         const union_of_reported_bboxes = addBoundingBoxes(
             reportedBoundingBoxAcc,

--- a/react/src/lib/components/DeckGLMap/components/Map.tsx
+++ b/react/src/lib/components/DeckGLMap/components/Map.tsx
@@ -302,6 +302,19 @@ const Map: React.FC<MapProps> = ({
     // state for views prop of DeckGL component
     const [viewsProps, setViewsProps] = useState<ViewportType[]>([]);
 
+    // React.useEffect(() => {
+    //     function handleResize() {
+    //         console.log(
+    //             "resized to: ",
+    //             window.innerWidth,
+    //             "x",
+    //             window.innerHeight
+    //         );
+    //     }
+
+    //     window.addEventListener("resize", handleResize);
+    // });
+
     useEffect(() => {
         setViewsProps(getViews(views) as ViewportType[]);
     }, [views]);
@@ -401,7 +414,6 @@ const Map: React.FC<MapProps> = ({
                 ),
             ])
         );
-        console.log("yes")
         if (!isBoundsDefined) {
             setViewStates(tempViewStates);
         }
@@ -428,7 +440,7 @@ const Map: React.FC<MapProps> = ({
             setViewStates(tempViewStates);
         }
     }, [bounds]);
-    console.log(cameraPosition);
+
     // react on cameraPosition prop change
     useEffect(() => {
         let tempViewStates: Record<string, ViewStateType> = {};
@@ -731,10 +743,8 @@ const Map: React.FC<MapProps> = ({
         },
         [viewStates]
     );
-
     if (!deckGLViews || isEmpty(deckGLViews) || isEmpty(deckGLLayers))
         return null;
-
     return (
         <div onContextMenu={(event) => event.preventDefault()}>
             <DeckGL
@@ -892,7 +902,6 @@ function getViewState(
     zoom?: number,
     deck?: Deck
 ): ViewStateType {
-    console.log("getCalled");
     let bounds = [0, 0, 1, 1];
     if (typeof bounds_accessor == "function") {
         bounds = bounds_accessor();

--- a/react/src/lib/components/DeckGLMap/storybook/DeckGLMap.stories.jsx
+++ b/react/src/lib/components/DeckGLMap/storybook/DeckGLMap.stories.jsx
@@ -486,7 +486,6 @@ MultiView.args = {
     legend: {
         visible: false,
     },
-    zoom: -5,
     layers: [
         ...exampleData[0].layers,
         customLayerWithPolylineData,


### PR DESCRIPTION
fixes #1191 

Origin with CustomCameraPosition:
![image](https://user-images.githubusercontent.com/39239025/191784464-10b48d6b-cc21-450b-bc93-6a4c6b80963c.png)

After set CustomCamraPosition as null:
![image](https://user-images.githubusercontent.com/39239025/191784549-e5d8cf83-4d6e-443d-8a10-e28bfabb909e.png)

Improvement: 
- [ ]I think we can  update the getCameraPosition after cameraPosition set to null, otherwise it will be a bit confusing