### PR TITLE
Remove "onMouseEvent" property from SubsurfaceViewer.propTypes

### DIFF
--- a/typescript/packages/subsurface-viewer/src/SubsurfaceViewer.tsx
+++ b/typescript/packages/subsurface-viewer/src/SubsurfaceViewer.tsx
@@ -346,11 +346,6 @@ SubsurfaceViewer.propTypes = {
      * Validate JSON datafile against schema
      */
     checkDatafileSchema: PropTypes.bool,
-
-    /**
-     * For get mouse events
-     */
-    onMouseEvent: PropTypes.func,
 };
 
 export default SubsurfaceViewer;


### PR DESCRIPTION
 - if this property is present here storybook will add a default function value for it making the component slow.