### PR TITLE
ci: fix Update Storybook script

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -88,7 +88,7 @@ jobs:
       - name: 📚 Update Storybook
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
-          git clean -xdff ../storybook-static
+          rm -rf ../storybook-static
           mv ./storybook-static ..
 
           git config --local user.email "webviz-github-action"


### PR DESCRIPTION
Third tentative: delete existing ../storybook-static directory

The previous way to clean the directory does not work because ../storybook-static is not in any git repo. Replace
> git clean -xdff ../storybook-static
with
> rm -rf ../storybook-static