### PR TITLE
fix: wrong camera computation in 2D when bounds are provided

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -38735,7 +38735,7 @@
         },
         "packages/group-tree-plot": {
             "name": "@webviz/group-tree-plot",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "MPL-2.0",
             "dependencies": {
                 "d3": "^7.8.2",
@@ -38748,7 +38748,7 @@
         },
         "packages/subsurface-viewer": {
             "name": "@webviz/subsurface-viewer",
-            "version": "0.13.1",
+            "version": "0.13.2",
             "license": "MPL-2.0",
             "dependencies": {
                 "@deck.gl/core": "^8.9.32",
@@ -38795,7 +38795,7 @@
         },
         "packages/well-completions-plot": {
             "name": "@webviz/well-completions-plot",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "license": "MPL-2.0",
             "dependencies": {
                 "react-resize-detector": "^9.1.0",
@@ -38835,7 +38835,7 @@
         },
         "packages/well-log-viewer": {
             "name": "@webviz/well-log-viewer",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "license": "MPL-2.0",
             "dependencies": {
                 "@emerson-eps/color-tables": "^0.4.71",
@@ -38852,7 +38852,7 @@
         },
         "packages/wsc-common": {
             "name": "@webviz/wsc-common",
-            "version": "0.4.0",
+            "version": "0.4.1",
             "license": "MPL-2.0",
             "dependencies": {
                 "ajv": "^7.2.1"

--- a/typescript/packages/subsurface-viewer/src/components/Map.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.tsx
@@ -1104,6 +1104,7 @@ class ViewController {
             viewsChanged ||
             triggerHome ||
             state.camera != this.state_.camera ||
+            state.bounds != this.state_.bounds ||
             (!state.viewStateChanged &&
                 state.boundingBox3d !== this.state_.boundingBox3d);
         const needUpdate = updateZScale || updateTarget || updateViewState;
@@ -1523,7 +1524,8 @@ function buildDeckGlViews(views: ViewsType | undefined, size: Size): View[] {
 function updateViewState(
     camera: ViewStateType,
     boundingBox: BoundingBox3D | undefined,
-    size: Size
+    size: Size,
+    is3D = true
 ): ViewStateType {
     if (typeof camera.zoom === "number" && !Number.isNaN(camera.zoom)) {
         return camera;
@@ -1537,6 +1539,12 @@ function updateViewState(
     // return the camera if the bounding box is undefined
     if (boundingBox === undefined) {
         return camera;
+    }
+
+    if (!is3D) {
+        // in 2D, use flat boxes
+        boundingBox[2] = 0;
+        boundingBox[5] = 0;
     }
 
     // clone the camera in case of triggerHome
@@ -1593,6 +1601,12 @@ function computeViewState(
         };
         return updateViewState(defaultCamera, boundingBox, size);
     } else {
+        // If the camera is defined, use it
+        if (isCameraPositionDefined) {
+            const is3D = false;
+            return updateViewState(cameraPosition, boundingBox, size, is3D);
+        }
+
         const centerOfData: [number, number, number] = boundingBox
             ? boxCenter(boundingBox)
             : [0, 0, 0];
@@ -1606,11 +1620,6 @@ function computeViewState(
                 viewPort,
                 size
             );
-        }
-
-        // deprecated in 2D, kept for backward compatibility
-        if (isCameraPositionDefined) {
-            return cameraPosition;
         }
 
         return boundingBox
@@ -1775,3 +1784,4 @@ function handleMouseEvent(
     }
     return ev;
 }
+

--- a/typescript/packages/subsurface-viewer/src/components/Map.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.tsx
@@ -1784,4 +1784,3 @@ function handleMouseEvent(
     }
     return ev;
 }
-

--- a/typescript/packages/subsurface-viewer/src/storybook/examples/CameraControlExamples.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/examples/CameraControlExamples.stories.tsx
@@ -60,12 +60,13 @@ const Root = styled("div")({
     },
 });
 
-const CustomTemplate: React.FC<SubsurfaceViewerProps> = (args) => {
-    const [state, setState] = React.useState(args.cameraPosition);
+const DisplayCameraPositionComponent: React.FC<SubsurfaceViewerProps> = (
+    args
+) => {
+    const [cameraState, setCameraState] = React.useState(args.cameraPosition);
 
     const getCameraPosition = React.useCallback((input: ViewStateType) => {
-        setState(input);
-        return input;
+        setCameraState(input);
     }, []);
     return (
         <>
@@ -80,34 +81,34 @@ const CustomTemplate: React.FC<SubsurfaceViewerProps> = (args) => {
                     marginLeft: 200,
                 }}
             >
-                <div>zoom: {state?.zoom}</div>
-                <div>rotationX: {state?.rotationX}</div>
-                <div>rotationOrbit: {state?.rotationOrbit}</div>
-                <div>targetX: {state?.target[0]}</div>
-                <div>targetY: {state?.target[1]}</div>
+                <div>zoom: {cameraState?.zoom}</div>
+                <div>rotationX: {cameraState?.rotationX}</div>
+                <div>rotationOrbit: {cameraState?.rotationOrbit}</div>
+                <div>targetX: {cameraState?.target[0]}</div>
+                <div>targetY: {cameraState?.target[1]}</div>
             </div>
         </>
     );
 };
 
 const cameraPosition: ViewStateType = {
-    target: [437500, 6475000],
-    zoom: -5.0,
+    target: [435800, 6478000],
+    zoom: -3.5,
     rotationX: 90,
     rotationOrbit: 0,
 };
 
-export const customizedCameraPosition: StoryObj<typeof SubsurfaceViewer> = {
+export const DisplayCameraState: StoryObj<typeof SubsurfaceViewer> = {
     args: {
         id: "volve-wells",
         bounds: volveWellsBounds,
         layers: [volveWellsLayer],
         cameraPosition,
     },
-    render: (args) => <CustomTemplate {...args} />,
+    render: (args) => <DisplayCameraPositionComponent {...args} />,
 };
 
-const ViewStateSynchronizationStory = (args: {
+const SyncedMultiViewComponent = (args: {
     show3d: boolean;
     sync: string[];
 }) => {
@@ -154,9 +155,7 @@ const ViewStateSynchronizationStory = (args: {
     return <SubsurfaceViewer {...subsurfaceViewerArgs} />;
 };
 
-export const ViewStateSynchronization: StoryObj<
-    typeof ViewStateSynchronizationStory
-> = {
+export const SyncedMultiView: StoryObj<typeof SyncedMultiViewComponent> = {
     args: {
         show3d: false,
         sync: ["view_1", "view_2", "view_3", "view_4"],
@@ -168,7 +167,60 @@ export const ViewStateSynchronization: StoryObj<
             control: "check",
         },
     },
-    render: (args) => <ViewStateSynchronizationStory {...args} />,
+    render: (args) => <SyncedMultiViewComponent {...args} />,
+};
+
+const SyncedCameraSettingsComponent = (args: SubsurfaceViewerProps) => {
+    const [cameraPosition, setCameraPosition] = React.useState(
+        args.cameraPosition
+    );
+
+    React.useEffect(() => {
+        if (args.cameraPosition) {
+            setCameraPosition({ ...args.cameraPosition });
+        }
+    }, [args.cameraPosition]);
+
+    const props = {
+        ...args,
+        cameraPosition,
+        getCameraPosition: setCameraPosition,
+    };
+
+    return (
+        <div
+            style={{
+                height: "96vh",
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr",
+            }}
+        >
+            <div
+                style={{
+                    position: "relative",
+                }}
+            >
+                <SubsurfaceViewer {...props} />
+            </div>
+            <div
+                style={{
+                    position: "relative",
+                }}
+            >
+                <SubsurfaceViewer {...props} />
+            </div>
+        </div>
+    );
+};
+
+export const SyncedSubsurfaceViewer: StoryObj<typeof SubsurfaceViewer> = {
+    args: {
+        id: "volve-wells",
+        bounds: volveWellsBounds,
+        layers: [volveWellsLayer],
+        cameraPosition,
+    },
+    render: (args) => <SyncedCameraSettingsComponent {...args} />,
 };
 
 const zoomBox3D: BoundingBox3D = [-325, -450, -25, 125, 150, 125];


### PR DESCRIPTION
Fix regression introduced in #1837.

Revert to use initial precedence to compute camera in 2D:
- camera if provided,
- 2D bounds if provided,
- default computation otherwise

Add story to demonstrate how to sync 2 SubSurfaceViewer.