### PR TITLE
fix: 'domain' prop handling in WellLogViewer/SyncLogViewer

### DIFF
--- a/python/src/components/WellLogViewer/WellLogViewer.tsx
+++ b/python/src/components/WellLogViewer/WellLogViewer.tsx
@@ -77,9 +77,6 @@ type WellLogViewerProps = {
     /** Names for axes */
     axisMnemos?: object;
 
-    /** The maximum zoom value */
-    maxContentZoom?: number;
-
     /** Set to true for default titles or to array of individual well log titles */
     viewTitle?: boolean | string | object; // 'object' might be replaced by a specific type like ReactNode
 

--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
@@ -340,7 +340,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
             });
         }
 
-        if (isEqualRanges(this.props.domain, prevProps.domain)) {
+        if (!isEqualRanges(this.props.domain, prevProps.domain)) {
             this.setControllersZoom();
         }
         if (
@@ -815,7 +815,11 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
     setControllersZoom(): void {
         for (const controller of this.controllers) {
             if (!controller) continue;
-            if (this.props.domain) controller.zoomContentTo(this.props.domain);
+            if (this.props.domain) {
+                controller.zoomContentTo(this.props.domain);
+                //this.forceUpdate();
+                break; // Set the domain only to the first controllers. Another controllers should be set by syncContentDomain or wellpickFlatting options
+            }
         }
     }
     setControllersSelection(): void {

--- a/typescript/packages/well-log-viewer/src/WellLogViewer.tsx
+++ b/typescript/packages/well-log-viewer/src/WellLogViewer.tsx
@@ -254,7 +254,6 @@ export default class WellLogViewer extends Component<
     }
 
     render(): JSX.Element {
-        const maxContentZoom = 256;
         return (
             <div style={{ height: "100%", width: "100%", display: "flex" }}>
                 <WellLogViewWithScroller
@@ -263,7 +262,8 @@ export default class WellLogViewer extends Component<
                     colorTables={this.props.colorTables}
                     wellpick={this.props.wellpick}
                     horizontal={this.props.horizontal}
-                    maxContentZoom={maxContentZoom}
+                    domain={this.props.domain}
+                    selection={this.props.selection}
                     primaryAxis={this.state.primaryAxis}
                     axisTitles={this.props.axisTitles}
                     axisMnemos={this.props.axisMnemos}
@@ -309,7 +309,7 @@ export default class WellLogViewer extends Component<
                         >
                             <ZoomSlider
                                 value={this.state.sliderValue}
-                                max={maxContentZoom}
+                                max={this.props.options?.maxContentZoom}
                                 onChange={this.onZoomSliderChange}
                             />
                         </span>


### PR DESCRIPTION
1. Remove unused 'domain' prop in python\src\components\WellLogViewer\WellLogViewer.tsx
2. Fix WellLogViewer props copying to WellLogView object
3. Fix bug in 'domain' prop handling in SyncLogViewer. Close #1773 