### PR TITLE
Fixes: Phong shading for map layer #1290

### DIFF
--- a/react/src/lib/components/DeckGLMap/layers/layersDefaultProps.ts
+++ b/react/src/lib/components/DeckGLMap/layers/layersDefaultProps.ts
@@ -52,6 +52,8 @@ export const layersDefaultProps: Record<string, unknown> = {
         // If contour lines should follow depth or properties.
         isContoursDepth: true,
         gridLines: false,
+        enableSmoothShading: true,
+        material: true,
     },
 
     Map3DLayer: {

--- a/react/src/lib/components/DeckGLMap/layers/layersDefaultProps.ts
+++ b/react/src/lib/components/DeckGLMap/layers/layersDefaultProps.ts
@@ -52,7 +52,7 @@ export const layersDefaultProps: Record<string, unknown> = {
         // If contour lines should follow depth or properties.
         isContoursDepth: true,
         gridLines: false,
-        enableSmoothShading: true,
+        smoothShading: true,
         material: true,
     },
 
@@ -73,7 +73,7 @@ export const layersDefaultProps: Record<string, unknown> = {
         contours: [-1.0, -1.0],
         // If contour lines should follow depth or properties.
         isContoursDepth: true,
-        enableSmoothShading: true,
+        smoothShading: true,
         material: true,
     },
     GridLayer: {

--- a/react/src/lib/components/DeckGLMap/layers/map/fragment.fs.glsl.ts
+++ b/react/src/lib/components/DeckGLMap/layers/map/fragment.fs.glsl.ts
@@ -31,7 +31,7 @@ uniform float colorMapRangeMax;
 uniform vec3 colorMapClampColor;
 uniform bool isClampColor;
 uniform bool isColorMapClampColorTransparent;
-uniform bool enableSmoothShading;
+uniform bool smoothShading;
 
 
 void main(void) {
@@ -39,7 +39,7 @@ void main(void) {
 
    vec3 normal = normals_commonspace;
 
-   if (!enableSmoothShading) {
+   if (!smoothShading) {
       normal = normalize(cross(dFdx(position_commonspace.xyz), dFdy(position_commonspace.xyz)));
    } 
 

--- a/react/src/lib/components/DeckGLMap/layers/map/fragment.fs.glsl.ts
+++ b/react/src/lib/components/DeckGLMap/layers/map/fragment.fs.glsl.ts
@@ -10,7 +10,7 @@ uniform float contourInterval;
 
 in vec2 vTexCoord;
 in vec3 cameraPosition;
-//in vec3 normals_commonspace;
+in vec3 normals_commonspace;
 in vec4 position_commonspace;
 in vec4 vColor;
 
@@ -21,7 +21,6 @@ out vec4 fragColor;
 in vec3 worldPos;
 in float property;
 
-// XXXX =========
 uniform sampler2D colormap;
 
 uniform float valueRangeMin;
@@ -32,20 +31,17 @@ uniform float colorMapRangeMax;
 uniform vec3 colorMapClampColor;
 uniform bool isClampColor;
 uniform bool isColorMapClampColorTransparent;
-
+uniform bool enableSmoothShading;
 
 
 void main(void) {
    geometry.uv = vTexCoord;
 
-   vec3 normal = vec3(0.0, 0.0, 1.0);
-   bool nomals_available = false;
-   if (!nomals_available) {
+   vec3 normal = normals_commonspace;
+
+   if (!enableSmoothShading) {
       normal = normalize(cross(dFdx(position_commonspace.xyz), dFdy(position_commonspace.xyz)));
    } 
-   // else {
-   //    normal = normals_commonspace;
-   // }
 
    // // Discard transparent pixels. KEEP
    // if (!picking_uActive && isnan(propertyValue)) {
@@ -120,7 +116,7 @@ void main(void) {
       color = color * vec4(c, c, c, 1.0);
    }
 
-   // Use normal lighting.
+   // Use normal lighting. This has no effect if "material" property is not set.
    vec3 lightColor = lighting_getLightColor(color.rgb, cameraPosition, position_commonspace.xyz, normal);
    fragColor = vec4(lightColor, 1.0);
 

--- a/react/src/lib/components/DeckGLMap/layers/map/mapLayer.stories.tsx
+++ b/react/src/lib/components/DeckGLMap/layers/map/mapLayer.stories.tsx
@@ -120,7 +120,7 @@ const cellCenteredPropertiesLayer = {
         value * 255,
         value * 255,
     ],
-    enableSmoothShading: true,
+    smoothShading: true,
 };
 
 // Example using "Map" layer. Uses PNG float for mesh and properties.
@@ -139,7 +139,7 @@ const meshMapLayerPng = {
     isContoursDepth: true,
     gridLines: false,
     material: true,
-    enableSmoothShading: true,
+    smoothShading: true,
     colorMapName: "Physics",
 };
 

--- a/react/src/lib/components/DeckGLMap/layers/map/mapLayer.stories.tsx
+++ b/react/src/lib/components/DeckGLMap/layers/map/mapLayer.stories.tsx
@@ -88,7 +88,7 @@ const nodeCenteredPropertiesLayer = {
     propertiesUrl:
         "data:text/plain;base64,ZmYmQM3MLEAzMzNAmpk5QM3MDEAzMxNAmpkZQAAAIEBmZuY/MzPzPwAAAEBmZgZAMzOzPwAAwD/NzMw/mpnZPwAAgD/NzIw/mpmZP2Zmpj8=",
     gridLines: true,
-    material: false,
+    material: true,
     // black to white colors.
     colorMapFunction: (value: number) => [
         value * 255,
@@ -113,13 +113,14 @@ const cellCenteredPropertiesLayer = {
     propertiesUrl:
         "data:text/plain;base64,ZmZmPwAAgD/NzIw/mpkZPzMzMz/NzEw/mpmZPs3MzD4AAAA/AAAAAM3MzD3NzEw+",
     gridLines: true,
-    material: false,
+    material: true,
     // black to white colors.
     colorMapFunction: (value: number) => [
         value * 255,
         value * 255,
         value * 255,
     ],
+    enableSmoothShading: true,
 };
 
 // Example using "Map" layer. Uses PNG float for mesh and properties.
@@ -138,6 +139,7 @@ const meshMapLayerPng = {
     isContoursDepth: true,
     gridLines: false,
     material: true,
+    enableSmoothShading: true,
     colorMapName: "Physics",
 };
 
@@ -580,7 +582,7 @@ SmallMap.args = {
         viewports: [
             {
                 id: "view_1",
-                show3D: false,
+                show3D: true,
             },
         ],
     },
@@ -598,7 +600,7 @@ SmallMap.parameters = {
 const axes_lite = {
     "@@type": "AxesLayer",
     id: "axes_small",
-    bounds: [-1, -1, -30, 4, 5, 0],
+    bounds: [-1, -1, -3, 4, 5, 0],
 };
 
 //-- CellCenteredPropMap --
@@ -615,7 +617,7 @@ CellCenteredPropMap.args = {
         viewports: [
             {
                 id: "view_1",
-                show3D: false,
+                show3D: true,
             },
         ],
     },
@@ -644,7 +646,7 @@ NodeCenteredPropMap.args = {
         viewports: [
             {
                 id: "view_1",
-                show3D: false,
+                show3D: true,
             },
         ],
     },

--- a/react/src/lib/components/DeckGLMap/layers/map/mapLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/map/mapLayer.ts
@@ -32,6 +32,7 @@ export type Params = {
     propertiesData: Float32Array;
     isMesh: boolean;
     frame: Frame;
+    enableSmoothShading: boolean;
 };
 
 async function load_mesh_and_properties(
@@ -207,6 +208,10 @@ export interface MapLayerProps<D> extends ExtendedLayerProps<D> {
     //           specularColor: [255, 255, 255],
     //       }
     material: Material;
+
+    // Will calculate normals for each vertex and enable phong shading.
+    // If not set the shader will calculate constant normal for each triangle.
+    enableSmoothShading: boolean;
 }
 
 export default class MapLayer extends CompositeLayer<MapLayerProps<unknown>> {
@@ -231,6 +236,7 @@ export default class MapLayer extends CompositeLayer<MapLayerProps<unknown>> {
                 propertiesData,
                 isMesh,
                 frame: this.props.frame,
+                enableSmoothShading: this.props.enableSmoothShading,
             };
 
             webWorker.postMessage(webworkerParams);
@@ -351,6 +357,7 @@ export default class MapLayer extends CompositeLayer<MapLayerProps<unknown>> {
                 colorMapFunction: this.props.colorMapFunction,
                 propertyValueRange: this.state["propertyValueRange"],
                 material: this.props.material,
+                enableSmoothShading: this.props.enableSmoothShading,
             })
         );
         return [layer];

--- a/react/src/lib/components/DeckGLMap/layers/map/mapLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/map/mapLayer.ts
@@ -32,7 +32,7 @@ export type Params = {
     propertiesData: Float32Array;
     isMesh: boolean;
     frame: Frame;
-    enableSmoothShading: boolean;
+    smoothShading: boolean;
 };
 
 async function load_mesh_and_properties(
@@ -211,7 +211,7 @@ export interface MapLayerProps<D> extends ExtendedLayerProps<D> {
 
     // Will calculate normals for each vertex and enable phong shading.
     // If not set the shader will calculate constant normal for each triangle.
-    enableSmoothShading: boolean;
+    smoothShading: boolean;
 }
 
 export default class MapLayer extends CompositeLayer<MapLayerProps<unknown>> {
@@ -236,7 +236,7 @@ export default class MapLayer extends CompositeLayer<MapLayerProps<unknown>> {
                 propertiesData,
                 isMesh,
                 frame: this.props.frame,
-                enableSmoothShading: this.props.enableSmoothShading,
+                smoothShading: this.props.smoothShading,
             };
 
             webWorker.postMessage(webworkerParams);
@@ -357,7 +357,7 @@ export default class MapLayer extends CompositeLayer<MapLayerProps<unknown>> {
                 colorMapFunction: this.props.colorMapFunction,
                 propertyValueRange: this.state["propertyValueRange"],
                 material: this.props.material,
-                enableSmoothShading: this.props.enableSmoothShading,
+                smoothShading: this.props.smoothShading,
             })
         );
         return [layer];

--- a/react/src/lib/components/DeckGLMap/layers/map/privateMapLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/map/privateMapLayer.ts
@@ -38,7 +38,7 @@ export type MeshType = {
     attributes: {
         positions: { value: Float32Array; size: number };
         TEXCOORD_0?: { value: Float32Array; size: number };
-        normals?: { value: Float32Array; size: number };
+        normals: { value: Float32Array; size: number };
         properties: { value: Float32Array; size: number };
         vertex_indexs: { value: Int32Array; size: number };
     };
@@ -105,6 +105,7 @@ export interface privateMapLayerProps<D> extends ExtendedLayerProps<D> {
     colorMapClampColor: Color | undefined | boolean;
     colorMapFunction?: colorMapFunctionType | false;
     propertyValueRange: [number, number];
+    enableSmoothShading: boolean;
 }
 
 const defaultProps = {
@@ -159,6 +160,7 @@ export default class privateMapLayer extends Layer<
                 drawMode: this.props.mesh.drawMode,
                 attributes: {
                     positions: this.props.mesh.attributes.positions,
+                    normals: this.props.mesh.attributes.normals,
                     properties: this.props.mesh.attributes.properties,
                     vertex_indexs: this.props.mesh.attributes.vertex_indexs,
                 },
@@ -222,6 +224,8 @@ export default class privateMapLayer extends Layer<
         const isColorMapClampColorTransparent: boolean =
             (this.props.colorMapClampColor as boolean) === false;
 
+        const enableSmoothShading = this.props.enableSmoothShading;
+
         gl.enable(gl.POLYGON_OFFSET_FILL);
         gl.polygonOffset(1, 1);
         model_mesh
@@ -249,6 +253,7 @@ export default class privateMapLayer extends Layer<
                 colorMapClampColor,
                 isColorMapClampColorTransparent,
                 isClampColor,
+                enableSmoothShading,
             })
             .draw();
         gl.disable(gl.POLYGON_OFFSET_FILL);

--- a/react/src/lib/components/DeckGLMap/layers/map/privateMapLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/map/privateMapLayer.ts
@@ -105,7 +105,7 @@ export interface privateMapLayerProps<D> extends ExtendedLayerProps<D> {
     colorMapClampColor: Color | undefined | boolean;
     colorMapFunction?: colorMapFunctionType | false;
     propertyValueRange: [number, number];
-    enableSmoothShading: boolean;
+    smoothShading: boolean;
 }
 
 const defaultProps = {
@@ -224,7 +224,7 @@ export default class privateMapLayer extends Layer<
         const isColorMapClampColorTransparent: boolean =
             (this.props.colorMapClampColor as boolean) === false;
 
-        const enableSmoothShading = this.props.enableSmoothShading;
+        const smoothShading = this.props.smoothShading;
 
         gl.enable(gl.POLYGON_OFFSET_FILL);
         gl.polygonOffset(1, 1);
@@ -253,7 +253,7 @@ export default class privateMapLayer extends Layer<
                 colorMapClampColor,
                 isColorMapClampColorTransparent,
                 isClampColor,
-                enableSmoothShading,
+                smoothShading,
             })
             .draw();
         gl.disable(gl.POLYGON_OFFSET_FILL);

--- a/react/src/lib/components/DeckGLMap/layers/map/vertex.glsl.ts
+++ b/react/src/lib/components/DeckGLMap/layers/map/vertex.glsl.ts
@@ -7,7 +7,7 @@ precision highp float;
 // Primitive attributes
 in vec3 positions;
 in float properties;
-//in vec3 normals;
+in vec3 normals;
 in vec3 colors;
 
 in int vertex_indexs;
@@ -17,7 +17,7 @@ flat out int vertex_indexs_;
 // Outputs to fragment shader
 out vec2 vTexCoord;
 out vec3 cameraPosition;
-// out vec3 normals_commonspace;
+out vec3 normals_commonspace;
 out vec4 position_commonspace;
 out vec4 vColor;
 out vec3 worldPos;
@@ -28,6 +28,8 @@ void main(void) {
    cameraPosition = project_uCameraPosition;
 
    worldPos = positions;
+
+   normals_commonspace = normals;
 
    vertex_indexs_ = vertex_indexs;
 

--- a/react/src/lib/components/DeckGLMap/layers/map/webworker.ts
+++ b/react/src/lib/components/DeckGLMap/layers/map/webworker.ts
@@ -13,7 +13,7 @@ export function makeFullMesh(e: { data: Params }): void {
     const propertiesData = params.propertiesData;
     const isMesh = params.isMesh;
     const frame = params.frame;
-    const enableSmoothShading = params.enableSmoothShading;
+    const smoothShading = params.smoothShading;
 
     function getFloat32ArrayMinMax(data: Float32Array) {
         let max = -99999999;
@@ -47,12 +47,12 @@ export function makeFullMesh(e: { data: Params }): void {
         nx: number,
         ny: number,
         isMesh: boolean,
-        enableSmoothShading: boolean,
+        smoothShading: boolean,
         meshData: Float32Array,
         ox: number,
         oy: number
     ) {
-        if (!enableSmoothShading) {
+        if (!smoothShading) {
             return [1, 1, 1];
         }
 
@@ -185,7 +185,7 @@ export function makeFullMesh(e: { data: Params }): void {
 
                 positions.push(x0, y0, z);
 
-                const normal = calcNormal(w, h, nx, ny, isMesh, enableSmoothShading, meshData, ox, oy); // eslint-disable-line
+                const normal = calcNormal(w, h, nx, ny, isMesh, smoothShading, meshData, ox, oy); // eslint-disable-line
                 normals.push(normal[0], normal[1], normal[2]);
 
                 vertexProperties.push(propertyValue);
@@ -282,10 +282,10 @@ export function makeFullMesh(e: { data: Params }): void {
                 const i2 = (h + 1) * nx + (w + 1);
                 const i3 = (h + 1) * nx + w;
 
-                const normal0 = calcNormal(w, h, nx, ny, isMesh, enableSmoothShading, meshData, ox, oy);         // eslint-disable-line
-                const normal1 = calcNormal(w + 1, h, nx, ny, isMesh, enableSmoothShading, meshData, ox, oy);     // eslint-disable-line
-                const normal2 = calcNormal(w + 1, h + 1, nx, ny, isMesh, enableSmoothShading, meshData, ox, oy); // eslint-disable-line
-                const normal3 = calcNormal(w, h + 1, nx, ny, isMesh, enableSmoothShading, meshData, ox, oy);     // eslint-disable-line
+                const normal0 = calcNormal(w, h, nx, ny, isMesh, smoothShading, meshData, ox, oy);         // eslint-disable-line
+                const normal1 = calcNormal(w + 1, h, nx, ny, isMesh, smoothShading, meshData, ox, oy);     // eslint-disable-line
+                const normal2 = calcNormal(w + 1, h + 1, nx, ny, isMesh, smoothShading, meshData, ox, oy); // eslint-disable-line
+                const normal3 = calcNormal(w, h + 1, nx, ny, isMesh, smoothShading, meshData, ox, oy);     // eslint-disable-line
 
                 const i0_act = !isNaN(meshData[i0]); // eslint-disable-line
                 const i1_act = !isNaN(meshData[i1]); // eslint-disable-line

--- a/react/src/lib/components/DeckGLMap/layers/map/webworker.ts
+++ b/react/src/lib/components/DeckGLMap/layers/map/webworker.ts
@@ -1,6 +1,8 @@
 import { MeshType, MeshTypeLines } from "./privateMapLayer";
 import { Params } from "./mapLayer";
 
+type Vec = [number, number, number];
+
 export function makeFullMesh(e: { data: Params }): void {
     const params = e.data;
 
@@ -11,6 +13,7 @@ export function makeFullMesh(e: { data: Params }): void {
     const propertiesData = params.propertiesData;
     const isMesh = params.isMesh;
     const frame = params.frame;
+    const enableSmoothShading = params.enableSmoothShading;
 
     function getFloat32ArrayMinMax(data: Float32Array) {
         let max = -99999999;
@@ -20,6 +23,116 @@ export function makeFullMesh(e: { data: Params }): void {
             min = data[i] < min ? data[i] : min;
         }
         return [min, max];
+    }
+
+    function crossProduct(a: Vec, b: Vec): Vec {
+        const c = [
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0],
+        ];
+        return c as Vec;
+    }
+
+    function normalize(a: Vec): void {
+        const L = Math.sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2]);
+        a[0] /= L;
+        a[1] /= L;
+        a[2] /= L;
+    }
+
+    function calcNormal(
+        w: number,
+        h: number,
+        nx: number,
+        ny: number,
+        isMesh: boolean,
+        enableSmoothShading: boolean,
+        meshData: Float32Array,
+        ox: number,
+        oy: number
+    ) {
+        if (!enableSmoothShading) {
+            return [1, 1, 1];
+        }
+
+        if (!isMesh) {
+            return [0, 0, 1];
+        }
+
+        const i0 = h * nx + w;
+        const i1 = h * nx + (w - 1);
+        const i2 = (h + 1) * nx + w;
+        const i3 = h * nx + (w + 1);
+        const i4 = (h - 1) * nx + w;
+
+        const i0_act =                 !isNaN(meshData[i0]); // eslint-disable-line
+        const i1_act = (w - 1) >= 0 && !isNaN(meshData[i1]); // eslint-disable-line
+        const i2_act = (h + 1) < ny && !isNaN(meshData[i2]); // eslint-disable-line
+        const i3_act = (w + 1) < nx && !isNaN(meshData[i3]); // eslint-disable-line
+        const i4_act = (h - 1) >= 0 && !isNaN(meshData[i4]); // eslint-disable-line
+
+        const noNormal = [0, 0, 1]; // signals a normal could not be calculated.
+        if (!i0_act) {
+            return noNormal;
+        }
+
+        const hh = ny - 1 - h; // Note use hh for h for getting y values.
+        const p0 = [ox + w * dx,         oy + hh * dy,        i0_act ? -meshData[i0] : 0]; // eslint-disable-line
+        const p1 = [ ox + (w - 1) * dx,  oy + hh * dy,        i1_act ? -meshData[i1] : 0]; // eslint-disable-line
+        const p2 = [ ox + w * dx,        oy + (hh + 1) * dy,  i2_act ? -meshData[i2] : 0]; // eslint-disable-line
+        const p3 = [ ox + (w + 1) * dx,  oy + hh * dy,        i3_act ? -meshData[i3] : 0]; // eslint-disable-line
+        const p4 = [ ox + w * dx,        oy + (hh - 1) * dy,  i4_act ? -meshData[i4] : 0]; // eslint-disable-line
+
+        const v1 = [p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]] as Vec;
+        const v2 = [p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2]] as Vec;
+        const v3 = [p3[0] - p0[0], p3[1] - p0[1], p3[2] - p0[2]] as Vec;
+        const v4 = [p4[0] - p0[0], p4[1] - p0[1], p4[2] - p0[2]] as Vec;
+
+        // Estimating a normal vector at p0:
+        // Take cross product of vectors v1, v2,
+        // Do this for all 4 quadrants.
+        // The resulting normal will be the mean of these four normals.
+        //        p2
+        //         |
+        //   p1 - p0 - p3
+        //         |
+        //        p4
+
+        const normals = [];
+        if (i1_act && i2_act) {
+            const normal = crossProduct(v2, v1);
+            normals.push(normal);
+        }
+
+        if (i2_act && i3_act) {
+            const normal = crossProduct(v3, v2);
+            normals.push(normal);
+        }
+
+        if (i3_act && i4_act) {
+            const normal = crossProduct(v4, v3);
+            normals.push(normal);
+        }
+
+        if (i4_act && i1_act) {
+            const normal = crossProduct(v1, v4);
+            normals.push(normal);
+        }
+
+        if (normals.length === 0) {
+            return noNormal;
+        }
+
+        const mean = normals[0];
+        for (let i = 1; i < normals.length; i++) {
+            mean[0] += normals[i][0];
+            mean[1] += normals[i][1];
+            mean[2] += normals[i][2];
+        }
+
+        normalize(mean);
+        return mean;
     }
 
     const meshZValueRange = getFloat32ArrayMinMax(meshData);
@@ -45,6 +158,7 @@ export function makeFullMesh(e: { data: Params }): void {
     }
 
     const positions: number[] = [];
+    const normals: number[] = [];
     const indices: number[] = [];
     const vertexProperties: number[] = [];
     const vertexIndexs: number[] = [];
@@ -70,6 +184,9 @@ export function makeFullMesh(e: { data: Params }): void {
                 const propertyValue = propertiesData[i0];
 
                 positions.push(x0, y0, z);
+
+                const normal = calcNormal(w, h, nx, ny, isMesh, enableSmoothShading, meshData, ox, oy); // eslint-disable-line
+                normals.push(normal[0], normal[1], normal[2]);
 
                 vertexProperties.push(propertyValue);
                 vertexIndexs.push(i++);
@@ -105,11 +222,6 @@ export function makeFullMesh(e: { data: Params }): void {
                 const x3 = ox + w * dx;
                 const y3 = oy + (hh - 1) * dy;
                 const z3 = isMesh ? -meshData[i3] : 0;
-
-                //   i0---------i1
-                //   |          |
-                //   |          |
-                //   i3---------i2
 
                 if (i1_act && i3_act) {
                     // diagonal i1, i3
@@ -170,6 +282,11 @@ export function makeFullMesh(e: { data: Params }): void {
                 const i2 = (h + 1) * nx + (w + 1);
                 const i3 = (h + 1) * nx + w;
 
+                const normal0 = calcNormal(w, h, nx, ny, isMesh, enableSmoothShading, meshData, ox, oy);         // eslint-disable-line
+                const normal1 = calcNormal(w + 1, h, nx, ny, isMesh, enableSmoothShading, meshData, ox, oy);     // eslint-disable-line
+                const normal2 = calcNormal(w + 1, h + 1, nx, ny, isMesh, enableSmoothShading, meshData, ox, oy); // eslint-disable-line
+                const normal3 = calcNormal(w, h + 1, nx, ny, isMesh, enableSmoothShading, meshData, ox, oy);     // eslint-disable-line
+
                 const i0_act = !isNaN(meshData[i0]); // eslint-disable-line
                 const i1_act = !isNaN(meshData[i1]); // eslint-disable-line
                 const i2_act = !isNaN(meshData[i2]); // eslint-disable-line
@@ -207,6 +324,10 @@ export function makeFullMesh(e: { data: Params }): void {
                         positions.push(x3, y3, z3);
                         positions.push(x0, y0, z0);
 
+                        normals.push(normal1[0], normal1[1], normal1[2]);
+                        normals.push(normal3[0], normal3[1], normal3[2]);
+                        normals.push(normal0[0], normal0[1], normal0[2]);
+
                         vertexIndexs.push(
                             i_vertices++,
                             i_vertices++,
@@ -230,6 +351,10 @@ export function makeFullMesh(e: { data: Params }): void {
                         positions.push(x1, y1, z1);
                         positions.push(x3, y3, z3);
                         positions.push(x2, y2, z2);
+
+                        normals.push(normal1[0], normal1[1], normal1[2]);
+                        normals.push(normal3[0], normal3[1], normal3[2]);
+                        normals.push(normal2[0], normal2[1], normal2[2]);
 
                         vertexIndexs.push(
                             i_vertices++,
@@ -262,6 +387,10 @@ export function makeFullMesh(e: { data: Params }): void {
                         positions.push(x2, y2, z2);
                         positions.push(x0, y0, z0);
 
+                        normals.push(normal1[0], normal1[1], normal1[2]);
+                        normals.push(normal2[0], normal2[1], normal2[2]);
+                        normals.push(normal0[0], normal0[1], normal0[2]);
+
                         vertexIndexs.push(
                             i_vertices++,
                             i_vertices++,
@@ -285,6 +414,10 @@ export function makeFullMesh(e: { data: Params }): void {
                         positions.push(x0, y0, z0);
                         positions.push(x3, y3, z3);
                         positions.push(x2, y2, z2);
+
+                        normals.push(normal0[0], normal0[1], normal0[2]);
+                        normals.push(normal3[0], normal3[1], normal3[2]);
+                        normals.push(normal2[0], normal2[1], normal2[2]);
 
                         vertexIndexs.push(
                             i_vertices++,
@@ -318,6 +451,7 @@ export function makeFullMesh(e: { data: Params }): void {
         drawMode: 4, // corresponds to GL.TRIANGLES,
         attributes: {
             positions: { value: new Float32Array(positions), size: 3 },
+            normals: { value: new Float32Array(normals), size: 3 },
             properties: { value: new Float32Array(vertexProperties), size: 1 },
             vertex_indexs: { value: new Int32Array(vertexIndexs), size: 1 },
         },

--- a/react/src/lib/components/DeckGLMap/layers/terrain/map3DLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/terrain/map3DLayer.ts
@@ -216,7 +216,7 @@ async function load_mesh_and_texture(
     bounds: Bounds,
     meshMaxError: number,
     meshValueRange: [number, number],
-    enableSmoothShading: boolean,
+    smoothShading: boolean,
     texture_name: string
 ) {
     const isMesh = mesh_name !== "";
@@ -253,7 +253,7 @@ async function load_mesh_and_texture(
         });
 
         // Note: mesh contains triangles. No normals they must be added.
-        if (enableSmoothShading) {
+        if (smoothShading) {
             mesh = add_normals(mesh, meshImageData, bounds);
         }
     } else {
@@ -339,7 +339,7 @@ export interface Map3DLayerProps<D> extends ExtendedLayerProps<D> {
     colorMapFunction?: colorMapFunctionType;
 
     // Will calculate normals and enable phong shading.
-    enableSmoothShading: boolean;
+    smoothShading: boolean;
 
     // Surface material properties.
     // material: true  = default material,
@@ -381,7 +381,7 @@ export default class Map3DLayer extends CompositeLayer<
             bounds,
             this.props.meshMaxError,
             this.props.meshValueRange,
-            this.props.enableSmoothShading,
+            this.props.smoothShading,
             this.props.propertyTexture
         );
 
@@ -434,7 +434,7 @@ export default class Map3DLayer extends CompositeLayer<
             !isEqual(props.frame, oldProps.frame) ||
             !isEqual(props.meshMaxError, oldProps.meshMaxError) ||
             !isEqual(props.meshValueRange, oldProps.meshValueRange) ||
-            !isEqual(props.enableSmoothShading, oldProps.enableSmoothShading) ||
+            !isEqual(props.smoothShading, oldProps.smoothShading) ||
             !isEqual(props.propertyTexture, oldProps.propertyTexture);
 
         if (needs_reload) {


### PR DESCRIPTION
 MapLayer now has a property "enableSmoothShading" which enabled will estimate normals for each vertex and henceenable phong (smooth) shading. Default true.