### PR TITLE
fix: Use double click to center component on mouse position.

### DIFF
--- a/typescript/packages/subsurface-viewer/src/components/Map.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.tsx
@@ -918,7 +918,12 @@ const Map: React.FC<MapProps> = ({
             infos: PickingInfo[],
             event: MjolnirEvent
         ): void => {
-            if ((event as MjolnirPointerEvent).leftButton) {
+            if (
+                (event as MjolnirPointerEvent).leftButton &&
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-expect-error
+                event.tapCount == 2 // Note. Detect double click.
+            ) {
                 // Left button click identifies new camera rotation anchor.
                 const viewstateKeys = Object.keys(viewStates);
                 if (infos.length >= 1 && viewstateKeys.length === 1) {


### PR DESCRIPTION
 - used to be single click

- May be possible to remove the typecheck complaint if anybody has a suggestion.