### PR TITLE
fix: camera update on resize

### DIFF
--- a/typescript/packages/subsurface-viewer/src/components/Map.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.tsx
@@ -1110,7 +1110,8 @@ class ViewController {
             state.camera != this.state_.camera ||
             state.bounds != this.state_.bounds ||
             (!state.viewStateChanged &&
-                state.boundingBox3d !== this.state_.boundingBox3d);
+                (state.boundingBox3d !== this.state_.boundingBox3d ||
+                    state.deckSize != this.state_.deckSize));
         const needUpdate = updateZScale || updateTarget || updateViewState;
 
         const isCacheEmpty = isEmpty(this.result_.viewState);


### PR DESCRIPTION
The camera should be updated on resize, except if the user manipulated it meanwhile.