### PR TITLE
Update workflow to remove `node 12` deprecation warnings in CI

### DIFF
--- a/.github/workflows/webviz-subsurface-components.yml
+++ b/.github/workflows/webviz-subsurface-components.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Cache Cypress
         if: github.event_name != 'release' && matrix.e2e-tests
         id: cache-cypress
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           # list of files to cache and restore
           path: ~/.cache/Cypress

--- a/.github/workflows/webviz-subsurface-components.yml
+++ b/.github/workflows/webviz-subsurface-components.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: 📖 Checkout commit locally
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: 🐍 Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -152,7 +152,7 @@ jobs:
           retention-days: 5
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 
       - name: 🔼 Build and publish Node.js package
         if: github.event_name == 'release' && matrix.python-version == '3.8'


### PR DESCRIPTION
In order to remove these:
![image](https://user-images.githubusercontent.com/31612826/203495441-ffab315a-fc01-4155-8850-979987707023.png)
