### PR TITLE
fix: "Grid3DLayer: surfaces are not displayed on firefox"

### DIFF
--- a/typescript/packages/subsurface-viewer/src/layers/grid3d/webworker.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/grid3d/webworker.ts
@@ -892,7 +892,7 @@ export function makeFullMesh(e: { data: WebWorkerParams }): void {
             positions: { value: new Float32Array(triang_points), size: 3 },
             properties: { value: new Float32Array(vertexProperties), size: 1 },
         },
-        vertexCount: triang_points.length,
+        vertexCount: triang_points.length / 3,
     };
 
     const mesh_lines: MeshTypeLines = {


### PR DESCRIPTION
This will fix the following webviz  issue: "Grid3DLayer: surfaces are not displayed on firefox #1765"

 - To many vertices was reported to webgl.