### PR TITLE
Update older components to use `d3` version 7

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -15,7 +15,7 @@
         "dist/**/*"
     ],
     "scripts": {
-        "start": "webpack serve --mode development --devtool inline-source-map --entry ./src/demo/index.js --open --allowed-hosts all",
+        "start": "webpack serve --mode development --devtool inline-source-map --entry ./src/demo/index.js --open",
         "copy-package-json": "copyfiles ./package.json ../webviz_subsurface_components/",
         "transpile": "tsc --project tsconfig.build.json && npm run copy-files",
         "transpile:dash": "tsc --project tsconfig.build.json && rimraf ./dist/lib/components/*/**/ && tsc --project tsconfig.dash.json",

--- a/react/package.json
+++ b/react/package.json
@@ -15,7 +15,7 @@
         "dist/**/*"
     ],
     "scripts": {
-        "start": "webpack serve --mode development --devtool inline-source-map --entry ./src/demo/index.js --open",
+        "start": "webpack serve --mode development --devtool inline-source-map --entry ./src/demo/index.js --open --allowed-hosts all",
         "copy-package-json": "copyfiles ./package.json ../webviz_subsurface_components/",
         "transpile": "tsc --project tsconfig.build.json && npm run copy-files",
         "transpile:dash": "tsc --project tsconfig.build.json && rimraf ./dist/lib/components/*/**/ && tsc --project tsconfig.dash.json",

--- a/react/src/lib/components/HistoryMatch/components/history_matching_plot.js
+++ b/react/src/lib/components/HistoryMatch/components/history_matching_plot.js
@@ -325,7 +325,7 @@ export default class HistoryMatchingPlot extends Component {
             .select("text.negative")
             .text(this.data.negative[index].toFixed(2));
 
-        const [x, y] = d3.mouse(this.parentElement.node());
+        const [x, y] = d3.pointer(this.parentElement.node());
 
         this.tooltip.attr("transform", `translate(${x + 20}, ${y - 30})`);
 

--- a/react/src/lib/components/Map/utils/compass.js
+++ b/react/src/lib/components/Map/utils/compass.js
@@ -59,7 +59,7 @@ export default class Compass extends Component {
     }
 
     _dragStarted() {
-        const [x, y] = d3.mouse(this.element.node());
+        const [x, y] = d3.pointer(this.element.node());
 
         this.element.selectAll("polygon").attr("fill", "#A75C7C");
 
@@ -67,7 +67,7 @@ export default class Compass extends Component {
     }
 
     _dragged() {
-        const [x, y] = d3.mouse(this.element.node());
+        const [x, y] = d3.pointer(this.element.node());
 
         this.dragAngle = this.constructor.calculateAngleFromCoord(x, y);
 

--- a/react/src/lib/components/Map/utils/map.js
+++ b/react/src/lib/components/Map/utils/map.js
@@ -98,8 +98,8 @@ export default class Map extends Component {
             .attr("fill", (d, i) => self.color(i))
             .on("mousemove", function (d, i) {
                 self.emit("mousemove", {
-                    x: d3.mouse(this)[0],
-                    y: d3.mouse(this)[1],
+                    x: d3.pointer(this)[0],
+                    y: d3.pointer(this)[1],
                     value: self.values[self.layer][i],
                 });
             })

--- a/react/src/lib/components/Map/utils/map2d.js
+++ b/react/src/lib/components/Map/utils/map2d.js
@@ -213,8 +213,8 @@ export default class Map2D extends Component {
         zoomListener(this.containerMap);
     }
 
-    handleZoom() {
-        const { transform } = d3.event;
+    handleZoom(event) {
+        const { transform } = event;
 
         this.mapTransform.x = transform.x;
         this.mapTransform.y = transform.y;

--- a/react/src/lib/components/Map/utils/vertical-slider.js
+++ b/react/src/lib/components/Map/utils/vertical-slider.js
@@ -109,8 +109,8 @@ export default class VerticalSlider extends Component {
                     .on("start.interrupt", () => {
                         self.slider.interrupt();
                     })
-                    .on("start drag", () => {
-                        self._onDragSlider(this.scale.invert(d3.event.y));
+                    .on("start drag", (event) => {
+                        self._onDragSlider(this.scale.invert(event.y));
                     })
             );
     }

--- a/react/src/lib/components/Morris/utils/morris.js
+++ b/react/src/lib/components/Morris/utils/morris.js
@@ -843,7 +843,7 @@ export default function sensitivitySliderPlot(
             function onMouseMove() {
                 // https://bl.ocks.org/mbostock/3902569
                 // https://bl.ocks.org/micahstubbs/e4f5c830c264d26621b80b754219ae1b
-                const x0 = self._graphX.invert(d3.mouse(this)[0]);
+                const x0 = self._graphX.invert(d3.pointer(this)[0]);
                 const i = self._bisectDate(self._output, x0, 1);
                 const d0 = self._output[i - 1];
                 const d1 = self._output[i];

--- a/react/src/lib/components/PriorPosteriorDistribution/utils/prior_posterior_distribution.js
+++ b/react/src/lib/components/PriorPosteriorDistribution/utils/prior_posterior_distribution.js
@@ -72,7 +72,7 @@ class D3PriorPosterior {
             (x_value - this.global_min) / (this.global_max - this.global_min);
         const tooltip_width = this.tooltip.node().getBoundingClientRect().width;
 
-        const mouse_position = d3.mouse(this.svg.node());
+        const mouse_position = d3.pointer(this.svg.node());
         this.tooltip
             .style(
                 "left",

--- a/react/src/lib/shared/slider.js
+++ b/react/src/lib/shared/slider.js
@@ -117,8 +117,10 @@ export default class Slider extends Component {
                 d3
                     .drag()
                     .on("start.interrupt", () => this.container.interrupt())
-                    .on("start drag", () => this.slideMove(d3.event[this.axis]))
-                    .on("end", () => this.slideEnd(d3.event[this.axis]))
+                    .on("start drag", (event) =>
+                        this.slideMove(event[this.axis])
+                    )
+                    .on("end", (event) => this.slideEnd(event[this.axis]))
             );
     }
 


### PR DESCRIPTION
We have updated `d3` version in this repository without moving some of the older components to the new syntax. This fixes that.

Closes https://github.com/equinor/webviz-subsurface/issues/1219.