### PR TITLE
fix: do not display "Loading assets" feedback when isRenderedCallback exists

### DIFF
--- a/typescript/packages/subsurface-viewer/src/SubsurfaceViewer.tsx
+++ b/typescript/packages/subsurface-viewer/src/SubsurfaceViewer.tsx
@@ -101,7 +101,7 @@ export interface SubsurfaceViewerProps {
      * Will be called while layers are processed to rendered data.
      * @param progress vlaue between 0 and 100.
      */
-    onRenderedProgress?: (progress: number) => void;
+    onRenderingProgress?: (progress: number) => void;
 
     onDragStart?: (info: PickingInfo, event: MjolnirGestureEvent) => void;
     onDragEnd?: (info: PickingInfo, event: MjolnirGestureEvent) => void;
@@ -144,7 +144,7 @@ const SubsurfaceViewer: React.FC<SubsurfaceViewerProps> = ({
     selection,
     getTooltip,
     getCameraPosition,
-    onRenderedProgress,
+    onRenderingProgress,
     onDragStart,
     onDragEnd,
     triggerResetMultipleWells,
@@ -229,7 +229,7 @@ const SubsurfaceViewer: React.FC<SubsurfaceViewerProps> = ({
             getTooltip={getTooltip}
             cameraPosition={cameraPosition}
             getCameraPosition={getCameraPosition}
-            onRenderedProgress={onRenderedProgress}
+            onRenderingProgress={onRenderingProgress}
             onDragStart={onDragStart}
             onDragEnd={onDragEnd}
             triggerHome={triggerHome}

--- a/typescript/packages/subsurface-viewer/src/SubsurfaceViewer.tsx
+++ b/typescript/packages/subsurface-viewer/src/SubsurfaceViewer.tsx
@@ -98,9 +98,10 @@ export interface SubsurfaceViewerProps {
     getCameraPosition?: (input: ViewStateType) => void;
 
     /**
-     * Will be called after all layers have rendered data.
+     * Will be called while layers are processed to rendered data.
+     * @param progress vlaue between 0 and 100.
      */
-    isRenderedCallback?: (arg: boolean) => void;
+    onRenderedProgress?: (progress: number) => void;
 
     onDragStart?: (info: PickingInfo, event: MjolnirGestureEvent) => void;
     onDragEnd?: (info: PickingInfo, event: MjolnirGestureEvent) => void;
@@ -143,7 +144,7 @@ const SubsurfaceViewer: React.FC<SubsurfaceViewerProps> = ({
     selection,
     getTooltip,
     getCameraPosition,
-    isRenderedCallback,
+    onRenderedProgress,
     onDragStart,
     onDragEnd,
     triggerResetMultipleWells,
@@ -228,7 +229,7 @@ const SubsurfaceViewer: React.FC<SubsurfaceViewerProps> = ({
             getTooltip={getTooltip}
             cameraPosition={cameraPosition}
             getCameraPosition={getCameraPosition}
-            isRenderedCallback={isRenderedCallback}
+            onRenderedProgress={onRenderedProgress}
             onDragStart={onDragStart}
             onDragEnd={onDragEnd}
             triggerHome={triggerHome}

--- a/typescript/packages/subsurface-viewer/src/__snapshots__/SubsurfaceViewer.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/__snapshots__/SubsurfaceViewer.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`Test Map component snapshot test 1`] = `
     />
   </div>
   <div
-    style="align-items: center; display: flex; justify-content: center; position: absolute; height: 90%; width: 90%; z-index: 200;"
+    style="display: flex; align-items: flex-end; justify-content: right; position: absolute; height: 90%; width: 90%; bottom: 10px; right: 10px; z-index: 200;"
   >
     <div>
       <svg
@@ -139,7 +139,7 @@ exports[`Test Map component snapshot test with edited data 1`] = `
     />
   </div>
   <div
-    style="align-items: center; display: flex; justify-content: center; position: absolute; height: 90%; width: 90%; z-index: 200;"
+    style="display: flex; align-items: flex-end; justify-content: right; position: absolute; height: 90%; width: 90%; bottom: 10px; right: 10px; z-index: 200;"
   >
     <div>
       <svg
@@ -233,7 +233,7 @@ exports[`Test Map component snapshot test with invalid array length 1`] = `
     />
   </div>
   <div
-    style="align-items: center; display: flex; justify-content: center; position: absolute; height: 90%; width: 90%; z-index: 200;"
+    style="display: flex; align-items: flex-end; justify-content: right; position: absolute; height: 90%; width: 90%; bottom: 10px; right: 10px; z-index: 200;"
   >
     <div>
       <svg

--- a/typescript/packages/subsurface-viewer/src/__snapshots__/SubsurfaceViewer.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/__snapshots__/SubsurfaceViewer.test.tsx.snap
@@ -44,48 +44,52 @@ exports[`Test Map component snapshot test 1`] = `
       style="width: 100px; height: 4px; border: 2px solid; display: inline-block; margin-left: 3px;"
     />
   </div>
-  <div>
-    <svg
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="c0"
-      height="48"
-      preserveAspectRatio="xMidYMid meet"
-      role="progressbar"
-      viewBox="24 24 48 48"
-      width="48"
-    >
-      <circle
-        class=""
-        cx="48"
-        cy="48"
-        fill="none"
-        r="22"
-        stroke="var(--eds_infographic_primary__moss_green_13, rgba(222, 237, 238, 1))"
-        stroke-width="4"
-        style="stroke: 138.230; stroke-dashoffset: 138.230px;"
-      />
-      <circle
-        class=""
-        cx="48"
-        cy="48"
-        fill="none"
-        r="22"
-        stroke="var(--eds_infographic_primary__moss_green_100, rgba(0, 112, 121, 1))"
-        stroke-dasharray="138.23007675795088"
-        stroke-linecap="round"
-        stroke-width="4"
-        style="stroke: 138.230; stroke-dashoffset: 138.230px;"
-      />
-    </svg>
-    <output
-      class="c1"
-    >
-      Loading 0%
-    </output>
-    <br />
-    Loading assets...
+  <div
+    style="align-items: center; display: flex; justify-content: center; position: absolute; height: 90%; width: 90%; z-index: 200;"
+  >
+    <div>
+      <svg
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c0"
+        height="48"
+        preserveAspectRatio="xMidYMid meet"
+        role="progressbar"
+        viewBox="24 24 48 48"
+        width="48"
+      >
+        <circle
+          class=""
+          cx="48"
+          cy="48"
+          fill="none"
+          r="22"
+          stroke="var(--eds_infographic_primary__moss_green_13, rgba(222, 237, 238, 1))"
+          stroke-width="4"
+          style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+        />
+        <circle
+          class=""
+          cx="48"
+          cy="48"
+          fill="none"
+          r="22"
+          stroke="var(--eds_infographic_primary__moss_green_100, rgba(0, 112, 121, 1))"
+          stroke-dasharray="138.23007675795088"
+          stroke-linecap="round"
+          stroke-width="4"
+          style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+        />
+      </svg>
+      <output
+        class="c1"
+      >
+        Loading 0%
+      </output>
+      <br />
+      Loading assets...
+    </div>
   </div>
 </div>
 `;
@@ -134,48 +138,52 @@ exports[`Test Map component snapshot test with edited data 1`] = `
       style="width: 100px; height: 4px; border: 2px solid; display: inline-block; margin-left: 3px;"
     />
   </div>
-  <div>
-    <svg
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="c0"
-      height="48"
-      preserveAspectRatio="xMidYMid meet"
-      role="progressbar"
-      viewBox="24 24 48 48"
-      width="48"
-    >
-      <circle
-        class=""
-        cx="48"
-        cy="48"
-        fill="none"
-        r="22"
-        stroke="var(--eds_infographic_primary__moss_green_13, rgba(222, 237, 238, 1))"
-        stroke-width="4"
-        style="stroke: 138.230; stroke-dashoffset: 138.230px;"
-      />
-      <circle
-        class=""
-        cx="48"
-        cy="48"
-        fill="none"
-        r="22"
-        stroke="var(--eds_infographic_primary__moss_green_100, rgba(0, 112, 121, 1))"
-        stroke-dasharray="138.23007675795088"
-        stroke-linecap="round"
-        stroke-width="4"
-        style="stroke: 138.230; stroke-dashoffset: 138.230px;"
-      />
-    </svg>
-    <output
-      class="c1"
-    >
-      Loading 0%
-    </output>
-    <br />
-    Loading assets...
+  <div
+    style="align-items: center; display: flex; justify-content: center; position: absolute; height: 90%; width: 90%; z-index: 200;"
+  >
+    <div>
+      <svg
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c0"
+        height="48"
+        preserveAspectRatio="xMidYMid meet"
+        role="progressbar"
+        viewBox="24 24 48 48"
+        width="48"
+      >
+        <circle
+          class=""
+          cx="48"
+          cy="48"
+          fill="none"
+          r="22"
+          stroke="var(--eds_infographic_primary__moss_green_13, rgba(222, 237, 238, 1))"
+          stroke-width="4"
+          style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+        />
+        <circle
+          class=""
+          cx="48"
+          cy="48"
+          fill="none"
+          r="22"
+          stroke="var(--eds_infographic_primary__moss_green_100, rgba(0, 112, 121, 1))"
+          stroke-dasharray="138.23007675795088"
+          stroke-linecap="round"
+          stroke-width="4"
+          style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+        />
+      </svg>
+      <output
+        class="c1"
+      >
+        Loading 0%
+      </output>
+      <br />
+      Loading assets...
+    </div>
   </div>
 </div>
 `;
@@ -224,48 +232,52 @@ exports[`Test Map component snapshot test with invalid array length 1`] = `
       style="width: 100px; height: 4px; border: 2px solid; display: inline-block; margin-left: 3px;"
     />
   </div>
-  <div>
-    <svg
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="c0"
-      height="48"
-      preserveAspectRatio="xMidYMid meet"
-      role="progressbar"
-      viewBox="24 24 48 48"
-      width="48"
-    >
-      <circle
-        class=""
-        cx="48"
-        cy="48"
-        fill="none"
-        r="22"
-        stroke="var(--eds_infographic_primary__moss_green_13, rgba(222, 237, 238, 1))"
-        stroke-width="4"
-        style="stroke: 138.230; stroke-dashoffset: 138.230px;"
-      />
-      <circle
-        class=""
-        cx="48"
-        cy="48"
-        fill="none"
-        r="22"
-        stroke="var(--eds_infographic_primary__moss_green_100, rgba(0, 112, 121, 1))"
-        stroke-dasharray="138.23007675795088"
-        stroke-linecap="round"
-        stroke-width="4"
-        style="stroke: 138.230; stroke-dashoffset: 138.230px;"
-      />
-    </svg>
-    <output
-      class="c1"
-    >
-      Loading 0%
-    </output>
-    <br />
-    Loading assets...
+  <div
+    style="align-items: center; display: flex; justify-content: center; position: absolute; height: 90%; width: 90%; z-index: 200;"
+  >
+    <div>
+      <svg
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c0"
+        height="48"
+        preserveAspectRatio="xMidYMid meet"
+        role="progressbar"
+        viewBox="24 24 48 48"
+        width="48"
+      >
+        <circle
+          class=""
+          cx="48"
+          cy="48"
+          fill="none"
+          r="22"
+          stroke="var(--eds_infographic_primary__moss_green_13, rgba(222, 237, 238, 1))"
+          stroke-width="4"
+          style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+        />
+        <circle
+          class=""
+          cx="48"
+          cy="48"
+          fill="none"
+          r="22"
+          stroke="var(--eds_infographic_primary__moss_green_100, rgba(0, 112, 121, 1))"
+          stroke-dasharray="138.23007675795088"
+          stroke-linecap="round"
+          stroke-width="4"
+          style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+        />
+      </svg>
+      <output
+        class="c1"
+      >
+        Loading 0%
+      </output>
+      <br />
+      Loading assets...
+    </div>
   </div>
 </div>
 `;

--- a/typescript/packages/subsurface-viewer/src/components/Map.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.tsx
@@ -417,7 +417,7 @@ export interface MapProps {
      * Will be called while layers have rendered data.
      * progress is a number between 0 and 100.
      */
-    onRenderedProgress?: (progress: number) => void;
+    onRenderingProgress?: (progress: number) => void;
 
     onDragStart?: (info: PickingInfo, event: MjolnirGestureEvent) => void;
     onDragEnd?: (info: PickingInfo, event: MjolnirGestureEvent) => void;
@@ -463,7 +463,7 @@ const Map: React.FC<MapProps> = ({
     children,
     getTooltip = defaultTooltip,
     getCameraPosition,
-    onRenderedProgress,
+    onRenderingProgress,
     onDragStart,
     onDragEnd,
     lights,
@@ -746,11 +746,11 @@ const Map: React.FC<MapProps> = ({
             }
 
             setLoadingProgress(progress);
-            if (onRenderedProgress) {
-                onRenderedProgress(progress);
+            if (onRenderingProgress) {
+                onRenderingProgress(progress);
             }
         }
-    }, [deckGLLayers, onRenderedProgress]);
+    }, [deckGLLayers, onRenderingProgress]);
 
     // validate layers data
     const [errorText, setErrorText] = useState<string>();
@@ -904,7 +904,7 @@ const Map: React.FC<MapProps> = ({
                     style={scale.cssStyle ?? {}}
                 />
             ) : null}
-            {!onRenderedProgress && loadingProgress < 100 && (
+            {!onRenderingProgress && loadingProgress < 100 && (
                 <div
                     style={{
                         display: "flex",

--- a/typescript/packages/subsurface-viewer/src/components/Map.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.tsx
@@ -896,8 +896,25 @@ const Map: React.FC<MapProps> = ({
                     style={scale.cssStyle ?? {}}
                 />
             ) : null}
-            <StatusIndicator layers={deckGLLayers} isLoaded={isLoaded} />
-            {coords?.visible ? <InfoCard pickInfos={hoverInfo} /> : null}
+            {!isRenderedCallback && !isLoaded && (
+                <div
+                    style={{
+                        alignItems: "center",
+                        display: "flex",
+                        justifyContent: "center",
+                        position: "absolute",
+                        height: "90%",
+                        width: "90%",
+                        zIndex: 200,
+                    }}
+                >
+                    <StatusIndicator
+                        layers={deckGLLayers}
+                        isLoaded={isLoaded}
+                    />
+                </div>
+            )}
+            {coords?.visible && <InfoCard pickInfos={hoverInfo} />}
             {errorText && (
                 <pre
                     style={{

--- a/typescript/packages/subsurface-viewer/src/components/StatusIndicator.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/StatusIndicator.tsx
@@ -1,27 +1,22 @@
 import React from "react";
 import { CircularProgress } from "@equinor/eds-core-react";
-import type { Layer, LayersList } from "@deck.gl/core/typed";
 
 interface StatusIndicatorProps {
-    layers: LayersList;
-    isLoaded: boolean;
-}
-
-function getLoadProgress(layers: LayersList) {
-    const loaded = layers?.filter((layer) => (layer as Layer)?.isLoaded);
-    const count = loaded?.length;
-    const progress = count / layers?.length;
-    return progress * 100;
+    // progress between 0 and 100
+    progress: number | boolean;
+    label: string;
 }
 
 const StatusIndicator: React.FC<StatusIndicatorProps> = ({
-    layers,
-    isLoaded,
+    progress,
+    label,
 }: StatusIndicatorProps) => {
-    if (isLoaded) {
-        return <div />;
+    if (typeof progress === "boolean") {
+        progress = progress ? 100 : 0;
     }
-    const progress = getLoadProgress(layers);
+    if (progress >= 100) {
+        return null;
+    }
     return (
         <div>
             <CircularProgress
@@ -30,7 +25,7 @@ const StatusIndicator: React.FC<StatusIndicatorProps> = ({
                 variant={"determinate"}
             />
             <br />
-            Loading assets...
+            {label}
         </div>
     );
 };

--- a/typescript/packages/subsurface-viewer/src/components/__snapshots__/Map.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/__snapshots__/Map.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`Test Map component snapshot test 1`] = `
     />
   </div>
   <div
-    style="align-items: center; display: flex; justify-content: center; position: absolute; height: 90%; width: 90%; z-index: 200;"
+    style="display: flex; align-items: flex-end; justify-content: right; position: absolute; height: 90%; width: 90%; bottom: 10px; right: 10px; z-index: 200;"
   >
     <div>
       <svg
@@ -139,7 +139,7 @@ exports[`Test Map component snapshot test with edited data 1`] = `
     />
   </div>
   <div
-    style="align-items: center; display: flex; justify-content: center; position: absolute; height: 90%; width: 90%; z-index: 200;"
+    style="display: flex; align-items: flex-end; justify-content: right; position: absolute; height: 90%; width: 90%; bottom: 10px; right: 10px; z-index: 200;"
   >
     <div>
       <svg

--- a/typescript/packages/subsurface-viewer/src/components/__snapshots__/Map.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/__snapshots__/Map.test.tsx.snap
@@ -44,48 +44,52 @@ exports[`Test Map component snapshot test 1`] = `
       style="width: 100px; height: 4px; border: 2px solid; display: inline-block; margin-left: 3px;"
     />
   </div>
-  <div>
-    <svg
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="c0"
-      height="48"
-      preserveAspectRatio="xMidYMid meet"
-      role="progressbar"
-      viewBox="24 24 48 48"
-      width="48"
-    >
-      <circle
-        class=""
-        cx="48"
-        cy="48"
-        fill="none"
-        r="22"
-        stroke="var(--eds_infographic_primary__moss_green_13, rgba(222, 237, 238, 1))"
-        stroke-width="4"
-        style="stroke: 138.230; stroke-dashoffset: 138.230px;"
-      />
-      <circle
-        class=""
-        cx="48"
-        cy="48"
-        fill="none"
-        r="22"
-        stroke="var(--eds_infographic_primary__moss_green_100, rgba(0, 112, 121, 1))"
-        stroke-dasharray="138.23007675795088"
-        stroke-linecap="round"
-        stroke-width="4"
-        style="stroke: 138.230; stroke-dashoffset: 138.230px;"
-      />
-    </svg>
-    <output
-      class="c1"
-    >
-      Loading 0%
-    </output>
-    <br />
-    Loading assets...
+  <div
+    style="align-items: center; display: flex; justify-content: center; position: absolute; height: 90%; width: 90%; z-index: 200;"
+  >
+    <div>
+      <svg
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c0"
+        height="48"
+        preserveAspectRatio="xMidYMid meet"
+        role="progressbar"
+        viewBox="24 24 48 48"
+        width="48"
+      >
+        <circle
+          class=""
+          cx="48"
+          cy="48"
+          fill="none"
+          r="22"
+          stroke="var(--eds_infographic_primary__moss_green_13, rgba(222, 237, 238, 1))"
+          stroke-width="4"
+          style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+        />
+        <circle
+          class=""
+          cx="48"
+          cy="48"
+          fill="none"
+          r="22"
+          stroke="var(--eds_infographic_primary__moss_green_100, rgba(0, 112, 121, 1))"
+          stroke-dasharray="138.23007675795088"
+          stroke-linecap="round"
+          stroke-width="4"
+          style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+        />
+      </svg>
+      <output
+        class="c1"
+      >
+        Loading 0%
+      </output>
+      <br />
+      Loading assets...
+    </div>
   </div>
 </div>
 `;
@@ -134,48 +138,52 @@ exports[`Test Map component snapshot test with edited data 1`] = `
       style="width: 100px; height: 4px; border: 2px solid; display: inline-block; margin-left: 3px;"
     />
   </div>
-  <div>
-    <svg
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="c0"
-      height="48"
-      preserveAspectRatio="xMidYMid meet"
-      role="progressbar"
-      viewBox="24 24 48 48"
-      width="48"
-    >
-      <circle
-        class=""
-        cx="48"
-        cy="48"
-        fill="none"
-        r="22"
-        stroke="var(--eds_infographic_primary__moss_green_13, rgba(222, 237, 238, 1))"
-        stroke-width="4"
-        style="stroke: 138.230; stroke-dashoffset: 138.230px;"
-      />
-      <circle
-        class=""
-        cx="48"
-        cy="48"
-        fill="none"
-        r="22"
-        stroke="var(--eds_infographic_primary__moss_green_100, rgba(0, 112, 121, 1))"
-        stroke-dasharray="138.23007675795088"
-        stroke-linecap="round"
-        stroke-width="4"
-        style="stroke: 138.230; stroke-dashoffset: 138.230px;"
-      />
-    </svg>
-    <output
-      class="c1"
-    >
-      Loading 0%
-    </output>
-    <br />
-    Loading assets...
+  <div
+    style="align-items: center; display: flex; justify-content: center; position: absolute; height: 90%; width: 90%; z-index: 200;"
+  >
+    <div>
+      <svg
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="c0"
+        height="48"
+        preserveAspectRatio="xMidYMid meet"
+        role="progressbar"
+        viewBox="24 24 48 48"
+        width="48"
+      >
+        <circle
+          class=""
+          cx="48"
+          cy="48"
+          fill="none"
+          r="22"
+          stroke="var(--eds_infographic_primary__moss_green_13, rgba(222, 237, 238, 1))"
+          stroke-width="4"
+          style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+        />
+        <circle
+          class=""
+          cx="48"
+          cy="48"
+          fill="none"
+          r="22"
+          stroke="var(--eds_infographic_primary__moss_green_100, rgba(0, 112, 121, 1))"
+          stroke-dasharray="138.23007675795088"
+          stroke-linecap="round"
+          stroke-width="4"
+          style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+        />
+      </svg>
+      <output
+        class="c1"
+      >
+        Loading 0%
+      </output>
+      <br />
+      Loading assets...
+    </div>
   </div>
 </div>
 `;

--- a/typescript/packages/subsurface-viewer/src/components/__snapshots__/StatusIndicator.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/__snapshots__/StatusIndicator.test.tsx.snap
@@ -1,3 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Test Status Indicator snapshot test with no props 1`] = `<div />`;
+exports[`Test Status Indicator snapshot test with no props 1`] = `
+.c0 {
+  display: inline-block;
+  -webkit-transform: rotate(-90deg);
+  -ms-transform: rotate(-90deg);
+  transform: rotate(-90deg);
+}
+
+.c1 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+<div>
+  <svg
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow="0"
+    class="c0"
+    height="48"
+    preserveAspectRatio="xMidYMid meet"
+    role="progressbar"
+    viewBox="24 24 48 48"
+    width="48"
+  >
+    <circle
+      class=""
+      cx="48"
+      cy="48"
+      fill="none"
+      r="22"
+      stroke="var(--eds_infographic_primary__moss_green_13, rgba(222, 237, 238, 1))"
+      stroke-width="4"
+      style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+    />
+    <circle
+      class=""
+      cx="48"
+      cy="48"
+      fill="none"
+      r="22"
+      stroke="var(--eds_infographic_primary__moss_green_100, rgba(0, 112, 121, 1))"
+      stroke-dasharray="138.23007675795088"
+      stroke-linecap="round"
+      stroke-width="4"
+      style="stroke: 138.230; stroke-dashoffset: 138.230px;"
+    />
+  </svg>
+  <output
+    class="c1"
+  >
+    Loading 0%
+  </output>
+  <br />
+</div>
+`;

--- a/typescript/packages/subsurface-viewer/src/storybook/examples/RenderingExamples.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/examples/RenderingExamples.stories.tsx
@@ -134,9 +134,9 @@ const IsRenderedComponent: React.FC<SubsurfaceViewerProps> = (
 
     const props2 = {
         ...props,
-        isRenderedCallback: (isLoaded: boolean) => {
-            console.log("isRenderedCallback", isLoaded);
-            setLabel(isLoaded ? "LOADED" : "NOT LOADED");
+        onRenderedProgress: (progress: number) => {
+            console.log("onRenderedProgress", progress);
+            setLabel(progress === 100 ? "LOADED" : `${progress} %`);
         },
         layers,
     };
@@ -148,7 +148,7 @@ const IsRenderedComponent: React.FC<SubsurfaceViewerProps> = (
             </div>
             <label>{"Add big map layer "}</label>
             <button onClick={handleChange}>Change layers</button>
-            <label>State from isRenderedCallback: {label}</label>
+            <label>State from onRenderedProgress: {label}</label>
         </Root>
     );
 };

--- a/typescript/packages/subsurface-viewer/src/storybook/examples/RenderingExamples.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/examples/RenderingExamples.stories.tsx
@@ -134,8 +134,8 @@ const IsRenderedComponent: React.FC<SubsurfaceViewerProps> = (
 
     const props2 = {
         ...props,
-        onRenderedProgress: (progress: number) => {
-            console.log("onRenderedProgress", progress);
+        onRenderingProgress: (progress: number) => {
+            console.log("onRenderingProgress", progress);
             setLabel(progress === 100 ? "LOADED" : `${progress} %`);
         },
         layers,
@@ -148,7 +148,7 @@ const IsRenderedComponent: React.FC<SubsurfaceViewerProps> = (
             </div>
             <label>{"Add big map layer "}</label>
             <button onClick={handleChange}>Change layers</button>
-            <label>State from onRenderedProgress: {label}</label>
+            <label>State from onRenderingProgress: {label}</label>
         </Root>
     );
 };


### PR DESCRIPTION
The client code can handle the assets loading feedback on its own using isRenderedCallback. This way it can control the look, feel and layout of this feedback, and will prevent possible inference with application own components.

BTW, this default feedback gets centered in the PR.

Viewers team has an example where the feedback component does move the application components...