### PR TITLE
fix: InfoPanel drawing in WellLogViewer

### DIFF
--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
@@ -423,7 +423,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
     updateReadoutPanel(): void {
         for (const controller of this.controllers) {
             if (!controller) continue;
-            controller.selectContent(controller.getContentSelection()); // force to update readout panel
+            controller.updateInfo(); // force to update readout panel
         }
     }
 

--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
@@ -1108,6 +1108,7 @@ SyncLogViewer.propTypes = {
      */
     spacers: PropTypes.oneOfType([
         PropTypes.bool,
+        PropTypes.number,
         PropTypes.arrayOf(PropTypes.number),
     ]),
 

--- a/typescript/packages/well-log-viewer/src/WellLogViewer.tsx
+++ b/typescript/packages/well-log-viewer/src/WellLogViewer.tsx
@@ -170,8 +170,7 @@ export default class WellLogViewer extends Component<
 
     updateReadoutPanel(): void {
         const controller = this.controller;
-        if (controller)
-            controller.selectContent(controller.getContentSelection()); // force to update readout panel
+        if (controller) controller.updateInfo(); // force to update readout panel
     }
 
     // callback function from WellLogView
@@ -246,11 +245,6 @@ export default class WellLogViewer extends Component<
         else delete this.collapsedTrackIds[i];
 
         this.updateReadoutPanel();
-
-        if (this.controller)
-            this.controller.selectContent(
-                this.controller.getContentSelection()
-            ); // force to update readout panel
     }
 
     render(): JSX.Element {

--- a/typescript/packages/well-log-viewer/src/__snapshots__/SyncLogViewer.test.tsx.snap
+++ b/typescript/packages/well-log-viewer/src/__snapshots__/SyncLogViewer.test.tsx.snap
@@ -503,7 +503,7 @@ exports[`Sync Log Viewer snapshot test 1`] = `
             style="left: 0%; width: 0%;"
           />
           <span
-            class="MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary css-eg0mwd-MuiSlider-thumb"
+            class="MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary css-jx1sa5-MuiSlider-thumb"
             data-index="0"
             style="left: 0%;"
           >
@@ -524,7 +524,7 @@ exports[`Sync Log Viewer snapshot test 1`] = `
             />
             <span
               aria-hidden="true"
-              class="MuiSlider-valueLabel css-nnid7-MuiSlider-valueLabel"
+              class="MuiSlider-valueLabel css-7d61z1-MuiSlider-valueLabel"
             >
               <span
                 class="MuiSlider-valueLabelCircle"

--- a/typescript/packages/well-log-viewer/src/__snapshots__/SyncLogViewer.test.tsx.snap
+++ b/typescript/packages/well-log-viewer/src/__snapshots__/SyncLogViewer.test.tsx.snap
@@ -316,7 +316,9 @@ exports[`Sync Log Viewer snapshot test 1`] = `
               >
                 ⬤
               </td>
-              <td>
+              <td
+                style="white-space: nowrap;"
+              >
                 DEPT
               </td>
               <td
@@ -337,7 +339,9 @@ exports[`Sync Log Viewer snapshot test 1`] = `
               >
                 ⬤
               </td>
-              <td>
+              <td
+                style="white-space: nowrap;"
+              >
                 DVER
               </td>
               <td
@@ -366,7 +370,9 @@ exports[`Sync Log Viewer snapshot test 1`] = `
               >
                 ⬤
               </td>
-              <td>
+              <td
+                style="white-space: nowrap;"
+              >
                 MDIA
               </td>
               <td
@@ -387,7 +393,9 @@ exports[`Sync Log Viewer snapshot test 1`] = `
               >
                 ⬤
               </td>
-              <td>
+              <td
+                style="white-space: nowrap;"
+              >
                 HKLA
               </td>
               <td
@@ -408,7 +416,9 @@ exports[`Sync Log Viewer snapshot test 1`] = `
               >
                 ⬤
               </td>
-              <td>
+              <td
+                style="white-space: nowrap;"
+              >
                 HKLA
               </td>
               <td
@@ -429,7 +439,9 @@ exports[`Sync Log Viewer snapshot test 1`] = `
               >
                 ⬤
               </td>
-              <td>
+              <td
+                style="white-space: nowrap;"
+              >
                 HKLX
               </td>
               <td
@@ -450,7 +462,9 @@ exports[`Sync Log Viewer snapshot test 1`] = `
               >
                 ⬤
               </td>
-              <td>
+              <td
+                style="white-space: nowrap;"
+              >
                 HKLA
               </td>
               <td

--- a/typescript/packages/well-log-viewer/src/__snapshots__/SyncLogViewer.test.tsx.snap
+++ b/typescript/packages/well-log-viewer/src/__snapshots__/SyncLogViewer.test.tsx.snap
@@ -320,8 +320,11 @@ exports[`Sync Log Viewer snapshot test 1`] = `
                 DEPT
               </td>
               <td
-                style="width: 90px; padding-left: 1.5em; text-align: right;"
-              />
+                colspan="1"
+                style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+              >
+                 
+              </td>
               <td
                 style="padding-left: 0.5em;"
               >
@@ -338,8 +341,11 @@ exports[`Sync Log Viewer snapshot test 1`] = `
                 DVER
               </td>
               <td
-                style="width: 90px; padding-left: 1.5em; text-align: right;"
-              />
+                colspan="1"
+                style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+              >
+                 
+              </td>
               <td
                 style="padding-left: 0.5em;"
               >
@@ -364,8 +370,11 @@ exports[`Sync Log Viewer snapshot test 1`] = `
                 MDIA
               </td>
               <td
-                style="width: 90px; padding-left: 1.5em; text-align: right;"
-              />
+                colspan="1"
+                style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+              >
+                 
+              </td>
               <td
                 style="padding-left: 0.5em;"
               >
@@ -382,8 +391,11 @@ exports[`Sync Log Viewer snapshot test 1`] = `
                 HKLA
               </td>
               <td
-                style="width: 90px; padding-left: 1.5em; text-align: right;"
-              />
+                colspan="1"
+                style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+              >
+                 
+              </td>
               <td
                 style="padding-left: 0.5em;"
               >
@@ -400,8 +412,11 @@ exports[`Sync Log Viewer snapshot test 1`] = `
                 HKLA
               </td>
               <td
-                style="width: 90px; padding-left: 1.5em; text-align: right;"
-              />
+                colspan="1"
+                style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+              >
+                 
+              </td>
               <td
                 style="padding-left: 0.5em;"
               >
@@ -418,8 +433,11 @@ exports[`Sync Log Viewer snapshot test 1`] = `
                 HKLX
               </td>
               <td
-                style="width: 90px; padding-left: 1.5em; text-align: right;"
-              />
+                colspan="1"
+                style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+              >
+                 
+              </td>
               <td
                 style="padding-left: 0.5em;"
               >
@@ -436,8 +454,11 @@ exports[`Sync Log Viewer snapshot test 1`] = `
                 HKLA
               </td>
               <td
-                style="width: 90px; padding-left: 1.5em; text-align: right;"
-              />
+                colspan="1"
+                style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+              >
+                 
+              </td>
               <td
                 style="padding-left: 0.5em;"
               >
@@ -468,7 +489,7 @@ exports[`Sync Log Viewer snapshot test 1`] = `
             style="left: 0%; width: 0%;"
           />
           <span
-            class="MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary css-jx1sa5-MuiSlider-thumb"
+            class="MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary css-eg0mwd-MuiSlider-thumb"
             data-index="0"
             style="left: 0%;"
           >
@@ -489,7 +510,7 @@ exports[`Sync Log Viewer snapshot test 1`] = `
             />
             <span
               aria-hidden="true"
-              class="MuiSlider-valueLabel css-7d61z1-MuiSlider-valueLabel"
+              class="MuiSlider-valueLabel css-nnid7-MuiSlider-valueLabel"
             >
               <span
                 class="MuiSlider-valueLabelCircle"

--- a/typescript/packages/well-log-viewer/src/__snapshots__/WellLogViewer.test.tsx.snap
+++ b/typescript/packages/well-log-viewer/src/__snapshots__/WellLogViewer.test.tsx.snap
@@ -316,8 +316,11 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
                 DEPT
               </td>
               <td
-                style="width: 90px; padding-left: 1.5em; text-align: right;"
-              />
+                colspan="1"
+                style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+              >
+                 
+              </td>
               <td
                 style="padding-left: 0.5em;"
               >
@@ -334,8 +337,11 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
                 DVER
               </td>
               <td
-                style="width: 90px; padding-left: 1.5em; text-align: right;"
-              />
+                colspan="1"
+                style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+              >
+                 
+              </td>
               <td
                 style="padding-left: 0.5em;"
               >
@@ -375,8 +381,11 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
                 MDIA
               </td>
               <td
-                style="width: 90px; padding-left: 1.5em; text-align: right;"
-              />
+                colspan="1"
+                style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+              >
+                 
+              </td>
               <td
                 style="padding-left: 0.5em;"
               >
@@ -393,8 +402,11 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
                 HKLA
               </td>
               <td
-                style="width: 90px; padding-left: 1.5em; text-align: right;"
-              />
+                colspan="1"
+                style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+              >
+                 
+              </td>
               <td
                 style="padding-left: 0.5em;"
               >
@@ -426,8 +438,11 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
                 HKLA
               </td>
               <td
-                style="width: 90px; padding-left: 1.5em; text-align: right;"
-              />
+                colspan="1"
+                style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+              >
+                 
+              </td>
               <td
                 style="padding-left: 0.5em;"
               >
@@ -459,8 +474,11 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
                 HKLX
               </td>
               <td
-                style="width: 90px; padding-left: 1.5em; text-align: right;"
-              />
+                colspan="1"
+                style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+              >
+                 
+              </td>
               <td
                 style="padding-left: 0.5em;"
               >
@@ -477,8 +495,11 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
                 HKLA
               </td>
               <td
-                style="width: 90px; padding-left: 1.5em; text-align: right;"
-              />
+                colspan="1"
+                style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+              >
+                 
+              </td>
               <td
                 style="padding-left: 0.5em;"
               >
@@ -510,7 +531,7 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
             style="left: 0%; width: 0%;"
           />
           <span
-            class="MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary css-jx1sa5-MuiSlider-thumb"
+            class="MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary css-eg0mwd-MuiSlider-thumb"
             data-index="0"
             style="left: 0%;"
           >
@@ -531,7 +552,7 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
             />
             <span
               aria-hidden="true"
-              class="MuiSlider-valueLabel css-7d61z1-MuiSlider-valueLabel"
+              class="MuiSlider-valueLabel css-nnid7-MuiSlider-valueLabel"
             >
               <span
                 class="MuiSlider-valueLabelCircle"

--- a/typescript/packages/well-log-viewer/src/__snapshots__/WellLogViewer.test.tsx.snap
+++ b/typescript/packages/well-log-viewer/src/__snapshots__/WellLogViewer.test.tsx.snap
@@ -545,7 +545,7 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
             style="left: 0%; width: 0%;"
           />
           <span
-            class="MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary css-eg0mwd-MuiSlider-thumb"
+            class="MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary css-jx1sa5-MuiSlider-thumb"
             data-index="0"
             style="left: 0%;"
           >
@@ -566,7 +566,7 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
             />
             <span
               aria-hidden="true"
-              class="MuiSlider-valueLabel css-nnid7-MuiSlider-valueLabel"
+              class="MuiSlider-valueLabel css-7d61z1-MuiSlider-valueLabel"
             >
               <span
                 class="MuiSlider-valueLabelCircle"

--- a/typescript/packages/well-log-viewer/src/__snapshots__/WellLogViewer.test.tsx.snap
+++ b/typescript/packages/well-log-viewer/src/__snapshots__/WellLogViewer.test.tsx.snap
@@ -312,7 +312,9 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
               >
                 ⬤
               </td>
-              <td>
+              <td
+                style="white-space: nowrap;"
+              >
                 DEPT
               </td>
               <td
@@ -333,7 +335,9 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
               >
                 ⬤
               </td>
-              <td>
+              <td
+                style="white-space: nowrap;"
+              >
                 DVER
               </td>
               <td
@@ -377,7 +381,9 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
               >
                 ⬤
               </td>
-              <td>
+              <td
+                style="white-space: nowrap;"
+              >
                 MDIA
               </td>
               <td
@@ -398,7 +404,9 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
               >
                 ⬤
               </td>
-              <td>
+              <td
+                style="white-space: nowrap;"
+              >
                 HKLA
               </td>
               <td
@@ -434,7 +442,9 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
               >
                 ⬤
               </td>
-              <td>
+              <td
+                style="white-space: nowrap;"
+              >
                 HKLA
               </td>
               <td
@@ -470,7 +480,9 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
               >
                 ⬤
               </td>
-              <td>
+              <td
+                style="white-space: nowrap;"
+              >
                 HKLX
               </td>
               <td
@@ -491,7 +503,9 @@ exports[`Test Well Log Viewer Component snapshot test 1`] = `
               >
                 ⬤
               </td>
-              <td>
+              <td
+                style="white-space: nowrap;"
+              >
                 HKLA
               </td>
               <td

--- a/typescript/packages/well-log-viewer/src/components/InfoPanel.tsx
+++ b/typescript/packages/well-log-viewer/src/components/InfoPanel.tsx
@@ -42,6 +42,9 @@ function formatValue(value: number): string {
     return v;
 }
 
+const bigCircle = "\u2B24";
+const nbsp = "\xA0";
+const ellipsis = "\u2026"; //"…";
 class InfoPanel extends Component<Props> {
     constructor(props: Props) {
         super(props);
@@ -85,20 +88,26 @@ class InfoPanel extends Component<Props> {
             );
         }
 
+        const typeStyle: React.CSSProperties = {
+            color: info.color,
+            fontSize: "small",
+        };
         let name = info.name ? info.name : "?";
-        if (name.length > 15)
+        if (name.length > 16)
             // compress too long names
-            name = name.substring(0, 13) + "…";
+            name = name.substring(0, 14) + ellipsis;
         // print long names and values with a smaller font size
         const nameStyle: React.CSSProperties =
             name.length > 10 ? { fontSize: "x-small" } : {};
         let value = formatValue(info.value);
         if (info.discrete)
-            value = info.discrete + (value ? "\xA0(" + value + ")" : "");
+            value = info.discrete + (value ? nbsp + "(" + value + ")" : "");
+        if (value === "") value = nbsp; // set some text to force the empty line to have the same height as non-empty line
         const valueStyle: React.CSSProperties = {
             width: "90px",
             paddingLeft: "1.5em",
             textAlign: "right",
+            whiteSpace: "nowrap",
         };
         if (value.length > 10) valueStyle.fontSize = "x-small";
         return (
@@ -109,13 +118,14 @@ class InfoPanel extends Component<Props> {
                     info.name /*Set unique key prop just for react pleasure*/
                 }
             >
-                {/*info.type*/}
-                <td style={{ color: info.color, fontSize: "small" }}>
-                    {"\u2B24" /*big circle*/}
-                </td>
+                <td style={typeStyle}>{bigCircle}</td>
                 <td style={nameStyle}>{name}</td>
-                <td style={valueStyle}>{value}</td>
-                <td style={{ paddingLeft: "0.5em" }}>{info.units}</td>
+                <td style={valueStyle} colSpan={info.discrete ? 2 : 1}>
+                    {value}
+                </td>
+                {!info.discrete ? (
+                    <td style={{ paddingLeft: "0.5em" }}>{info.units}</td>
+                ) : null}
             </tr>
         );
     }

--- a/typescript/packages/well-log-viewer/src/components/InfoPanel.tsx
+++ b/typescript/packages/well-log-viewer/src/components/InfoPanel.tsx
@@ -97,8 +97,8 @@ class InfoPanel extends Component<Props> {
             // compress too long names
             name = name.substring(0, 14) + ellipsis;
         // print long names and values with a smaller font size
-        const nameStyle: React.CSSProperties =
-            name.length > 10 ? { fontSize: "x-small" } : {};
+        const nameStyle: React.CSSProperties = { whiteSpace: "nowrap" };
+        if (name.length > 10) nameStyle.fontSize = "x-small";
         let value = formatValue(info.value);
         if (info.discrete)
             value = info.discrete + (value ? nbsp + "(" + value + ")" : "");

--- a/typescript/packages/well-log-viewer/src/components/WellLogView.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogView.tsx
@@ -142,6 +142,8 @@ function addRubberbandOverlay(instance: LogViewer, parent: WellLogView) {
                     instance
                 );
             }
+            parent.setInfo(parent.selCurrent);
+            parent.onContentSelection();
         },
         onMouseExit: (event: OverlayMouseExitEvent) => {
             if (event.target) {
@@ -210,9 +212,6 @@ function addReadoutOverlay(instance: LogViewer, parent: WellLogView) {
                     : "-";
                 elem.style.visibility = "visible";
             }
-
-            parent.setInfo(value);
-            parent.onContentSelection();
         },
         onMouseExit: (event: OverlayMouseExitEvent): void => {
             const elem = event.target;

--- a/typescript/packages/well-log-viewer/src/components/WellLogView.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogView.tsx
@@ -925,6 +925,8 @@ export interface WellLogController {
     setSelectedTrackIndices(selection: number[]): boolean;
     getSelectedTrackIndices(): number[];
 
+    updateInfo(): void;
+
     setTemplate(template: Template): void;
     getTemplate(): Template;
 }
@@ -1357,7 +1359,7 @@ class WellLogView
         ) {
             this.onTrackScroll();
             this.onTrackSelection();
-            this.setInfo();
+            this.updateInfo();
         }
 
         if (
@@ -1409,7 +1411,7 @@ class WellLogView
 
             initOverlays(this.logController, this);
         }
-        this.setInfo();
+        this.updateInfo();
     }
     getAxesInfo(): AxesInfo {
         // get Object keys available in the welllog
@@ -1464,7 +1466,7 @@ class WellLogView
         this.setControllerSelection();
         this.onTrackScroll();
         this.onTrackSelection();
-        this.setInfo(); // Clear old track information
+        this.updateInfo(); // Clear old track information
     }
 
     findTrackById(trackId: string | number): Track | undefined {
@@ -1521,7 +1523,7 @@ class WellLogView
     }
 
     onTemplateChanged(): void {
-        this.setInfo();
+        this.updateInfo();
 
         this.template = this._generateTemplate(); // save current template
 
@@ -1608,7 +1610,7 @@ class WellLogView
         this.selPersistent = this.selPinned !== undefined;
 
         this.showSelection();
-        this.setInfo(); // reflect new value in this.selCurrent
+        this.updateInfo(); // reflect new value in this.selCurrent
     }
 
     setContentBaseDomain(domain: [number, number]): void {
@@ -1702,6 +1704,9 @@ class WellLogView
         if (changed) this.onTrackSelection();
         return changed;
     }
+    updateInfo(): void {
+        this.setInfo(); // reflect new value in this.selCurrent
+    }
 
     getTemplate(): Template {
         return this.template;
@@ -1777,7 +1782,7 @@ class WellLogView
                 this.scrollTrackBy(+1);
             else {
                 this.onTrackScroll();
-                this.setInfo();
+                this.updateInfo();
             }
             this.selectTrack(trackNew, true);
         }

--- a/typescript/packages/well-log-viewer/src/components/WellLogViewWithScroller.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogViewWithScroller.tsx
@@ -44,8 +44,7 @@ class WellLogViewWithScroller extends Component<WellLogViewWithScrollerProps> {
 
     updateReadoutPanel(): void {
         const controller = this.controller;
-        if (controller)
-            controller.selectContent(controller.getContentSelection()); // force to update readout panel
+        if (controller) controller.updateInfo(); // force to update readout panel
     }
 
     // callback function from WellLogView

--- a/typescript/packages/well-log-viewer/src/components/__snapshots__/InfoPanel.test.tsx.snap
+++ b/typescript/packages/well-log-viewer/src/components/__snapshots__/InfoPanel.test.tsx.snap
@@ -18,7 +18,9 @@ exports[`Test Info panel snapshot test 1`] = `
           >
             ⬤
           </td>
-          <td>
+          <td
+            style="white-space: nowrap;"
+          >
             DVER
           </td>
           <td
@@ -47,7 +49,9 @@ exports[`Test Info panel snapshot test 1`] = `
           >
             ⬤
           </td>
-          <td>
+          <td
+            style="white-space: nowrap;"
+          >
             BDIA
           </td>
           <td
@@ -86,7 +90,9 @@ exports[`Test Info panel snapshot test when value is infinity 1`] = `
           >
             ⬤
           </td>
-          <td>
+          <td
+            style="white-space: nowrap;"
+          >
             DVER
           </td>
           <td

--- a/typescript/packages/well-log-viewer/src/components/__snapshots__/InfoPanel.test.tsx.snap
+++ b/typescript/packages/well-log-viewer/src/components/__snapshots__/InfoPanel.test.tsx.snap
@@ -22,7 +22,8 @@ exports[`Test Info panel snapshot test 1`] = `
             DVER
           </td>
           <td
-            style="width: 90px; padding-left: 1.5em; text-align: right;"
+            colspan="1"
+            style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
           >
             2366
           </td>
@@ -50,7 +51,8 @@ exports[`Test Info panel snapshot test 1`] = `
             BDIA
           </td>
           <td
-            style="width: 90px; padding-left: 1.5em; text-align: right;"
+            colspan="1"
+            style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
           >
             8.5
           </td>
@@ -88,8 +90,11 @@ exports[`Test Info panel snapshot test when value is infinity 1`] = `
             DVER
           </td>
           <td
-            style="width: 90px; padding-left: 1.5em; text-align: right;"
-          />
+            colspan="1"
+            style="width: 90px; padding-left: 1.5em; text-align: right; white-space: nowrap;"
+          >
+             
+          </td>
           <td
             style="padding-left: 0.5em;"
           >

--- a/typescript/packages/well-log-viewer/src/components/__snapshots__/ZoomSlider.test.tsx.snap
+++ b/typescript/packages/well-log-viewer/src/components/__snapshots__/ZoomSlider.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Test zoom slider snapshot test 1`] = `
     style="left: 0%; width: 0%;"
   />
   <span
-    class="MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary css-eg0mwd-MuiSlider-thumb"
+    class="MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary css-jx1sa5-MuiSlider-thumb"
     data-index="0"
     style="left: 0%;"
   >
@@ -33,7 +33,7 @@ exports[`Test zoom slider snapshot test 1`] = `
     />
     <span
       aria-hidden="true"
-      class="MuiSlider-valueLabel css-nnid7-MuiSlider-valueLabel"
+      class="MuiSlider-valueLabel css-7d61z1-MuiSlider-valueLabel"
     >
       <span
         class="MuiSlider-valueLabelCircle"

--- a/typescript/packages/well-log-viewer/src/components/__snapshots__/ZoomSlider.test.tsx.snap
+++ b/typescript/packages/well-log-viewer/src/components/__snapshots__/ZoomSlider.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Test zoom slider snapshot test 1`] = `
     style="left: 0%; width: 0%;"
   />
   <span
-    class="MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary css-jx1sa5-MuiSlider-thumb"
+    class="MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary css-eg0mwd-MuiSlider-thumb"
     data-index="0"
     style="left: 0%;"
   >
@@ -33,7 +33,7 @@ exports[`Test zoom slider snapshot test 1`] = `
     />
     <span
       aria-hidden="true"
-      class="MuiSlider-valueLabel css-7d61z1-MuiSlider-valueLabel"
+      class="MuiSlider-valueLabel css-nnid7-MuiSlider-valueLabel"
     >
       <span
         class="MuiSlider-valueLabelCircle"


### PR DESCRIPTION
1. fix drawing of InfoPanel to prevent table cells size when the its values change (Closes: #1864)
2. fix a text wrapping in the value cells (See #1874 item 2)
3. fix updateReadoutPanel when InfoPanel group is clicked (Closes: #1878)
4. fix mouse tracking for displaying info panel  (Closes: #1785)
