### PR TITLE
fix: fix reservoir scalars color maping

### DIFF
--- a/react/src/lib/components/DeckGLMap/layers/grid3d/webworker.ts
+++ b/react/src/lib/components/DeckGLMap/layers/grid3d/webworker.ts
@@ -24,7 +24,7 @@ export function makeFullMesh(e: { data: WebWorkerParams }): void {
     let i = 0;
     while (i < polys.length) {
         const n = polys[i];
-        const propertyValue = properties[pn++];
+        const propertyValue = properties[pn];
 
         if (propertyValue !== null) {
             // For some reason propertyValue happens to be null.
@@ -132,6 +132,7 @@ export function makeFullMesh(e: { data: WebWorkerParams }): void {
         }
 
         i = i + n + 1;
+        pn += 1;
     }
     console.log("Number of polygons: ", pn);
 


### PR DESCRIPTION
- **Current behavior:** first scalar color (with index: 0) is never used and all colors is shifted by 1 cell.
- There is always undefined color for the last cell because it's index is scalars.length 
- **Reason:** we increase no. of polygons by 1 before we use its color
- **Solution:** use the cell color and increase no. of polygons at the end of the loop