### PR TITLE
Fixes impossible to rotate grid after going from 2d to wd in axes2d s…

### DIFF
--- a/react/src/lib/components/DeckGLMap/components/Map.tsx
+++ b/react/src/lib/components/DeckGLMap/components/Map.tsx
@@ -497,8 +497,6 @@ const Map: React.FC<MapProps> = ({
                 setFirstViewStatesId(viewsProps[0].id);
             }
             setViewStates(tempViewStates);
-        } else {
-            calcDefaultViewStates();
         }
     }, [bounds]);
 
@@ -1164,7 +1162,8 @@ function getViews(
                     : cur_viewport.id === "intersection_view"
                     ? "IntersectionView"
                     : "OrthographicView";
-                const view_id: string = cur_viewport.id;
+                const id_suffix = cur_viewport.show3D ? "_3D" : "_2D";
+                const view_id: string = cur_viewport.id + id_suffix;
 
                 const far = 9999;
                 const near = cur_viewport.show3D ? 0.1 : -9999;

--- a/react/src/lib/components/DeckGLMap/layers/axes2d/axes2DLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/axes2d/axes2DLayer.ts
@@ -95,6 +95,13 @@ export default class Axes2DLayer extends CompositeLayer<
     }
 
     renderLayers(): LayersList {
+        const is_orthographic =
+            this.context.viewport.constructor === OrthographicViewport;
+
+        if (!is_orthographic) {
+            return [];
+        }
+
         // pixels2world: factor to convert a length from pixels to world space.
         const npixels = 100;
         const p1 = [0, 0];
@@ -129,13 +136,6 @@ export default class Axes2DLayer extends CompositeLayer<
             number,
             number
         ];
-
-        const is_orthographic =
-            this.context.viewport.constructor === OrthographicViewport;
-
-        if (!is_orthographic) {
-            return [];
-        }
 
         const box_lines = GetBoxLines(bounds);
 

--- a/react/src/lib/components/DeckGLMap/layers/layersDefaultProps.ts
+++ b/react/src/lib/components/DeckGLMap/layers/layersDefaultProps.ts
@@ -129,8 +129,8 @@ export const layersDefaultProps: Record<string, unknown> = {
         name: "Axes2D",
         id: "axes2d-layer",
         visible: true,
-        marginH: 10, // Horizontal margin (%)
-        marginV: 10, // Vertical margin (%)
+        marginH: 30, // Horizontal margin (in pixles)
+        marginV: 30, // Vertical margin (in pixles)
     },
     NorthArrow3DLayer: {
         "@@type": "NorthArrow3DLayer",


### PR DESCRIPTION
…tory. Also removed a call to   "calcDefaultViewStates();"

that should not be there (introduce in commit "[NGRM] - View settings unexpected changes #1342 (#1359)"