### PR TITLE
Grid3 d layer array input

### DIFF
--- a/react/src/lib/components/SubsurfaceViewer/layers/grid3d/grid3dLayer.stories.tsx
+++ b/react/src/lib/components/SubsurfaceViewer/layers/grid3d/grid3dLayer.stories.tsx
@@ -57,13 +57,35 @@ Simgrid.args = {
         axes,
         {
             ...grid3dLayer,
-            pointsUrl: "vtk-grid/Simgrid_points.json",
-            polysUrl: "vtk-grid/Simgrid_polys.json",
-            propertiesUrl: "vtk-grid/Simgrid_scalar.json",
+            pointsData: "vtk-grid/Simgrid_points.json",
+            polysData: "vtk-grid/Simgrid_polys.json",
+            propertiesData: "vtk-grid/Simgrid_scalar.json",
         },
     ],
 };
 Simgrid.parameters = parameters;
+
+export const SimgridArrayInput = Template.bind({});
+SimgridArrayInput.args = {
+    ...defaultProps,
+    id: "grid-3darray",
+    layers: [
+        axes,
+        {
+            ...grid3dLayer,
+            pointsData: [
+                456063, 5935991, -1729, 456063, 5935991, -1731, 456138,
+                5935861.518843642, -1727.820068359375, 456138.5, 5935861.5,
+                -1726.3526611328125, 456193.90625, 5936066, -1730.7259521484375,
+                456193.8825946293, 5936065.981075703, -1732.200439453125,
+                456268.9375, 5935936.5, -1726.6915283203125,
+            ],
+            polysData: [4, 0, 1, 2, 3, 4, 0, 4, 5, 1, 4, 0, 3, 6, 4],
+            propertiesData: [0.2, 0.6, 0.8],
+        },
+    ],
+};
+SimgridArrayInput.parameters = parameters;
 
 export const Simgrid2x = Template.bind({});
 Simgrid2x.args = {
@@ -73,9 +95,9 @@ Simgrid2x.args = {
         axes,
         {
             ...grid3dLayer,
-            pointsUrl: "vtk-grid/Simgrid2x_points.json",
-            polysUrl: "vtk-grid/Simgrid2x_polys.json",
-            propertiesUrl: "vtk-grid/Simgrid2x_scalar.json",
+            pointsData: "vtk-grid/Simgrid2x_points.json",
+            polysData: "vtk-grid/Simgrid2x_polys.json",
+            propertiesData: "vtk-grid/Simgrid2x_scalar.json",
         },
     ],
 };
@@ -89,9 +111,9 @@ Simgrid4x.args = {
         axes,
         {
             ...grid3dLayer,
-            pointsUrl: "vtk-grid/Simgrid4x_points.json",
-            polysUrl: "vtk-grid/Simgrid4x_polys.json",
-            propertiesUrl: "vtk-grid/Simgrid4x_scalar.json",
+            pointsData: "vtk-grid/Simgrid4x_points.json",
+            polysData: "vtk-grid/Simgrid4x_polys.json",
+            propertiesData: "vtk-grid/Simgrid4x_scalar.json",
         },
     ],
 };
@@ -105,9 +127,9 @@ Simgrid8xIJonly.args = {
         axes,
         {
             ...grid3dLayer,
-            pointsUrl: "vtk-grid/Simgrid8xIJonly_points.json",
-            polysUrl: "vtk-grid/Simgrid8xIJonly_polys.json",
-            propertiesUrl: "vtk-grid/Simgrid8xIJonly_scalar.json",
+            pointsData: "vtk-grid/Simgrid8xIJonly_points.json",
+            polysData: "vtk-grid/Simgrid8xIJonly_polys.json",
+            propertiesData: "vtk-grid/Simgrid8xIJonly_scalar.json",
         },
     ],
 };
@@ -123,9 +145,9 @@ Simgrid8xIJonly.parameters = parameters;
 // const intersection = {
 //     "@@type": "Grid3DLayer",
 //     id: "Grid3DLayer",
-//     pointsUrl: "vtk-grid/intersection_points.json",
-//     polysUrl: "vtk-grid/intersection_polys.json",
-//     propertiesUrl: "vtk-grid/intersection_scalar.json",
+//     pointsData: "vtk-grid/intersection_points.json",
+//     polysData: "vtk-grid/intersection_polys.json",
+//     propertiesData: "vtk-grid/intersection_scalar.json",
 //     material: true,
 //     colorMapName: "Rainbow",
 //     scaleZ: 5,

--- a/react/src/lib/components/SubsurfaceViewer/layers/grid3d/grid3dLayer.ts
+++ b/react/src/lib/components/SubsurfaceViewer/layers/grid3d/grid3dLayer.ts
@@ -42,14 +42,21 @@ function FlipZ(points: number[]): void {
 }
 
 async function load_data(
-    pointsUrl: string,
-    polysUrl: string,
-    propertiesUrl: string
+    pointsData: string | number[],
+    polysData: string | number[],
+    propertiesData: string | number[]
 ) {
-    // FULL GRID
-    const points = await load(pointsUrl, JSONLoader);
-    const polys = await load(polysUrl, JSONLoader);
-    const properties = await load(propertiesUrl, JSONLoader);
+    const points = Array.isArray(pointsData)
+        ? pointsData
+        : await load(pointsData as string, JSONLoader);
+
+    const polys = Array.isArray(polysData)
+        ? polysData
+        : await load(polysData as string, JSONLoader);
+
+    const properties = Array.isArray(propertiesData)
+        ? propertiesData
+        : await load(propertiesData as string, JSONLoader);
 
     return Promise.all([points, polys, properties]);
 }
@@ -58,9 +65,23 @@ export interface Grid3DLayerProps<D> extends ExtendedLayerProps<D> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setReportedBoundingBox?: any;
 
-    pointsUrl: string;
-    polysUrl: string;
-    propertiesUrl: string;
+    /**  Url or native javascript array. Set of points.
+     * [x1, y1, z1, x2, y2, z2, ...]
+     */
+    pointsData: string | number[];
+
+    /**  Url or native javascript array.
+     * For each polygon ["number of points in poly", p1, , p2 ... ]
+     * Example One polygn ith 4 poitns and one with 3 points.
+     * [4, 3, 1, 9, 77, 3, 6, 44, 23]
+     */
+    polysData: string | number[];
+
+    /**  Url or native javascript array..
+     *  A scalar property for each polygon.
+     * [0.23, 0.11. 0.98, ...]
+     */
+    propertiesData: string | number[];
 
     /**  Name of color map. E.g "PORO"
      */
@@ -123,13 +144,15 @@ export default class Grid3DLayer extends CompositeLayer<
     Grid3DLayerProps<unknown>
 > {
     rebuildData(reportBoundingBox: boolean): void {
+
         const p = load_data(
-            this.props.pointsUrl,
-            this.props.polysUrl,
-            this.props.propertiesUrl
+            this.props.pointsData,
+            this.props.polysData,
+            this.props.propertiesData
         );
 
         p.then(([points, polys, properties]) => {
+            console.log(properties)
             if (!this.props.isZDepth) {
                 FlipZ(points);
             }
@@ -194,9 +217,9 @@ export default class Grid3DLayer extends CompositeLayer<
         oldProps: Grid3DLayerProps<unknown>;
     }): void {
         const needs_reload =
-            !isEqual(props.pointsUrl, oldProps.pointsUrl) ||
-            !isEqual(props.polysUrl, oldProps.polysUrl) ||
-            !isEqual(props.propertiesUrl, oldProps.propertiesUrl);
+            !isEqual(props.pointsData, oldProps.pointsData) ||
+            !isEqual(props.polysData, oldProps.polysData) ||
+            !isEqual(props.propertiesData, oldProps.propertiesData);
 
         if (needs_reload) {
             const reportBoundingBox = false;

--- a/react/src/lib/components/SubsurfaceViewer/layers/grid3d/grid3dLayer.ts
+++ b/react/src/lib/components/SubsurfaceViewer/layers/grid3d/grid3dLayer.ts
@@ -144,7 +144,6 @@ export default class Grid3DLayer extends CompositeLayer<
     Grid3DLayerProps<unknown>
 > {
     rebuildData(reportBoundingBox: boolean): void {
-
         const p = load_data(
             this.props.pointsData,
             this.props.polysData,
@@ -152,7 +151,6 @@ export default class Grid3DLayer extends CompositeLayer<
         );
 
         p.then(([points, polys, properties]) => {
-            console.log(properties)
             if (!this.props.isZDepth) {
                 FlipZ(points);
             }


### PR DESCRIPTION
This pull request is for fixing issue: "[NGRM] Additional support for in-memory array data as input in Grid3DLayer #1364"

It does not change the current behavior only adds to it (by allowing an additional method of setting input data)