### PR TITLE
fix: If camera or bounds property is set, the view should not change when adding a layer.

### DIFF
--- a/typescript/packages/subsurface-viewer/src/layers/map/mapLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/layers/map/mapLayer.stories.tsx
@@ -558,8 +558,13 @@ export const AddLayer: ComponentStory<typeof SubsurfaceViewer> = (args) => {
 
 AddLayer.args = {
     id: "map",
-
-    bounds: [432150, 6475800, 439400, 6481500] as NumberQuad,
+    //bounds: [432150, 6475800, 439400, 6481500] as NumberQuad,  // Keep this line for future testing.
+    cameraPosition: {
+        rotationOrbit: 45,
+        rotationX: -45,
+        zoom: [432150, 6475800, -2000, 439400, 6481500, -3500],
+        target: [0, 0, 0],
+    },
     views: {
         layout: [1, 1],
         viewports: [


### PR DESCRIPTION
I had to split an effect to accomplish this.