### PR TITLE
Bug fix for bounding undefined

### DIFF
--- a/react/src/lib/components/DeckGLMap/components/Map.tsx
+++ b/react/src/lib/components/DeckGLMap/components/Map.tsx
@@ -362,45 +362,25 @@ const Map: React.FC<MapProps> = ({
 
         let tempViewStates: Record<string, ViewStateType> = {};
         const isBoundsDefined = typeof bounds !== "undefined";
-        if (input) {
-            tempViewStates = Object.fromEntries(
-                input.map((item, index) => [
-                    item.id,
-                    isBoundsDefined
-                        ? getViewState(
-                              boundsInitial,
-                              target,
-                              views?.viewports?.[index].zoom,
-                              deckRef.current?.deck
-                          )
-                        : getViewState3D(
-                              is3D,
-                              union_of_reported_bboxes,
-                              views?.viewports?.[index].zoom,
-                              deckRef.current?.deck
-                          ),
-                ])
-            );
-        } else {
-            tempViewStates = Object.fromEntries(
-                viewsProps.map((item, index) => [
-                    item.id,
-                    isBoundsDefined
-                        ? getViewState(
-                              boundsInitial,
-                              target,
-                              views?.viewports?.[index].zoom,
-                              deckRef.current?.deck
-                          )
-                        : getViewState3D(
-                              is3D,
-                              union_of_reported_bboxes,
-                              views?.viewports?.[index].zoom,
-                              deckRef.current?.deck
-                          ),
-                ])
-            );
-        }
+        const updatedViewProps = input ? input : viewsProps;
+        tempViewStates = Object.fromEntries(
+            updatedViewProps.map((item, index) => [
+                item.id,
+                isBoundsDefined
+                    ? getViewState(
+                          boundsInitial,
+                          target,
+                          views?.viewports?.[index].zoom,
+                          deckRef.current?.deck
+                      )
+                    : getViewState3D(
+                          is3D,
+                          union_of_reported_bboxes,
+                          views?.viewports?.[index].zoom,
+                          deckRef.current?.deck
+                      ),
+            ])
+        );
         setDidUserChangeCamera(false);
         setViewStates(tempViewStates);
     }
@@ -575,13 +555,8 @@ const Map: React.FC<MapProps> = ({
             scaleDownFunction
         ) as ViewportType[];
 
-        setViewsProps(
-            getViews(
-                views,
-                scaleUpFunction,
-                scaleDownFunction
-            ) as ViewportType[]
-        );
+        setViewsProps(viewProps);
+
         if (!bounds) {
             calcDefaultViewStates(viewProps);
         }

--- a/react/src/lib/components/DeckGLMap/components/Map.tsx
+++ b/react/src/lib/components/DeckGLMap/components/Map.tsx
@@ -338,7 +338,6 @@ const Map: React.FC<MapProps> = ({
     function calcDefaultViewStates(input?: ViewportType[]) {
         // If "bounds" or "cameraPosition" is not defined "viewState" will be
         // calculated based on the union of the reported bounding boxes from each layer.
-        console.log("get Called");
         const union_of_reported_bboxes = addBoundingBoxes(
             reportedBoundingBoxAcc,
             reportedBoundingBox
@@ -364,7 +363,6 @@ const Map: React.FC<MapProps> = ({
         let tempViewStates: Record<string, ViewStateType> = {};
         const isBoundsDefined = typeof bounds !== "undefined";
         if (input) {
-            console.log("1");
             tempViewStates = Object.fromEntries(
                 input.map((item, index) => [
                     item.id,
@@ -372,19 +370,18 @@ const Map: React.FC<MapProps> = ({
                         ? getViewState(
                               boundsInitial,
                               target,
-                              -5,
+                              views?.viewports?.[index].zoom,
                               deckRef.current?.deck
                           )
                         : getViewState3D(
                               is3D,
                               union_of_reported_bboxes,
-                              -5,
+                              views?.viewports?.[index].zoom,
                               deckRef.current?.deck
                           ),
                 ])
             );
         } else {
-            console.log("2");
             tempViewStates = Object.fromEntries(
                 viewsProps.map((item, index) => [
                     item.id,
@@ -392,19 +389,18 @@ const Map: React.FC<MapProps> = ({
                         ? getViewState(
                               boundsInitial,
                               target,
-                              -5,
+                              views?.viewports?.[index].zoom,
                               deckRef.current?.deck
                           )
                         : getViewState3D(
                               is3D,
                               union_of_reported_bboxes,
-                              -5,
+                              views?.viewports?.[index].zoom,
                               deckRef.current?.deck
                           ),
                 ])
             );
         }
-       
         setDidUserChangeCamera(false);
         setViewStates(tempViewStates);
     }
@@ -573,14 +569,12 @@ const Map: React.FC<MapProps> = ({
     }, [scaleZDown]);
 
     useEffect(() => {
-        console.log(views?.viewports.length);
         const viewProps = getViews(
             views,
             scaleUpFunction,
             scaleDownFunction
-        ) as ViewportType[]
+        ) as ViewportType[];
 
-        console.log(viewProps);
         setViewsProps(
             getViews(
                 views,

--- a/react/src/lib/components/DeckGLMap/components/Map.tsx
+++ b/react/src/lib/components/DeckGLMap/components/Map.tsx
@@ -335,10 +335,10 @@ const Map: React.FC<MapProps> = ({
     );
 
     // Local help function.
-    function calcDefaultViewStates() {
+    function calcDefaultViewStates(input?: ViewportType[]) {
         // If "bounds" or "cameraPosition" is not defined "viewState" will be
         // calculated based on the union of the reported bounding boxes from each layer.
-
+        console.log("get Called");
         const union_of_reported_bboxes = addBoundingBoxes(
             reportedBoundingBoxAcc,
             reportedBoundingBox
@@ -363,24 +363,48 @@ const Map: React.FC<MapProps> = ({
 
         let tempViewStates: Record<string, ViewStateType> = {};
         const isBoundsDefined = typeof bounds !== "undefined";
-        tempViewStates = Object.fromEntries(
-            viewsProps.map((item, index) => [
-                item.id,
-                isBoundsDefined
-                    ? getViewState(
-                          boundsInitial,
-                          target,
-                          views?.viewports?.[index].zoom,
-                          deckRef.current?.deck
-                      )
-                    : getViewState3D(
-                          is3D,
-                          union_of_reported_bboxes,
-                          views?.viewports?.[index].zoom,
-                          deckRef.current?.deck
-                      ),
-            ])
-        );
+        if (input) {
+            console.log("1");
+            tempViewStates = Object.fromEntries(
+                input.map((item, index) => [
+                    item.id,
+                    isBoundsDefined
+                        ? getViewState(
+                              boundsInitial,
+                              target,
+                              -5,
+                              deckRef.current?.deck
+                          )
+                        : getViewState3D(
+                              is3D,
+                              union_of_reported_bboxes,
+                              -5,
+                              deckRef.current?.deck
+                          ),
+                ])
+            );
+        } else {
+            console.log("2");
+            tempViewStates = Object.fromEntries(
+                viewsProps.map((item, index) => [
+                    item.id,
+                    isBoundsDefined
+                        ? getViewState(
+                              boundsInitial,
+                              target,
+                              -5,
+                              deckRef.current?.deck
+                          )
+                        : getViewState3D(
+                              is3D,
+                              union_of_reported_bboxes,
+                              -5,
+                              deckRef.current?.deck
+                          ),
+                ])
+            );
+        }
+       
         setDidUserChangeCamera(false);
         setViewStates(tempViewStates);
     }
@@ -549,6 +573,14 @@ const Map: React.FC<MapProps> = ({
     }, [scaleZDown]);
 
     useEffect(() => {
+        console.log(views?.viewports.length);
+        const viewProps = getViews(
+            views,
+            scaleUpFunction,
+            scaleDownFunction
+        ) as ViewportType[]
+
+        console.log(viewProps);
         setViewsProps(
             getViews(
                 views,
@@ -556,6 +588,9 @@ const Map: React.FC<MapProps> = ({
                 scaleDownFunction
             ) as ViewportType[]
         );
+        if (!bounds) {
+            calcDefaultViewStates(viewProps);
+        }
     }, [views]);
 
     useEffect(() => {
@@ -892,6 +927,7 @@ const Map: React.FC<MapProps> = ({
         },
         [viewStates]
     );
+
     if (!deckGLViews || isEmpty(deckGLViews) || isEmpty(deckGLLayers))
         return null;
     return (


### PR DESCRIPTION
The reason for this bug issue has following two probleams:
1) the bounds is not provided and once the user update the views, the bounds will not be updated and still remained as undefined, In the initiali stage, the default cal function can be called and provide a bound for it but in this case the func will not be called and thus cause the error.
2) we need to update the viewProps immediately rather than wait till the setviewProps  get the viewProps prop updated. I have put a fix for this in this PR and hopefully it address all the issues