### PR TITLE
test: fix storybook test runner

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -115,6 +115,7 @@ jobs:
           HOST: 127.0.0.1
         run: |
           npm install concurrently http-server wait-on
+          npx playwright install
           npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
             "npx http-server storybook-static --port $PORT -a $HOST" \
             "npx wait-on http://$HOST:$PORT/ && npm run storybook:test -- --ci --url http://$HOST:$PORT/"

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -111,10 +111,10 @@ jobs:
 
       - name: Serve Storybook and run tests
         env:
-            PORT: 8080
-            HOST: 127.0.0.1
+          PORT: 8080
+          HOST: 127.0.0.1
         run: |
-            npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
-              "npx playwright install"  \
-              "npx http-server storybook-static --port $PORT -a $HOST" \
-              "npx wait-on http://$HOST:$PORT/ && npm run storybook:test -- --ci --url http://$HOST:$PORT/"
+          npm install concurrently http-server wait-on
+          npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
+            "npx http-server storybook-static --port $PORT -a $HOST" \
+            "npx wait-on http://$HOST:$PORT/ && npm run storybook:test -- --ci --url http://$HOST:$PORT/"


### PR DESCRIPTION
The tests were not run due to misuse of `concurrently`