### PR TITLE
Make pie chart work both on minified and non-minified code

### DIFF
--- a/react/src/lib/components/DeckGLMap/layers/piechart/pieChartLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/piechart/pieChartLayer.ts
@@ -70,12 +70,9 @@ export default class PieChartLayer extends CompositeLayer<
             return [];
         }
 
-        const is_orthographic =
-            this.context.viewport.constructor.name === "OrthographicViewport";
-
         const npixels = 100;
-        const p1 = is_orthographic ? [0, 0] : [0, 0, 0];
-        const p2 = is_orthographic ? [npixels, 0] : [npixels, 0, 0];
+        const p1 = [0, 0, 0];
+        const p2 = [npixels, 0, 0];
 
         const v1 = new Vector3(this.context.viewport.unproject(p1));
         const v2 = new Vector3(this.context.viewport.unproject(p2));

--- a/react/src/lib/components/DeckGLMap/layers/piechart/pieChartLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/piechart/pieChartLayer.ts
@@ -9,7 +9,7 @@ import { ExtendedLayerProps, isDrawingEnabled } from "../utils/layerTools";
 import { SolidPolygonLayer } from "@deck.gl/layers/typed";
 import { layersDefaultProps } from "../layersDefaultProps";
 import { DeckGLLayerContext } from "../../components/Map";
-import { Vector3 } from "@math.gl/core";
+import { Vector2 } from "@math.gl/core";
 
 type PieProperties = [{ color: Color; label: string }];
 
@@ -71,11 +71,14 @@ export default class PieChartLayer extends CompositeLayer<
         }
 
         const npixels = 100;
-        const p1 = [0, 0, 0];
-        const p2 = [npixels, 0, 0];
+        const p1 = [0, 0];
+        const p2 = [npixels, 0];
 
-        const v1 = new Vector3(this.context.viewport.unproject(p1));
-        const v2 = new Vector3(this.context.viewport.unproject(p2));
+        const p1_unproj = this.context.viewport.unproject(p1);
+        const p2_unproj = this.context.viewport.unproject(p2);
+
+        const v1 = new Vector2(p1_unproj[0], p1_unproj[1]);
+        const v2 = new Vector2(p2_unproj[0], p2_unproj[1]);
         const d = v1.distance(v2);
 
         // Factor to convert a length in pixels to a length in world space.

--- a/tests/test_deckgl_map.py
+++ b/tests/test_deckgl_map.py
@@ -6,13 +6,17 @@
 
 import json
 import time
+import pytest
 
 import dash
 import webviz_subsurface_components
 
 
 # Basic test for the component rendering.
-def test_render_deckgl_map(dash_duo: dash.testing.composite.DashComposite) -> None:
+@pytest.mark.parametrize("dev_tools_serve_dev_bundles", [False, True])
+def test_render_deckgl_map(
+    dev_tools_serve_dev_bundles, dash_duo: dash.testing.composite.DashComposite
+) -> None:
 
     with open(
         "react/src/demo/example-data/deckgl-map.json", encoding="utf8"
@@ -22,6 +26,6 @@ def test_render_deckgl_map(dash_duo: dash.testing.composite.DashComposite) -> No
     app = dash.Dash(__name__)
     app.layout = webviz_subsurface_components.DeckGLMap(**deckgl_data)
 
-    dash_duo.start_server(app)
+    dash_duo.start_server(app, dev_tools_serve_dev_bundles=dev_tools_serve_dev_bundles)
     time.sleep(5)
     assert dash_duo.get_logs() == []  # Console should have no errors


### PR DESCRIPTION
- [X] Verify that `debug=False` (minified JS code) goes through, but _not_ `debug=True` (non-minified JS code), in the Python deck.gl test.
- [x] Change pie chart layer such that both tests pass in CI.

Related to https://github.com/equinor/webviz-subsurface-components/issues/1295.