### PR TITLE
ci: fix Update Storybook script

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -88,7 +88,7 @@ jobs:
       - name: 📚 Update Storybook
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
-          git git clean -xdff ../storybook-static
+          git clean -xdff ../storybook-static
           cp -r ./storybook-static ..
 
           git config --local user.email "webviz-github-action"

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -88,6 +88,7 @@ jobs:
       - name: 📚 Update Storybook
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
+          git git clean -xdff ../storybook-static
           cp -r ./storybook-static ..
 
           git config --local user.email "webviz-github-action"


### PR DESCRIPTION
The Update Storybook starts with:
`cp -r ./storybook-static ..` which fails if this directory already exists.
The fix is to clean this directory before.