### PR TITLE
fix: camera state when hidden page is rendered

### DIFF
--- a/typescript/packages/subsurface-viewer/src/SubsurfaceViewer.tsx
+++ b/typescript/packages/subsurface-viewer/src/SubsurfaceViewer.tsx
@@ -58,7 +58,11 @@ export interface SubsurfaceViewerProps {
     id: string;
     resources?: Record<string, unknown>;
     layers?: Record<string, unknown>[] | LayersList;
+
     bounds?: [number, number, number, number] | BoundsAccessor;
+    cameraPosition?: ViewStateType | undefined;
+    triggerHome?: number;
+
     views?: ViewsType;
     coords?: {
         visible?: boolean | null;
@@ -96,10 +100,6 @@ export interface SubsurfaceViewerProps {
     onDragStart?: (info: PickingInfo, event: MjolnirGestureEvent) => void;
     onDragEnd?: (info: PickingInfo, event: MjolnirGestureEvent) => void;
 
-    /**
-     * If changed will reset camera to default position.
-     */
-    triggerHome?: number;
     triggerResetMultipleWells?: number;
     /**
      * Range selection of the current well
@@ -113,7 +113,6 @@ export interface SubsurfaceViewerProps {
      * Override default tooltip with a callback.
      */
     getTooltip?: TooltipCallback;
-    cameraPosition?: ViewStateType | undefined;
 
     lights?: LightsType;
 
@@ -125,6 +124,8 @@ const SubsurfaceViewer: React.FC<SubsurfaceViewerProps> = ({
     resources,
     layers,
     bounds,
+    cameraPosition,
+    triggerHome,
     views,
     coords,
     scale,
@@ -136,12 +137,10 @@ const SubsurfaceViewer: React.FC<SubsurfaceViewerProps> = ({
     onMouseEvent,
     selection,
     getTooltip,
-    cameraPosition,
     getCameraPosition,
-    isRenderedCallback: isRenderedCallback,
+    isRenderedCallback,
     onDragStart,
     onDragEnd,
-    triggerHome,
     triggerResetMultipleWells,
     lights,
     children,

--- a/typescript/packages/subsurface-viewer/src/components/Map.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.tsx
@@ -3,7 +3,6 @@ import type { DeckGLRef } from "@deck.gl/react/typed";
 import DeckGL from "@deck.gl/react/typed";
 import type {
     Color,
-    Deck,
     Layer,
     LayersList,
     LayerProps,
@@ -622,6 +621,7 @@ const Map: React.FC<MapProps> = ({
                 height: deckRef.current.deck.height,
             });
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [deckRef.current?.deck?.width, deckRef.current?.deck?.height]);
 
     // Deck.gl View's and viewStates as input to Deck.gl
@@ -637,7 +637,7 @@ const Map: React.FC<MapProps> = ({
 
     const [viewStateChanged, setViewStateChanged] = useState<boolean>(false);
 
-    const camera = useMemo<ViewStateType>(() => {
+    const camera = useMemo<ViewStateType | undefined>(() => {
         return calculateZoomFromBBox3D(cameraPosition, deckSize);
     }, [cameraPosition, deckSize]);
 
@@ -1310,7 +1310,7 @@ function getViewState(
 function getViewState3D(
     is3D: boolean,
     bounds: BoundingBox3D,
-    zoom?: number,
+    zoom: number | undefined,
     size: Size
 ): ViewStateType {
     const xMin = bounds[0];
@@ -1374,15 +1374,15 @@ function createViewsAndViewStates(
     const mPixels = views?.marginPixels ?? 0;
 
     const isOk: boolean =
-        views &&
-        Object.keys(views).length !== 0 &&
-        views.layout[0] >= 1 &&
-        views.layout[1] >= 1 &&
+        views?.layout !== undefined &&
+        views?.layout?.[0] >= 1 &&
+        views?.layout?.[1] >= 1 &&
         widthViewPort > 0 &&
         heightViewPort > 0;
 
     // if props for multiple viewport are not proper, or deck size is not yet initialized, return 2d view
-    if (!isOk) {
+    // add redundant check on views to please lint
+    if (!views || !isOk) {
         deckgl_views.push(
             new OrthographicView({
                 id: "main",

--- a/typescript/packages/subsurface-viewer/src/components/Map.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.tsx
@@ -330,8 +330,22 @@ export interface MapProps {
 
     /**
      * Coordinate boundary for the view defined as [left, bottom, right, top].
+     * Should be used for 2D view only.
      */
     bounds?: [number, number, number, number] | BoundsAccessor;
+
+    /**
+     * Camera state for the view defined as [left, bottom, right, top].
+     * Should be used for 3D view only.
+     * If the zoom is given as a 3D bounding box, the camera state is computed to
+     * display the full box.
+     */
+    cameraPosition?: ViewStateType;
+
+    /**
+     * If changed will reset view settings (bounds or camera) to default position.
+     */
+    triggerHome?: number;
 
     /**
      * Views configuration for map. If not specified, all the layers will be
@@ -402,10 +416,6 @@ export interface MapProps {
     onDragStart?: (info: PickingInfo, event: MjolnirGestureEvent) => void;
     onDragEnd?: (info: PickingInfo, event: MjolnirGestureEvent) => void;
 
-    /**
-     * If changed will reset camera to default position.
-     */
-    triggerHome?: number;
     triggerResetMultipleWells?: number;
     selection?: {
         well: string | undefined;
@@ -417,7 +427,6 @@ export interface MapProps {
     children?: React.ReactNode;
 
     getTooltip?: TooltipCallback;
-    cameraPosition?: ViewStateType;
 }
 
 export interface MapMouseEvent {
@@ -566,6 +575,8 @@ const Map: React.FC<MapProps> = ({
     id,
     layers,
     bounds,
+    cameraPosition,
+    triggerHome,
     views,
     coords,
     scale,
@@ -577,12 +588,10 @@ const Map: React.FC<MapProps> = ({
     selection,
     children,
     getTooltip = defaultTooltip,
-    cameraPosition,
     getCameraPosition,
     isRenderedCallback,
     onDragStart,
     onDragEnd,
-    triggerHome,
     lights,
     triggerResetMultipleWells,
 }: MapProps) => {
@@ -1029,7 +1038,7 @@ const Map: React.FC<MapProps> = ({
         ({ viewId, viewState }: { viewId: string; viewState: any }) => {
             const viewports = views?.viewports || [];
             if (viewState.target.length === 2) {
-                // In orthograpic mode viewState.target contains only x and y. Add existing z value.
+                // In orthographic mode viewState.target contains only x and y. Add existing z value.
                 viewState.target.push(viewStates[viewId].target[2]);
             }
             const isSyncIds = viewports

--- a/typescript/packages/subsurface-viewer/src/components/__snapshots__/Map.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/__snapshots__/Map.test.tsx.snap
@@ -1,5 +1,155 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Test Map component snapshot test 1`] = `null`;
+exports[`Test Map component snapshot test 1`] = `
+.c0 {
+  display: inline-block;
+  -webkit-transform: rotate(-90deg);
+  -ms-transform: rotate(-90deg);
+  transform: rotate(-90deg);
+}
 
-exports[`Test Map component snapshot test with edited data 1`] = `null`;
+.c1 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+<div>
+  <div
+    id="DeckGL-Map-wrapper"
+    style="position: absolute; z-index: 0; left: 0px; top: 0px; width: 100%; height: 100%;"
+  >
+    <canvas
+      id="DeckGL-Map"
+      style="left: 0px; top: 0px; width: 100%; position: absolute; height: 100%;"
+    />
+  </div>
+  <div>
+    <svg
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="0"
+      class="c0"
+      height="48"
+      preserveAspectRatio="xMidYMid meet"
+      role="progressbar"
+      viewBox="24 24 48 48"
+      width="48"
+    >
+      <circle
+        class=""
+        cx="48"
+        cy="48"
+        fill="none"
+        r="22"
+        stroke="var(--eds_infographic_primary__moss_green_13, rgba(222, 237, 238, 1))"
+        stroke-width="4"
+        style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+      />
+      <circle
+        class=""
+        cx="48"
+        cy="48"
+        fill="none"
+        r="22"
+        stroke="var(--eds_infographic_primary__moss_green_100, rgba(0, 112, 121, 1))"
+        stroke-dasharray="138.23007675795088"
+        stroke-linecap="round"
+        stroke-width="4"
+        style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+      />
+    </svg>
+    <output
+      class="c1"
+    >
+      Loading 0%
+    </output>
+    <br />
+    Loading assets...
+  </div>
+</div>
+`;
+
+exports[`Test Map component snapshot test with edited data 1`] = `
+.c0 {
+  display: inline-block;
+  -webkit-transform: rotate(-90deg);
+  -ms-transform: rotate(-90deg);
+  transform: rotate(-90deg);
+}
+
+.c1 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+<div>
+  <div
+    id="DeckGL-Map-wrapper"
+    style="position: absolute; z-index: 0; left: 0px; top: 0px; width: 100%; height: 100%;"
+  >
+    <canvas
+      id="DeckGL-Map"
+      style="left: 0px; top: 0px; width: 100%; position: absolute; height: 100%;"
+    />
+  </div>
+  <div>
+    <svg
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="0"
+      class="c0"
+      height="48"
+      preserveAspectRatio="xMidYMid meet"
+      role="progressbar"
+      viewBox="24 24 48 48"
+      width="48"
+    >
+      <circle
+        class=""
+        cx="48"
+        cy="48"
+        fill="none"
+        r="22"
+        stroke="var(--eds_infographic_primary__moss_green_13, rgba(222, 237, 238, 1))"
+        stroke-width="4"
+        style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+      />
+      <circle
+        class=""
+        cx="48"
+        cy="48"
+        fill="none"
+        r="22"
+        stroke="var(--eds_infographic_primary__moss_green_100, rgba(0, 112, 121, 1))"
+        stroke-dasharray="138.23007675795088"
+        stroke-linecap="round"
+        stroke-width="4"
+        style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+      />
+    </svg>
+    <output
+      class="c1"
+    >
+      Loading 0%
+    </output>
+    <br />
+    Loading assets...
+  </div>
+</div>
+`;

--- a/typescript/packages/subsurface-viewer/src/components/settings/LayersButton.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/settings/LayersButton.test.tsx
@@ -10,7 +10,15 @@ import LayersButton from "./LayersButton";
 
 import exampleData from "../../../../../../example-data/deckgl-map.json";
 
-const testLayers: Record<string, unknown>[] = exampleData[0].layers;
+// Ensure layers have an id (which is not stored un the example data) to avoid react error messages
+const testLayers: Record<string, unknown>[] = exampleData[0].layers.map(
+    (layer) => {
+        if (layer["id"] === undefined) {
+            layer["id"] = layer["@@type"];
+        }
+        return layer;
+    }
+);
 
 describe("test 'layers' button", () => {
     it("snapshot test", () => {

--- a/typescript/packages/subsurface-viewer/src/layers/axes/axesLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/axes/axesLayer.ts
@@ -578,9 +578,7 @@ function GetTickLines(
     return [lines, tick_labels];
 }
 
-function GetBoxLines(
-    bounds: BoundingBox3D
-): number[] {
+function GetBoxLines(bounds: BoundingBox3D): number[] {
     const x_min = bounds[0];
     const x_max = bounds[3];
 

--- a/typescript/packages/subsurface-viewer/src/layers/axes/axesLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/axes/axesLayer.ts
@@ -11,6 +11,10 @@ import {
 } from "@deck.gl/core/typed";
 import BoxLayer from "./boxLayer";
 import type { Position3D, ExtendedLayerProps } from "../utils/layerTools";
+import type {
+    BoundingBox3D,
+    ReportBoundingBoxAction,
+} from "../../components/Map";
 import { TextLayer } from "@deck.gl/layers/typed";
 import { cloneDeep } from "lodash";
 
@@ -20,7 +24,7 @@ export interface AxesLayerProps extends ExtendedLayerProps {
      *  Note that z values are default interptreted as going downwards. See property "ZIncreasingDownwards".
      *  So by default zmax is expected to be bigger than zmin.
      */
-    bounds: [number, number, number, number, number, number];
+    bounds: BoundingBox3D;
     labelColor?: Color;
     labelFontSize?: number;
     fontFamily?: string;
@@ -32,9 +36,7 @@ export interface AxesLayerProps extends ExtendedLayerProps {
     ZIncreasingDownwards: boolean;
 
     // Non public properties:
-    setReportedBoundingBox?: React.Dispatch<
-        React.SetStateAction<[number, number, number, number, number, number]>
-    >;
+    reportBoundingBox?: React.Dispatch<ReportBoundingBoxAction>;
 }
 
 const defaultProps = {
@@ -99,10 +101,10 @@ export default class AxesLayer extends CompositeLayer<AxesLayerProps> {
         this.setState({ box_lines, tick_lines, textlayerData });
 
         if (
-            typeof this.props.setReportedBoundingBox !== "undefined" &&
+            typeof this.props.reportBoundingBox !== "undefined" &&
             reportBoundingBox
         ) {
-            this.props.setReportedBoundingBox(bounds);
+            this.props.reportBoundingBox({ layerBoundingBox: bounds });
         }
     }
 
@@ -242,7 +244,7 @@ function maketextLayerData(
     is_orthographic: boolean,
     tick_lines: number[],
     tick_labels: string[],
-    bounds: [number, number, number, number, number, number],
+    bounds: BoundingBox3D,
     labelFontSize?: number
 ): [TextLayerData] {
     const x_min = bounds[0];
@@ -351,7 +353,7 @@ function GetTicks(
 function GetTickLines(
     isZIncreasingDownwards: boolean,
     is_orthographic: boolean,
-    bounds: [number, number, number, number, number, number],
+    bounds: BoundingBox3D,
     viewport: Viewport
 ): [number[], string[]] {
     const ndecimals = 0;
@@ -577,7 +579,7 @@ function GetTickLines(
 }
 
 function GetBoxLines(
-    bounds: [number, number, number, number, number, number]
+    bounds: BoundingBox3D
 ): number[] {
     const x_min = bounds[0];
     const x_max = bounds[3];

--- a/typescript/packages/subsurface-viewer/src/layers/colormap/colormapLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/colormap/colormapLayer.ts
@@ -11,7 +11,10 @@ import { decodeRGB } from "../utils/propertyMapTools";
 import type { colorMapFunctionType } from "../utils/layerTools";
 import { getModelMatrix } from "../utils/layerTools";
 import fsColormap from "./colormap.fs.glsl";
-import type { DeckGLLayerContext } from "../../components/Map";
+import type {
+    DeckGLLayerContext,
+    ReportBoundingBoxAction,
+} from "../../components/Map";
 import type { colorTablesArray } from "@emerson-eps/color-tables/";
 import { getRgbData } from "@emerson-eps/color-tables";
 import type { ContinuousLegendDataType } from "../../components/ColorLegend";
@@ -93,8 +96,8 @@ export interface ColormapLayerProps extends BitmapLayerProps {
     // Rotates image around bounds upper left corner counterclockwise in degrees.
     rotDeg: number;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    setReportedBoundingBox?: any;
+    // Non public properties:
+    reportBoundingBox?: React.Dispatch<ReportBoundingBoxAction>;
 }
 
 const defaultProps = {
@@ -132,16 +135,17 @@ export default class ColormapLayer extends BitmapLayer<ColormapLayerProps> {
                 isLoaded: true,
             });
 
-            if (typeof this.props.setReportedBoundingBox !== "undefined") {
-                const xMin = this.props.bounds[0];
-                const yMin = this.props.bounds[1];
+            if (typeof this.props.reportBoundingBox !== "undefined") {
+                const xMin = this.props.bounds[0] as number;
+                const yMin = this.props.bounds[1] as number;
                 const zMin = 1;
-                const xMax = this.props.bounds[2];
-                const yMax = this.props.bounds[3];
+                const xMax = this.props.bounds[2] as number;
+                const yMax = this.props.bounds[3] as number;
                 const zMax = -1;
-                const bbox = [xMin, yMin, zMin, xMax, yMax, zMax];
 
-                this.props.setReportedBoundingBox(bbox);
+                this.props.reportBoundingBox({
+                    layerBoundingBox: [xMin, yMin, zMin, xMax, yMax, zMax],
+                });
             }
         }
 

--- a/typescript/packages/subsurface-viewer/src/layers/grid3d/grid3dLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/grid3d/grid3dLayer.ts
@@ -6,6 +6,10 @@ import type {
     ExtendedLayerProps,
     colorMapFunctionType,
 } from "../utils/layerTools";
+import type {
+    BoundingBox3D,
+    ReportBoundingBoxAction,
+} from "../../components/Map";
 import { makeFullMesh } from "./webworker";
 import { isEqual } from "lodash";
 import { load, JSONLoader } from "@loaders.gl/core";
@@ -16,9 +20,7 @@ export type WebWorkerParams = {
     properties: Float32Array;
 };
 
-function GetBBox(
-    points: Float32Array
-): [number, number, number, number, number, number] {
+function GetBBox(points: Float32Array): BoundingBox3D {
     let xmax = -99999999;
     let ymax = -99999999;
     let zmax = -99999999;
@@ -84,9 +86,6 @@ async function load_data(
 }
 
 export interface Grid3DLayerProps extends ExtendedLayerProps {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    setReportedBoundingBox?: any;
-
     /**  Url, or native, or typed javascript array. Set of points.
      * [x1, y1, z1, x2, y2, z2, ...]
      */
@@ -155,6 +154,9 @@ export interface Grid3DLayerProps extends ExtendedLayerProps {
      *   For example depth of z = 1000 corresponds to -1000 on the z axis. Default true.
      */
     ZIncreasingDownwards: boolean;
+
+    // Non public properties:
+    reportBoundingBox?: React.Dispatch<ReportBoundingBoxAction>;
 }
 
 const defaultProps = {
@@ -226,10 +228,10 @@ export default class Grid3DLayer extends CompositeLayer<Grid3DLayerProps> {
                 });
 
                 if (
-                    typeof this.props.setReportedBoundingBox !== "undefined" &&
+                    typeof this.props.reportBoundingBox !== "undefined" &&
                     reportBoundingBox
                 ) {
-                    this.props.setReportedBoundingBox(bbox);
+                    this.props.reportBoundingBox({ layerBoundingBox: bbox });
                 }
 
                 webWorker.terminate();

--- a/typescript/packages/subsurface-viewer/src/layers/hillshading2d/hillshading2dLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/hillshading2d/hillshading2dLayer.ts
@@ -7,6 +7,7 @@ import type { ValueDecoder } from "../utils/propertyMapTools";
 import { decodeRGB } from "../utils/propertyMapTools";
 import { getModelMatrix } from "../utils/layerTools";
 import type { LayerPickInfo } from "../../layers/utils/layerTools";
+import type { ReportBoundingBoxAction } from "../../components/Map";
 
 import fsHillshading from "./hillshading2d.fs.glsl";
 
@@ -35,8 +36,8 @@ export interface Hillshading2DProps extends BitmapLayerProps {
     // Rotates image around bounds upper left corner counterclockwise in degrees.
     rotDeg: number;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    setReportedBoundingBox?: any;
+    // Non public properties:
+    reportBoundingBox?: React.Dispatch<ReportBoundingBoxAction>;
 }
 
 const defaultProps = {
@@ -76,16 +77,17 @@ export default class Hillshading2DLayer extends BitmapLayer<Hillshading2DProps> 
                 isLoaded: true,
             });
 
-            if (typeof this.props.setReportedBoundingBox !== "undefined") {
-                const xMin = this.props.bounds[0];
-                const yMin = this.props.bounds[1];
+            if (typeof this.props.reportBoundingBox !== "undefined") {
+                const xMin = this.props.bounds[0] as number;
+                const yMin = this.props.bounds[1] as number;
                 const zMin = 1;
-                const xMax = this.props.bounds[2];
-                const yMax = this.props.bounds[3];
+                const xMax = this.props.bounds[2] as number;
+                const yMax = this.props.bounds[3] as number;
                 const zMax = -1;
-                const bbox = [xMin, yMin, zMin, xMax, yMax, zMax];
 
-                this.props.setReportedBoundingBox(bbox);
+                this.props.reportBoundingBox({
+                    layerBoundingBox: [xMin, yMin, zMin, xMax, yMax, zMax],
+                });
             }
         }
 

--- a/typescript/packages/subsurface-viewer/src/layers/map/mapLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/layers/map/mapLayer.stories.tsx
@@ -1,5 +1,6 @@
 import type { SyntheticEvent } from "react";
 import React from "react";
+import { ComponentMeta } from "@storybook/react";
 import { styled } from "@mui/material/styles";
 import type { BoundingBox3D, ViewsType } from "../../components/Map";
 import { useHoverInfo } from "../../components/Map";
@@ -46,7 +47,12 @@ const Root = styled("div")({
 export default {
     component: SubsurfaceViewer,
     title: "SubsurfaceViewer / Map Layer",
-};
+    args: {
+        // Add a reset button for all the stories.
+        // Somehow, I do not manage to add the triggerHome to the general "unset" controls :/
+        triggerHome: 0,
+    },
+} as ComponentMeta<typeof SubsurfaceViewer>;
 
 type NumberQuad = [number, number, number, number];
 

--- a/typescript/packages/subsurface-viewer/src/layers/map/mapLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/layers/map/mapLayer.stories.tsx
@@ -1,6 +1,6 @@
 import type { SyntheticEvent } from "react";
 import React from "react";
-import { ComponentMeta } from "@storybook/react";
+import type { ComponentMeta } from "@storybook/react";
 import { styled } from "@mui/material/styles";
 import type { BoundingBox3D, ViewsType } from "../../components/Map";
 import { useHoverInfo } from "../../components/Map";

--- a/typescript/packages/subsurface-viewer/src/layers/map/mapLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/map/mapLayer.ts
@@ -11,6 +11,7 @@ import type {
     ExtendedLayerProps,
     colorMapFunctionType,
 } from "../utils/layerTools";
+import type { ReportBoundingBoxAction } from "../../components/Map";
 import { getModelMatrix } from "../utils/layerTools";
 import { isEqual } from "lodash";
 import * as png from "@vivaxy/png";
@@ -187,9 +188,6 @@ async function loadMeshAndProperties(
 }
 
 export interface MapLayerProps extends ExtendedLayerProps {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    setReportedBoundingBox?: any;
-
     /**  Url to the height (z values) mesh.
      */
     meshUrl: string; // Deprecated
@@ -286,6 +284,9 @@ export interface MapLayerProps extends ExtendedLayerProps {
      * For example depth of z = 1000 corresponds to -1000 on the z axis. Default true.
      */
     ZIncreasingDownwards: boolean;
+
+    // Non public properties:
+    reportBoundingBox?: React.Dispatch<ReportBoundingBoxAction>;
 }
 
 const defaultProps = {
@@ -366,7 +367,7 @@ export default class MapLayer<
             });
 
             if (
-                typeof this.props.setReportedBoundingBox !== "undefined" &&
+                typeof this.props.reportBoundingBox !== "undefined" &&
                 reportBoundingBox
             ) {
                 const xinc = this.props.frame?.increment?.[0] ?? 0;
@@ -400,14 +401,9 @@ export default class MapLayer<
                 const y_min = Math.min(y0, y1, y2, y3);
                 const y_max = Math.max(y0, y1, y2, y3);
 
-                this.props.setReportedBoundingBox([
-                    x_min,
-                    y_min,
-                    zMin,
-                    x_max,
-                    y_max,
-                    zMax,
-                ]);
+                this.props.reportBoundingBox({
+                    layerBoundingBox: [x_min, y_min, zMin, x_max, y_max, zMax],
+                });
             }
 
             this.setState({

--- a/typescript/packages/subsurface-viewer/src/layers/points/pointsLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/points/pointsLayer.ts
@@ -7,6 +7,7 @@ import type {
     ExtendedLayerProps,
     LayerPickInfo,
 } from "../utils/layerTools";
+import type { ReportBoundingBoxAction } from "../../components/Map";
 import { createPropertyData, defineBoundingBox } from "../utils/layerTools";
 
 import { PrivatePointsLayer } from "./privatePointsLayer";
@@ -42,9 +43,7 @@ export interface PointsLayerProps extends ExtendedLayerProps {
     depthTest: boolean;
 
     // Non public properties:
-    setReportedBoundingBox?: React.Dispatch<
-        React.SetStateAction<[number, number, number, number, number, number]>
-    >;
+    reportBoundingBox?: React.Dispatch<ReportBoundingBoxAction>;
 }
 
 const defaultProps = {
@@ -159,14 +158,14 @@ export default class PointsLayer extends CompositeLayer<PointsLayerProps> {
     private updateBoundingBox(reportBoundingBox: boolean) {
         if (
             this.state["dataAttributes"] &&
-            typeof this.props.setReportedBoundingBox === "function" &&
+            typeof this.props.reportBoundingBox === "function" &&
             reportBoundingBox
         ) {
             const boundingBox = defineBoundingBox(
                 this.state["dataAttributes"],
                 this.props.ZIncreasingDownwards
             );
-            this.props.setReportedBoundingBox(boundingBox);
+            this.props.reportBoundingBox({ layerBoundingBox: boundingBox });
         }
     }
 }

--- a/typescript/packages/subsurface-viewer/src/layers/polylines/polylinesLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/polylines/polylinesLayer.ts
@@ -8,6 +8,7 @@ import type {
     ExtendedLayerProps,
     LayerPickInfo,
 } from "../utils/layerTools";
+import type { ReportBoundingBoxAction } from "../../components/Map";
 import {
     createPropertyData,
     invertZCoordinate,
@@ -60,9 +61,7 @@ export interface PolylinesLayerProps extends ExtendedLayerProps {
     ZIncreasingDownwards: boolean;
 
     // Non public properties:
-    setReportedBoundingBox?: React.Dispatch<
-        React.SetStateAction<[number, number, number, number, number, number]>
-    >;
+    reportBoundingBox?: React.Dispatch<ReportBoundingBoxAction>;
 }
 
 const defaultProps = {
@@ -139,11 +138,11 @@ export default class PolylinesLayer extends CompositeLayer<PolylinesLayerProps> 
             invertZCoordinate(dataArrays.positions);
         }
         if (
-            typeof this.props.setReportedBoundingBox === "function" &&
+            typeof this.props.reportBoundingBox === "function" &&
             reportBoundingBox
         ) {
             const boundingBox = defineBoundingBox(dataArrays.positions);
-            this.props.setReportedBoundingBox(boundingBox);
+            this.props.reportBoundingBox({ layerBoundingBox: boundingBox });
         }
 
         return {

--- a/typescript/packages/subsurface-viewer/src/layers/terrain/map3DLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/terrain/map3DLayer.ts
@@ -6,6 +6,7 @@ import type {
     ExtendedLayerProps,
     colorMapFunctionType,
 } from "../utils/layerTools";
+import type { ReportBoundingBoxAction } from "../../components/Map";
 import { TerrainLoader } from "@loaders.gl/terrain";
 import { ImageLoader } from "@loaders.gl/images";
 import { load } from "@loaders.gl/core";
@@ -280,9 +281,6 @@ async function load_mesh_and_texture(
 }
 
 export interface Map3DLayerProps extends ExtendedLayerProps {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    setReportedBoundingBox?: any;
-
     // Url to png image representing the height mesh.
     mesh: string;
 
@@ -355,6 +353,9 @@ export interface Map3DLayerProps extends ExtendedLayerProps {
 
     // Enable/disable depth testing when rendering layer. Default true.
     depthTest: boolean;
+
+    // Non public properties:
+    reportBoundingBox?: React.Dispatch<ReportBoundingBoxAction>;
 }
 
 const defaultProps = {
@@ -431,15 +432,10 @@ export default class Map3DLayer extends CompositeLayer<Map3DLayerProps> {
             const yMax = isFrame ? yMin + yinc * ycount : bounds[3];
             const zMax = -this.props.meshValueRange[0];
 
-            if (typeof this.props.setReportedBoundingBox !== "undefined") {
-                this.props.setReportedBoundingBox([
-                    xMin,
-                    yMin,
-                    zMin,
-                    xMax,
-                    yMax,
-                    zMax,
-                ]);
+            if (typeof this.props.reportBoundingBox !== "undefined") {
+                this.props.reportBoundingBox({
+                    layerBoundingBox: [xMin, yMin, zMin, xMax, yMax, zMax],
+                });
             }
         });
     }

--- a/typescript/packages/subsurface-viewer/src/layers/triangle/triangleLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/triangle/triangleLayer.ts
@@ -3,6 +3,7 @@ import { CompositeLayer } from "@deck.gl/core/typed";
 import type { Material } from "./privateTriangleLayer";
 import PrivateTriangleLayer from "./privateTriangleLayer";
 import type { ExtendedLayerProps } from "../utils/layerTools";
+import type { ReportBoundingBoxAction } from "../../components/Map";
 import { isEqual } from "lodash";
 import { makeFullMesh } from "./webworker";
 import type React from "react";
@@ -119,9 +120,7 @@ export interface TriangleLayerProps extends ExtendedLayerProps {
     debug: boolean;
 
     // Non public properties:
-    setReportedBoundingBox?: React.Dispatch<
-        React.SetStateAction<[number, number, number, number, number, number]>
-    >;
+    reportBoundingBox?: React.Dispatch<ReportBoundingBoxAction>;
 }
 
 const defaultProps = {
@@ -185,7 +184,7 @@ export default class TriangleLayer extends CompositeLayer<TriangleLayerProps> {
                 });
 
                 if (
-                    typeof this.props.setReportedBoundingBox !== "undefined" &&
+                    typeof this.props.reportBoundingBox !== "undefined" &&
                     reportBoundingBox
                 ) {
                     let xmax = -99999999;
@@ -214,14 +213,9 @@ export default class TriangleLayer extends CompositeLayer<TriangleLayerProps> {
                         zmax = tmp;
                     }
 
-                    this.props.setReportedBoundingBox([
-                        xmin,
-                        ymin,
-                        zmin,
-                        xmax,
-                        ymax,
-                        zmax,
-                    ]);
+                    this.props.reportBoundingBox({
+                        layerBoundingBox: [xmin, ymin, zmin, xmax, ymax, zmax],
+                    });
                 }
 
                 webWorker.terminate();

--- a/typescript/packages/subsurface-viewer/src/layers/wells/wellsLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/wells/wellsLayer.ts
@@ -33,7 +33,10 @@ import {
     removeDuplicates,
 } from "./utils/spline";
 import { interpolateNumberArray } from "d3";
-import type { DeckGLLayerContext } from "../../components/Map";
+import type {
+    ReportBoundingBoxAction,
+    DeckGLLayerContext,
+} from "../../components/Map";
 import type {
     ContinuousLegendDataType,
     DiscreteLegendDataType,
@@ -74,8 +77,8 @@ function onDataLoad(
     }
 ): void {
     const bbox = GetBoundingBox(data as unknown as FeatureCollection);
-    if (typeof context.layer.props.setReportedBoundingBox !== "undefined") {
-        context.layer.props.setReportedBoundingBox(bbox);
+    if (typeof context.layer.props.reportBoundingBox !== "undefined") {
+        context.layer.props.reportBoundingBox({ layerBoundingBox: bbox });
     }
 }
 
@@ -114,6 +117,9 @@ export interface WellsLayerProps extends ExtendedLayerProps {
      *   Useful for example during panning and rotation to gain speed.
      */
     simplifiedRendering: boolean;
+
+    // Non public properties:
+    reportBoundingBox?: React.Dispatch<ReportBoundingBoxAction>;
 }
 
 const defaultProps = {

--- a/typescript/packages/subsurface-viewer/src/storybook/SubsurfaceViewer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/SubsurfaceViewer.stories.tsx
@@ -789,10 +789,6 @@ const ViewerTabs: React.FC<ViewerTabsProps> = (
 };
 
 export const ViewTabs: StoryFn<typeof ViewerTabs> = (args) => {
-    const props = {
-        ...args,
-    };
-
     return (
         <Root>
             <ViewerTabs {...args}></ViewerTabs>

--- a/typescript/packages/subsurface-viewer/src/storybook/SubsurfaceViewer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/SubsurfaceViewer.stories.tsx
@@ -695,9 +695,7 @@ const CustomTabPanel: React.FC<TabPanelProps> = (props: TabPanelProps) => {
             {...other}
         >
             {(value === index || renderHiddenTabs) && (
-                <Box sx={{ p: 3 }}>
-                    <Typography>{children}</Typography>
-                </Box>
+                <Box sx={{ p: 3 }}>{children}</Box>
             )}
         </div>
     );
@@ -708,6 +706,22 @@ const a11yProps = (index: number) => {
         id: `simple-tab-${index}`,
         "aria-controls": `simple-tabpanel-${index}`,
     };
+};
+
+const SubsurfaceWrapper: React.FC<SubsurfaceViewerProps> = (
+    props: SubsurfaceViewerProps
+) => {
+    return (
+        <div
+            style={{
+                height: "65vh",
+                //width: "50vw",
+                position: "relative",
+            }}
+        >
+            <SubsurfaceViewer {...props} />
+        </div>
+    );
 };
 
 type ViewerTabsProps = SubsurfaceViewerProps & { renderHiddenTabs: boolean };
@@ -742,45 +756,21 @@ const ViewerTabs: React.FC<ViewerTabsProps> = (
                         index={0}
                         renderHiddenTabs={props.renderHiddenTabs}
                     >
-                        <div
-                            style={{
-                                height: "65vh",
-                                //width: "50vw",
-                                position: "relative",
-                            }}
-                        >
-                            {<SubsurfaceViewer {...props} />}
-                        </div>
+                        <SubsurfaceWrapper {...props} />
                     </CustomTabPanel>
                     <CustomTabPanel
                         value={value}
                         index={1}
                         renderHiddenTabs={props.renderHiddenTabs}
                     >
-                        <div
-                            style={{
-                                height: "65vh",
-                                //width: "50vw",
-                                position: "relative",
-                            }}
-                        >
-                            {<SubsurfaceViewer {...props} />}
-                        </div>
+                        <SubsurfaceWrapper {...props} />
                     </CustomTabPanel>
                     <CustomTabPanel
                         value={value}
                         index={2}
                         renderHiddenTabs={props.renderHiddenTabs}
                     >
-                        <div
-                            style={{
-                                height: "65vh",
-                                //width: "50vw",
-                                position: "relative",
-                            }}
-                        >
-                            {<SubsurfaceViewer {...props} />}
-                        </div>
+                        <SubsurfaceWrapper {...props} />
                     </CustomTabPanel>
                 </Box>
             </Box>

--- a/typescript/packages/subsurface-viewer/src/storybook/SubsurfaceViewer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/SubsurfaceViewer.stories.tsx
@@ -1,13 +1,20 @@
 import React from "react";
 import type { StoryFn } from "@storybook/react";
 import { styled } from "@mui/material/styles";
+import type { SubsurfaceViewerProps } from "../SubsurfaceViewer";
 import SubsurfaceViewer from "../SubsurfaceViewer";
 import exampleData from "../../../../../example-data/deckgl-map.json";
+
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
 
 const PREFIX = "Default";
 
 const classes = {
     main: `${PREFIX}-main`,
+    tab: `${PREFIX}-tab`,
 };
 
 const Root = styled("div")({
@@ -47,13 +54,20 @@ export default {
             Each JSON object will consist of layer type with key as `@@type` and layer specific data, if any.",
         },
 
+        cameraPosition: {
+            description: "Camera position to set the point of view.",
+        },
+
         bounds: {
             description:
                 "Coordinate boundary for the view defined as [left, bottom, right, top].",
         },
 
-        zoom: {
-            description: "Zoom level for the view",
+        triggerHome: {
+            description: "Forces resetting to initial home position",
+            control: {
+                type: "number",
+            },
         },
 
         views: {
@@ -118,7 +132,12 @@ export default {
             description: "For reacting to prop changes",
         },
     },
-};
+    args: {
+        // Add a reset button for all the stories.
+        // Somehow, I do not manage to add the triggerHome to the general "unset" controls :/
+        triggerHome: 0,
+    },
+} as ComponentMeta<typeof SubsurfaceViewer>;
 
 // Template for when edited data needs to be captured.
 const EditDataTemplate = (args) => {
@@ -621,6 +640,168 @@ export const ViewMatrixMargin: StoryFn<typeof SubsurfaceViewer> = (args) => {
 };
 
 ViewMatrixMargin.args = {
+    id: "DeckGL-Map",
+    layers: [meshMapLayerPng, axes2D],
+    bounds: [432150, 6475800, 439400, 6481501],
+    views: {
+        layout: [2, 2],
+        marginPixels: 10,
+        showLabel: true,
+        viewports: [
+            {
+                id: "view_1",
+                show3D: false,
+                layerIds: ["mesh-layer-png", "axes-layer"],
+                isSync: true,
+            },
+            {
+                id: "view_2",
+                show3D: false,
+                layerIds: ["mesh-layer-png", "axes-layer"],
+                isSync: true,
+            },
+            {
+                id: "view_3",
+                show3D: false,
+                layerIds: ["mesh-layer-png", "axes-layer"],
+                isSync: false,
+            },
+            {
+                id: "view_4",
+                show3D: false,
+                layerIds: ["mesh-layer-png", "axes-layer"],
+                isSync: false,
+            },
+        ],
+    },
+};
+
+interface TabPanelProps {
+    children?: React.ReactNode;
+    index: number;
+    value: number;
+    renderHiddenTabs: boolean;
+}
+
+const CustomTabPanel: React.FC<TabPanelProps> = (props: TabPanelProps) => {
+    const { children, value, index, renderHiddenTabs, ...other } = props;
+
+    return (
+        <div
+            role="tabpanel"
+            hidden={value !== index}
+            id={`simple-tabpanel-${index}`}
+            aria-labelledby={`simple-tab-${index}`}
+            {...other}
+        >
+            {(value === index || renderHiddenTabs) && (
+                <Box sx={{ p: 3 }}>
+                    <Typography>{children}</Typography>
+                </Box>
+            )}
+        </div>
+    );
+};
+
+const a11yProps = (index: number) => {
+    return {
+        id: `simple-tab-${index}`,
+        "aria-controls": `simple-tabpanel-${index}`,
+    };
+};
+
+type ViewerTabsProps = SubsurfaceViewerProps & { renderHiddenTabs: boolean };
+
+const ViewerTabs: React.FC<ViewerTabsProps> = (
+    props: SubsurfaceViewerProps
+) => {
+    const [value, setValue] = React.useState(0);
+
+    const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+        setValue(newValue);
+    };
+
+    return (
+        <Box sx={{ width: "100%" }}>
+            <Box sx={{ flexDirection: "column" }}>
+                <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+                    <Tabs
+                        value={value}
+                        onChange={handleChange}
+                        aria-label="basic tabs example"
+                    >
+                        <Tab label="Tab One" {...a11yProps(0)} />
+                        <Tab label="Tab Two" {...a11yProps(1)} />
+                        <Tab label="Tab Three" {...a11yProps(2)} />
+                    </Tabs>
+                </Box>
+
+                <Box sx={{ height: "80%" }}>
+                    <CustomTabPanel
+                        value={value}
+                        index={0}
+                        renderHiddenTabs={props.renderHiddenTabs}
+                    >
+                        <div
+                            style={{
+                                height: "65vh",
+                                //width: "50vw",
+                                position: "relative",
+                            }}
+                        >
+                            {<SubsurfaceViewer {...props} />}
+                        </div>
+                    </CustomTabPanel>
+                    <CustomTabPanel
+                        value={value}
+                        index={1}
+                        renderHiddenTabs={props.renderHiddenTabs}
+                    >
+                        <div
+                            style={{
+                                height: "65vh",
+                                //width: "50vw",
+                                position: "relative",
+                            }}
+                        >
+                            {<SubsurfaceViewer {...props} />}
+                        </div>
+                    </CustomTabPanel>
+                    <CustomTabPanel
+                        value={value}
+                        index={2}
+                        renderHiddenTabs={props.renderHiddenTabs}
+                    >
+                        <div
+                            style={{
+                                height: "65vh",
+                                //width: "50vw",
+                                position: "relative",
+                            }}
+                        >
+                            {<SubsurfaceViewer {...props} />}
+                        </div>
+                    </CustomTabPanel>
+                </Box>
+            </Box>
+        </Box>
+    );
+};
+
+export const ViewTabs: StoryFn<typeof ViewerTabs> = (args) => {
+    const props = {
+        ...args,
+    };
+
+    return (
+        <Root>
+            <ViewerTabs {...args}></ViewerTabs>
+        </Root>
+    );
+};
+
+ViewTabs.args = {
+    renderHiddenTabs: true,
     id: "DeckGL-Map",
     layers: [meshMapLayerPng, axes2D],
     bounds: [432150, 6475800, 439400, 6481501],

--- a/typescript/packages/subsurface-viewer/src/storybook/SubsurfaceViewer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/SubsurfaceViewer.stories.tsx
@@ -7,7 +7,6 @@ import exampleData from "../../../../../example-data/deckgl-map.json";
 
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
-import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 
 const PREFIX = "Default";


### PR DESCRIPTION
Fix for #1820 

Add formal size state and effect to retrieve size from deck ref for code clarity
Move global bounding box handling to React reducer instead of useEffect.
Move camera computation to useMemo instead of useEffect.
Memoize viewPortMargins and deckGLLayers

Add a new story displaying the subsurface viewer in tabs to reproduce the issue

Note that this is a first step to reduce the number of useEffect in the Map component