### PR TITLE
Dash wrapper for SubsurfaceViewer

### DIFF
--- a/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.stories.tsx
+++ b/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.stories.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import SubsurfaceViewerDashWrapper from "./SubsurfaceViewerDashWrapper";
+import { ViewFooter } from "../..";
+
+export default {
+    component: SubsurfaceViewerDashWrapper,
+    title: "SubsurfaceViewerDashWrapper",
+} as ComponentMeta<typeof SubsurfaceViewerDashWrapper>;
+
+const mapLayer = {
+    "@@type": "MapLayer",
+    id: "hugin",
+    meshUrl: "hugin_depth_25_m.float32",
+    frame: {
+        origin: [432150, 6475800],
+        count: [291, 229],
+        increment: [25, 25],
+        rotDeg: 0,
+    },
+    propertiesUrl: "kh_netmap_25_m.float32",
+    contours: [0, 100],
+    material: false,
+};
+
+const Template: ComponentStory<typeof SubsurfaceViewerDashWrapper> = (args) => (
+    <SubsurfaceViewerDashWrapper {...args} />
+);
+
+export const DashWrapperViewAnnotation = Template.bind({});
+
+DashWrapperViewAnnotation.args = {
+    id: "dash_annotation",
+    layers: [
+        mapLayer,
+        {
+            ...mapLayer,
+            id: "kh_netmap",
+            propertiesUrl: "hugin_depth_25_m.float32",
+        },
+    ],
+    views: {
+        layout: [1, 2],
+        showLabel: true,
+        viewports: [
+            {
+                id: "view_1",
+                layerIds: ["hugin"],
+            },
+            {
+                id: "view_2",
+                layerIds: ["kh_netmap"],
+            },
+        ],
+    },
+    annotation: {
+        view_1: <ViewFooter>Hugin</ViewFooter>,
+        view_2: <ViewFooter>kH Netmap</ViewFooter>,
+    },
+};

--- a/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.stories.tsx
+++ b/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.stories.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import SubsurfaceViewerDashWrapper from "./SubsurfaceViewerDashWrapper";
-import { ViewFooter } from "../..";
+import { ViewFooter, SubsurfaceViewerDashWrapper } from "../..";
 
 export default {
     component: SubsurfaceViewerDashWrapper,
@@ -23,11 +22,11 @@ const mapLayer = {
     material: false,
 };
 
-const Template: ComponentStory<typeof SubsurfaceViewerDashWrapper> = (args) => (
-    <SubsurfaceViewerDashWrapper {...args} />
-);
+const DashWrapperTemplate: ComponentStory<
+    typeof SubsurfaceViewerDashWrapper
+> = (args) => <SubsurfaceViewerDashWrapper {...args} />;
 
-export const DashWrapperViewAnnotation = Template.bind({});
+export const DashWrapperViewAnnotation = DashWrapperTemplate.bind({});
 
 DashWrapperViewAnnotation.args = {
     id: "dash_annotation",

--- a/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.stories.tsx
+++ b/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.stories.tsx
@@ -5,7 +5,7 @@ import { ViewFooter } from "../..";
 
 export default {
     component: SubsurfaceViewerDashWrapper,
-    title: "SubsurfaceViewerDashWrapper",
+    title: "DeckGLMap / SubsurfaceViewerDashWrapper",
 } as ComponentMeta<typeof SubsurfaceViewerDashWrapper>;
 
 const mapLayer = {

--- a/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.tsx
+++ b/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.tsx
@@ -65,13 +65,20 @@ export interface SubsurfaceViewerDashWrapperProps {
     cameraPosition?: ViewStateType | undefined;
 
     children?: React.ReactNode;
+
+    /**
+     * A mapping associating annotation components to view ids.
+     * Example: {"view_1": <ColorLegend/>}
+     */
     annotation?: Record<string, unknown>;
 }
 
 function mapAnnotation(annotation: Record<string, unknown>) {
-    return Object.entries(annotation).map(([viewId, annotation]) => {
-        <View id={viewId}>{annotation}</View>;
-    });
+    return Object.entries(annotation).map(([viewId, annotation]) => (
+        <View key={viewId} id={viewId}>
+            {annotation}
+        </View>
+    ));
 }
 
 const SubsurfaceViewerDashWrapper: React.FC<
@@ -121,6 +128,8 @@ const SubsurfaceViewerDashWrapper: React.FC<
         triggerResetMultipleWells: triggerResetMultipleWells,
         children: children,
     };
+
+    //console.log(annotation);
 
     return (
         <>
@@ -260,4 +269,12 @@ SubsurfaceViewerDashWrapper.propTypes = {
      * For get mouse events
      */
     onMouseEvent: PropTypes.func,
+
+    /**
+     * A mapping associating annotation components to view ids.
+     * Example: {"view_1": <ColorLegend/>}
+     */
+    annotation: PropTypes.any,
 };
+
+export default SubsurfaceViewerDashWrapper;

--- a/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.tsx
+++ b/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.tsx
@@ -1,0 +1,263 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { View } from "../..";
+import { colorTablesArray } from "@emerson-eps/color-tables/";
+import DeckGLMap, { DeckGLMapProps } from "./DeckGLMap";
+import {
+    ViewsType,
+    TooltipCallback,
+    ViewStateType,
+    BoundsAccessor,
+} from "./components/Map";
+import { MapMouseEvent } from "./components/Map";
+
+export interface SubsurfaceViewerDashWrapperProps {
+    id: string;
+    resources?: Record<string, unknown>;
+    layers?: Record<string, unknown>[];
+    bounds?: [number, number, number, number] | BoundsAccessor;
+    views?: ViewsType;
+    coords?: {
+        visible?: boolean | null;
+        multiPicking?: boolean | null;
+        pickDepth?: number | null;
+    };
+    scale?: {
+        visible?: boolean | null;
+        incrementValue?: number | null;
+        widthPerUnit?: number | null;
+        cssStyle?: Record<string, unknown> | null;
+    };
+    coordinateUnit?: string;
+    colorTables?: colorTablesArray;
+    editedData?: Record<string, unknown>;
+    setProps?: (data: Record<string, unknown>) => void;
+
+    /**
+     * Validate JSON datafile against schema
+     */
+    checkDatafileSchema?: boolean;
+
+    /**
+     * For get mouse events
+     */
+    onMouseEvent?: (event: MapMouseEvent) => void;
+
+    getCameraPosition?: (input: ViewStateType) => void;
+
+    /**
+     * If changed will reset camera to default position.
+     */
+    triggerHome?: number;
+    triggerResetMultipleWells?: number;
+    /**
+     * Range selection of the current well
+     */
+    selection?: {
+        well: string | undefined;
+        selection: [number | undefined, number | undefined] | undefined;
+    };
+
+    /**
+     * Override default tooltip with a callback.
+     */
+    getTooltip?: TooltipCallback;
+    cameraPosition?: ViewStateType | undefined;
+
+    children?: React.ReactNode;
+    annotation?: Record<string, unknown>;
+}
+
+function mapAnnotation(annotation: Record<string, unknown>) {
+    return Object.entries(annotation).map(([viewId, annotation]) => {
+        <View id={viewId}>{annotation}</View>;
+    });
+}
+
+const SubsurfaceViewerDashWrapper: React.FC<
+    SubsurfaceViewerDashWrapperProps
+> = ({
+    id,
+    resources,
+    layers,
+    bounds,
+    views,
+    coords,
+    scale,
+    coordinateUnit,
+    colorTables,
+    editedData,
+    setProps,
+    checkDatafileSchema,
+    onMouseEvent,
+    selection,
+    getTooltip,
+    cameraPosition,
+    getCameraPosition,
+    triggerHome,
+    triggerResetMultipleWells,
+    children,
+    annotation = {},
+}: SubsurfaceViewerDashWrapperProps) => {
+    const mapArgs: DeckGLMapProps = {
+        id: id,
+        resources: resources,
+        layers: layers,
+        bounds: bounds,
+        views: views,
+        coords: coords,
+        scale: scale,
+        coordinateUnit: coordinateUnit,
+        colorTables: colorTables,
+        editedData: editedData,
+        setProps: setProps,
+        checkDatafileSchema: checkDatafileSchema,
+        onMouseEvent: onMouseEvent,
+        selection: selection,
+        getTooltip: getTooltip,
+        cameraPosition: cameraPosition,
+        getCameraPosition: getCameraPosition,
+        triggerHome: triggerHome,
+        triggerResetMultipleWells: triggerResetMultipleWells,
+        children: children,
+    };
+
+    return (
+        <>
+            <DeckGLMap {...mapArgs}>{mapAnnotation(annotation)}</DeckGLMap>
+        </>
+    );
+};
+
+SubsurfaceViewerDashWrapper.defaultProps = {
+    views: {
+        layout: [1, 1],
+        showLabel: false,
+        viewports: [{ id: "main-view", show3D: false, layerIds: [] }],
+    },
+    checkDatafileSchema: false,
+};
+
+SubsurfaceViewerDashWrapper.propTypes = {
+    /**
+     * The ID of this component, used to identify dash components
+     * in callbacks. The ID needs to be unique across all of the
+     * components in an app.
+     */
+    id: PropTypes.string.isRequired,
+
+    /**
+     * Resource dictionary made available in the DeckGL specification as an enum.
+     * The values can be accessed like this: `"@@#resources.resourceId"`, where
+     * `resourceId` is the key in the `resources` dict. For more information,
+     * see the DeckGL documentation on enums in the json spec:
+     * https://deck.gl/docs/api-reference/json/conversion-reference#enumerations-and-using-the--prefix
+     */
+    resources: PropTypes.objectOf(PropTypes.any),
+
+    /* List of JSON object containing layer specific data.
+     * Each JSON object will consist of layer type with key as "@@type" and
+     * layer specific data, if any.
+     */
+    layers: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any).isRequired),
+
+    /**
+     * Coordinate boundary for the view defined as [left, bottom, right, top].
+     * It can be either an array or a callback returning [number, number, number, number].
+     */
+    bounds: PropTypes.any,
+
+    /**
+     * Views configuration for map. If not specified, all the layers will be
+     * displayed in a single 2D viewport.
+     * Example:
+     *      views = {
+     *          "layout": [1, 1],
+     *          "showLabel": false,
+     *          "viewports": [
+     *              {
+     *                  "id": "view_1",
+     *                  "name"?: "View 1"
+     *                  "show3D"?: false,
+     *                  "layerIds": ["layer-ids"],
+     *                  "isSync?": true,
+     *              }
+     *          ]
+     *      }
+     */
+    // TODO - define proper type for views prop
+    views: PropTypes.any,
+
+    /**
+     * Parameters for the InfoCard component
+     */
+    coords: PropTypes.shape({
+        /**
+         * Toggle component visibility.
+         */
+        visible: PropTypes.bool,
+        /**
+         * Enable or disable multi picking. Might have a performance penalty.
+         * See https://deck.gl/docs/api-reference/core/deck#pickmultipleobjects
+         */
+        multiPicking: PropTypes.bool,
+        /**
+         * Number of objects to pick. The more objects picked, the more picking operations will be done.
+         * See https://deck.gl/docs/api-reference/core/deck#pickmultipleobjects
+         */
+        pickDepth: PropTypes.number,
+    }),
+
+    /**
+     * Parameters for the Distance Scale component
+     */
+    scale: PropTypes.shape({
+        /**
+         * Toggle component visibility.
+         */
+        visible: PropTypes.bool,
+        /**
+         * Increment value for the scale.
+         */
+        incrementValue: PropTypes.number,
+        /**
+         * Scale bar width in pixels per unit value.
+         */
+        widthPerUnit: PropTypes.number,
+        /**
+         * Scale bar css style can be used for positioning.
+         */
+        cssStyle: PropTypes.objectOf(PropTypes.any),
+    }),
+
+    /**
+     * Parameters for the Distance Scale component
+     * Unit for the scale ruler
+     */
+    coordinateUnit: PropTypes.string,
+
+    /**
+     * Prop containing color table data
+     */
+    colorTables: PropTypes.array,
+
+    /**
+     * Prop containing edited data from layers
+     */
+    editedData: PropTypes.objectOf(PropTypes.any),
+
+    /**
+     * For reacting to prop changes
+     */
+    setProps: PropTypes.func,
+
+    /**
+     * Validate JSON datafile against schema
+     */
+    checkDatafileSchema: PropTypes.bool,
+
+    /**
+     * For get mouse events
+     */
+    onMouseEvent: PropTypes.func,
+};

--- a/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.tsx
+++ b/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { View } from "../..";
+import { View } from "@deck.gl/core/typed";
 import { colorTablesArray } from "@emerson-eps/color-tables/";
 import DeckGLMap, { DeckGLMapProps } from "./DeckGLMap";
 import {
@@ -75,6 +75,7 @@ export interface SubsurfaceViewerDashWrapperProps {
 
 function mapAnnotation(annotation: Record<string, unknown>) {
     return Object.entries(annotation).map(([viewId, annotation]) => (
+        // @ts-expect-error This is demonstrated to work with js, but with ts it gives error
         <View key={viewId} id={viewId}>
             {annotation}
         </View>

--- a/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.tsx
+++ b/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.tsx
@@ -129,11 +129,7 @@ const SubsurfaceViewerDashWrapper: React.FC<
         children: children,
     };
 
-    return (
-        <>
-            <DeckGLMap {...mapArgs}>{mapAnnotation(annotation)}</DeckGLMap>
-        </>
-    );
+    return <DeckGLMap {...mapArgs}>{mapAnnotation(annotation)}</DeckGLMap>;
 };
 
 SubsurfaceViewerDashWrapper.defaultProps = {

--- a/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.tsx
+++ b/react/src/lib/components/DeckGLMap/SubsurfaceViewerDashWrapper.tsx
@@ -129,8 +129,6 @@ const SubsurfaceViewerDashWrapper: React.FC<
         children: children,
     };
 
-    //console.log(annotation);
-
     return (
         <>
             <DeckGLMap {...mapArgs}>{mapAnnotation(annotation)}</DeckGLMap>

--- a/react/src/lib/components/DeckGLMap/index.js
+++ b/react/src/lib/components/DeckGLMap/index.js
@@ -1,5 +1,5 @@
 export { default, DeckGLMapProps } from "./DeckGLMap";
 export {
-    SubsurfaceViewerDashWrapper,
+    default as SubsurfaceViewerDashWrapper,
     SubsurfaceViewerDashWrapperProps,
 } from "./SubsurfaceViewerDashWrapper";

--- a/react/src/lib/components/DeckGLMap/index.js
+++ b/react/src/lib/components/DeckGLMap/index.js
@@ -1,1 +1,5 @@
 export { default, DeckGLMapProps } from "./DeckGLMap";
+export {
+    SubsurfaceViewerDashWrapper,
+    SubsurfaceViewerDashWrapperProps,
+} from "./SubsurfaceViewerDashWrapper";

--- a/react/src/lib/index.js
+++ b/react/src/lib/index.js
@@ -4,7 +4,7 @@
  *
  * Copyright (C) 2020 - Equinor ASA. */
 
-import DeckGLMap from "./components/DeckGLMap";
+import DeckGLMap, { SubsurfaceViewerDashWrapper } from "./components/DeckGLMap";
 import GroupTree from "./components/GroupTree";
 import HistoryMatch from "./components/HistoryMatch";
 import LayeredMap from "./components/LayeredMap";
@@ -57,4 +57,5 @@ export {
     LayerPickInfo,
     ViewFooter,
     View,
+    SubsurfaceViewerDashWrapper,
 };


### PR DESCRIPTION
Allows mapping annotations to views in Dash.

Example:

```
annotation: {
    view_1: <ViewFooter>Hugin</ViewFooter>,
    view_2: <ViewFooter>kH Netmap</ViewFooter>,
}
```