### PR TITLE
fix: bump to latest @emerson-eps/color-tables

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -3424,9 +3424,9 @@
             }
         },
         "node_modules/@emerson-eps/color-tables": {
-            "version": "0.4.61",
-            "resolved": "https://registry.npmjs.org/@emerson-eps/color-tables/-/color-tables-0.4.61.tgz",
-            "integrity": "sha512-hQZgEoTbfllCI6by14RI/Jpqftn9m3wBT6afNOu/ffM4/IxjxpKYaG1ycle310AOAJWoTj9wByIwE7YlkJIFoQ==",
+            "version": "0.4.71",
+            "resolved": "https://registry.npmjs.org/@emerson-eps/color-tables/-/color-tables-0.4.71.tgz",
+            "integrity": "sha512-LgawQZR/5wBHPEfebVbfv5mtnMHyzlo1fTJ1XRD9rTrOQAqIrhtxJNtdSQngSmA+BV2qIkVFDfdI+WejZ+RYEg==",
             "dependencies": {
                 "@emotion/react": "^11.10.6",
                 "@emotion/styled": "^11.10.0",
@@ -42364,7 +42364,7 @@
         },
         "packages/group-tree": {
             "name": "@webviz/group-tree",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "license": "MPL-2.0",
             "dependencies": {
                 "@equinor/eds-core-react": "^0.33.0",
@@ -42381,11 +42381,11 @@
         },
         "packages/subsurface-viewer": {
             "name": "@webviz/subsurface-viewer",
-            "version": "0.5.5",
+            "version": "0.5.8",
             "license": "MPL-2.0",
             "dependencies": {
                 "@deck.gl/core": "^8.9.32",
-                "@emerson-eps/color-tables": "^0.4.61",
+                "@emerson-eps/color-tables": "^0.4.71",
                 "@equinor/eds-core-react": "^0.33.0",
                 "@equinor/eds-icons": "^0.19.1",
                 "@nebula.gl/layers": "^1.0.4",
@@ -42428,7 +42428,7 @@
         },
         "packages/well-completions-plot": {
             "name": "@webviz/well-completions-plot",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "license": "MPL-2.0",
             "dependencies": {
                 "react-resize-detector": "^9.1.0",
@@ -42468,10 +42468,10 @@
         },
         "packages/well-log-viewer": {
             "name": "@webviz/well-log-viewer",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "license": "MPL-2.0",
             "dependencies": {
-                "@emerson-eps/color-tables": "^0.4.61",
+                "@emerson-eps/color-tables": "^0.4.71",
                 "@equinor/videx-wellog": "^0.8.0",
                 "@webviz/wsc-common": "*",
                 "convert-units": "^2.3.4",
@@ -42485,7 +42485,7 @@
         },
         "packages/wsc-common": {
             "name": "@webviz/wsc-common",
-            "version": "0.2.3",
+            "version": "0.2.4",
             "license": "MPL-2.0",
             "dependencies": {
                 "ajv": "^7.2.1"

--- a/typescript/packages/subsurface-viewer/package.json
+++ b/typescript/packages/subsurface-viewer/package.json
@@ -22,7 +22,7 @@
     "license": "MPL-2.0",
     "dependencies": {
         "@deck.gl/core": "^8.9.32",
-        "@emerson-eps/color-tables": "^0.4.61",
+        "@emerson-eps/color-tables": "^0.4.71",
         "@equinor/eds-core-react": "^0.33.0",
         "@equinor/eds-icons": "^0.19.1",
         "@nebula.gl/layers": "^1.0.4",

--- a/typescript/packages/well-log-viewer/package.json
+++ b/typescript/packages/well-log-viewer/package.json
@@ -21,7 +21,7 @@
     "author": "Equinor <opensource@equinor.com>",
     "license": "MPL-2.0",
     "dependencies": {
-        "@emerson-eps/color-tables": "^0.4.61",
+        "@emerson-eps/color-tables": "^0.4.71",
         "@equinor/videx-wellog": "^0.8.0",
         "@webviz/wsc-common": "*",
         "convert-units": "^2.3.4",


### PR DESCRIPTION
Prevents overriding background color css.

Fixes #1752