### PR TITLE
fix: Point layer and line layer cursor readout not working

### DIFF
--- a/typescript/packages/subsurface-viewer/src/layers/points/pointsLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/points/pointsLayer.ts
@@ -1,10 +1,18 @@
-import type { UpdateParameters } from "@deck.gl/core/typed";
+import type { PickingInfo, UpdateParameters } from "@deck.gl/core/typed";
 import { CompositeLayer } from "@deck.gl/core/typed";
 import { ScatterplotLayer } from "@deck.gl/layers/typed";
 import { isEqual } from "lodash";
 
-import type { ExtendedLayerProps } from "../utils/layerTools";
-import { invertZCoordinate, defineBoundingBox } from "../utils/layerTools";
+import type {
+    PropertyDataType,
+    ExtendedLayerProps,
+    LayerPickInfo,
+} from "../utils/layerTools";
+import {
+    createPropertyData,
+    invertZCoordinate,
+    defineBoundingBox,
+} from "../utils/layerTools";
 
 export interface PointsLayerProps extends ExtendedLayerProps {
     /**
@@ -96,6 +104,26 @@ export default class PointsLayer extends CompositeLayer<PointsLayerProps> {
             const dataAttributes = this.rebuildDataAttributes(false);
             this.setState({ dataAttributes });
         }
+    }
+
+    getPickingInfo({ info }: { info: PickingInfo }): LayerPickInfo {
+        if (!info.color) {
+            return info;
+        }
+
+        const layer_properties: PropertyDataType[] = [];
+
+        if (typeof info.coordinate?.[2] !== "undefined") {
+            const depth = this.props.ZIncreasingDownwards
+                ? -info.coordinate[2]
+                : info.coordinate[2];
+            layer_properties.push(createPropertyData("Depth", depth));
+        }
+
+        return {
+            ...info,
+            properties: layer_properties,
+        };
     }
 
     private rebuildDataAttributes(

--- a/typescript/packages/subsurface-viewer/src/layers/polylines/polylinesLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/polylines/polylinesLayer.ts
@@ -3,8 +3,16 @@ import { CompositeLayer } from "@deck.gl/core/typed";
 import { PathLayer } from "@deck.gl/layers/typed";
 import { isEqual } from "lodash";
 
-import type { ExtendedLayerProps } from "../utils/layerTools";
-import { invertZCoordinate, defineBoundingBox } from "../utils/layerTools";
+import type {
+    PropertyDataType,
+    ExtendedLayerProps,
+    LayerPickInfo,
+} from "../utils/layerTools";
+import {
+    createPropertyData,
+    invertZCoordinate,
+    defineBoundingBox,
+} from "../utils/layerTools";
 
 type IsPolylineClosedFunc = (index: number) => boolean;
 
@@ -148,6 +156,26 @@ export default class PolylinesLayer extends CompositeLayer<PolylinesLayerProps> 
                 },
             },
             pathType: dataArrays.pathType,
+        };
+    }
+
+    getPickingInfo({ info }: { info: PickingInfo }): LayerPickInfo {
+        if (!info.color) {
+            return info;
+        }
+
+        const layer_properties: PropertyDataType[] = [];
+
+        if (typeof info.coordinate?.[2] !== "undefined") {
+            const depth = this.props.ZIncreasingDownwards
+                ? -info.coordinate[2]
+                : info.coordinate[2];
+            layer_properties.push(createPropertyData("Depth", depth));
+        }
+
+        return {
+            ...info,
+            properties: layer_properties,
         };
     }
 

--- a/typescript/packages/subsurface-viewer/src/layers/polylines/polylinesLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/polylines/polylinesLayer.ts
@@ -1,4 +1,4 @@
-import type { UpdateParameters } from "@deck.gl/core/typed";
+import type { PickingInfo, UpdateParameters } from "@deck.gl/core/typed";
 import { CompositeLayer } from "@deck.gl/core/typed";
 import { PathLayer } from "@deck.gl/layers/typed";
 import { isEqual } from "lodash";


### PR DESCRIPTION
- This is a fix of webviz issue: "Point layer and line layer cursor readout not working #1655"
- https://github.com/equinor/webviz-subsurface-components/issues/1655