### PR TITLE
Fix python color legend examples

### DIFF
--- a/examples/example_webviz_colorlegend.py
+++ b/examples/example_webviz_colorlegend.py
@@ -4,14 +4,16 @@
 #
 # Copyright (C) 2020 - Equinor ASA.
 
+import requests
+
 import dash
 import webviz_subsurface_components as wsc
 
 
-COLOR_TABLES = (
+COLOR_TABLES = requests.get(
     "https://raw.githubusercontent.com/emerson-eps/color-tables/"
     "main/react-app/src/component/color-tables.json"
-)
+).json()
 
 legend_obj = wsc.WebVizColorLegend(
     min=0,

--- a/examples/example_webviz_colorlegend.py
+++ b/examples/example_webviz_colorlegend.py
@@ -4,15 +4,16 @@
 #
 # Copyright (C) 2020 - Equinor ASA.
 
-import requests
 
 import dash
 import webviz_subsurface_components as wsc
 
+import requests
 
 COLOR_TABLES = requests.get(
     "https://raw.githubusercontent.com/emerson-eps/color-tables/"
-    "main/react-app/src/component/color-tables.json"
+    "main/react-app/src/component/color-tables.json",
+    timeout=5,
 ).json()
 
 legend_obj = wsc.WebVizColorLegend(

--- a/examples/example_webviz_continuouslegend.py
+++ b/examples/example_webviz_continuouslegend.py
@@ -12,7 +12,8 @@ import requests
 
 COLOR_TABLES = requests.get(
     "https://raw.githubusercontent.com/emerson-eps/color-tables/"
-    "main/react-app/src/component/color-tables.json"
+    "main/react-app/src/component/color-tables.json",
+    timeout=5,
 ).json()
 
 

--- a/examples/example_webviz_continuouslegend.py
+++ b/examples/example_webviz_continuouslegend.py
@@ -8,10 +8,13 @@ import dash
 import webviz_subsurface_components as wsc
 
 
-COLOR_TABLES = (
+import requests
+
+COLOR_TABLES = requests.get(
     "https://raw.githubusercontent.com/emerson-eps/color-tables/"
     "main/react-app/src/component/color-tables.json"
-)
+).json()
+
 
 legend_obj = wsc.WebVizContinuousLegend(
     min=0,

--- a/examples/example_webviz_discretelegend.py
+++ b/examples/example_webviz_discretelegend.py
@@ -9,10 +9,13 @@ import webviz_core_components as wcc
 import webviz_subsurface_components as wsc
 
 
-COLOR_TABLES = (
+import requests
+
+COLOR_TABLES = requests.get(
     "https://raw.githubusercontent.com/emerson-eps/color-tables/"
     "main/react-app/src/component/color-tables.json"
-)
+).json()
+
 
 Discrete_Data = {
     "Above_BCU": [[255, 13, 186, 255], 0],

--- a/examples/example_webviz_discretelegend.py
+++ b/examples/example_webviz_discretelegend.py
@@ -13,7 +13,8 @@ import requests
 
 COLOR_TABLES = requests.get(
     "https://raw.githubusercontent.com/emerson-eps/color-tables/"
-    "main/react-app/src/component/color-tables.json"
+    "main/react-app/src/component/color-tables.json",
+    timeout=5,
 ).json()
 
 


### PR DESCRIPTION
Issue with python examples for deckgl color legends.
Parsing the color legend from an url does not work. Changed the code to use json instead.