### PR TITLE
build: validate PR titles instead of commit messages

### DIFF
--- a/.github/workflows/conventional_commit.yml
+++ b/.github/workflows/conventional_commit.yml
@@ -1,15 +1,17 @@
 name: Conventional Commits
 
 on:
-  pull_request:
-    branches: [ master ]
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
 
 jobs:
   build:
-    name: Conventional Commits
+    name: Validate pull request title
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: webiny/action-conventional-commits@03a9c76bdb2deeaf23f50e8ea9c6e99417bad467
-
+      - uses: amannn/action-semantic-pull-request@00282d63cda40a6eaf3e9d0cbb1ac4384de896e8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is needed because squash and merge is the default strategy