### PR TITLE
build: fix build target option in semantic release config

### DIFF
--- a/typescript/.nxreleaserc.json
+++ b/typescript/.nxreleaserc.json
@@ -6,6 +6,6 @@
   "branches": [
     "master"
   ],
-  "buildTarget": "build",
-  "outputPath": "dist"
+  "buildTarget": "${PROJECT_NAME}:build",
+  "outputPath": "${PROJECT_DIR}/dist"
 }


### PR DESCRIPTION
`buildTarget` should have a package name prefix (https://github.com/TheUnderScorer/nx-semantic-release/issues/65#issuecomment-1701205625)