### PR TITLE
feat: use webworker pool to control number of workers

### DIFF
--- a/python/webpack.config.js
+++ b/python/webpack.config.js
@@ -42,6 +42,11 @@ module.exports = function (env, argv) {
         externals,
         resolve: {
             extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],
+            fallback: {
+                os: false,
+                child_process: false,
+                worker_threads: false,
+            },
         },
         devtool: "source-map",
         module: {

--- a/typescript/.storybook/main.js
+++ b/typescript/.storybook/main.js
@@ -1,65 +1,79 @@
 module.exports = {
-  stories: ["../packages/*/src/**/*.stories.mdx", "../packages/*/src/**/*.stories.@(js|jsx|ts|tsx)"],
-  addons: ["@storybook/addon-links", "@storybook/addon-essentials", "@storybook/addon-actions", 
-    "@storybook/addon-docs", "@storybook/addon-storysource", "@storybook/addon-mdx-gfm"],
-  webpackFinal: config => {
-    config.module.rules.push({
-      test: /\.scss$/,
-      use: ["vue-style-loader", "css-loader", "sass-loader"]
-    }, {
-      test: /\.(fs|vs).glsl$/i,
-      use: ["raw-loader"]
+    stories: [
+        "../packages/*/src/**/*.stories.mdx",
+        "../packages/*/src/**/*.stories.@(js|jsx|ts|tsx)",
+    ],
+    addons: [
+        "@storybook/addon-links",
+        "@storybook/addon-essentials",
+        "@storybook/addon-actions",
+        "@storybook/addon-docs",
+        "@storybook/addon-storysource",
+        "@storybook/addon-mdx-gfm",
+    ],
+    webpackFinal: (config) => {
+        config.module.rules.push(
+            {
+                test: /\.scss$/,
+                use: ["vue-style-loader", "css-loader", "sass-loader"],
+            },
+            {
+                test: /\.(fs|vs).glsl$/i,
+                use: ["raw-loader"],
+            },
+            {
+                test: /\.(ts|js)x?$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: "babel-loader",
+                    options: {
+                        presets: [
+                            [
+                                "@babel/preset-env",
+                                {
+                                    targets: {
+                                        chrome: 100,
+                                    },
+                                },
+                            ],
+                            [
+                                "@babel/preset-typescript",
+                                { allowNamespaces: true },
+                            ],
+                            "@babel/preset-react",
+                        ],
+                    },
+                },
+            }
+        );
+        return {
+            ...config,
+            resolve: {
+                ...config.resolve,
+                fallback: {
+                    ...config.fallback,
+                    fs: false,
+                    tls: false,
+                    net: false,
+                    path: false,
+                    zlib: false,
+                    http: false,
+                    https: false,
+                    crypto: false,
+                    stream: false,
+                    os: false,
+                    child_process: false,
+                    worker_threads: false,
+                },
+            },
+        };
     },
-    {
-        test: /\.(ts|js)x?$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            "presets": [
-              [
-                "@babel/preset-env",
-                {
-                  "targets": {
-                    "chrome": 100
-                  }
-                }
-              ],
-              [
-              "@babel/preset-typescript", { "allowNamespaces": true },
-              ],
-              "@babel/preset-react"
-            ],
-
-          }
-        },
+    staticDirs: ["../../example-data"],
+    framework: {
+        name: "@storybook/react-webpack5",
+        options: {},
     },
-    );
-    return {
-      ...config,
-      resolve: {
-        ...config.resolve,
-        fallback: {
-          ...config.fallback,
-          fs: false,
-          tls: false,
-          net: false,
-          path: false,
-          zlib: false,
-          http: false,
-          https: false,
-          crypto: false,
-          stream: false
-        }
-      },
-    };
-  },
-  staticDirs: ["../../example-data"],
-  framework: {
-    name: "@storybook/react-webpack5",
-    options: {}
-  },
-  docs: {
-    autodocs: true
-  }
+    docs: {
+        autodocs: true,
+    },
 };

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -40,6 +40,7 @@
                 "@types/react-redux": "^7.1.25",
                 "@types/react-resize-detector": "^6.1.0",
                 "@types/uuid": "^8.3.0",
+                "@types/workerpool": "^6.4.7",
                 "@typescript-eslint/eslint-plugin": "^6.4.0",
                 "@typescript-eslint/parser": "^6.13.1",
                 "assert": "^2.0.0",
@@ -12113,6 +12114,15 @@
             "version": "5.3.4",
             "resolved": "https://registry.npmjs.org/@types/wait-on/-/wait-on-5.3.4.tgz",
             "integrity": "sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/workerpool": {
+            "version": "6.4.7",
+            "resolved": "https://registry.npmjs.org/@types/workerpool/-/workerpool-6.4.7.tgz",
+            "integrity": "sha512-DI2U4obcMzFViyNjLw0xXspim++qkAJ4BWRdYPVMMFtOpTvMr6PAk3UTZEoSqnZnvgUkJ3ck97Ybk+iIfuJHMg==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
@@ -38279,6 +38289,11 @@
             "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
             "dev": true
         },
+        "node_modules/workerpool": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.1.0.tgz",
+            "integrity": "sha512-+wRWfm9yyJghvXLSHMQj3WXDxHbibHAQmRrWbqKBfy0RjftZNeQaW+Std5bSYc83ydkrxoPTPOWVlXUR9RWJdQ=="
+        },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -38607,7 +38622,7 @@
         },
         "packages/subsurface-viewer": {
             "name": "@webviz/subsurface-viewer",
-            "version": "0.13.8",
+            "version": "0.14.0",
             "license": "MPL-2.0",
             "dependencies": {
                 "@deck.gl/aggregation-layers": "^8.9.33",
@@ -38634,7 +38649,8 @@
                 "gl-matrix": "^3.4.3",
                 "lodash": "^4.17.21",
                 "mathjs": "^12.2.1",
-                "react-redux": "^8.1.1"
+                "react-redux": "^8.1.1",
+                "workerpool": "^9.1.0"
             },
             "peerDependencies": {
                 "@mui/material": "^5.11",
@@ -38700,7 +38716,7 @@
         },
         "packages/well-log-viewer": {
             "name": "@webviz/well-log-viewer",
-            "version": "1.3.8",
+            "version": "1.3.9",
             "license": "MPL-2.0",
             "dependencies": {
                 "@emerson-eps/color-tables": "^0.4.71",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -69,6 +69,7 @@
         "@types/react-redux": "^7.1.25",
         "@types/react-resize-detector": "^6.1.0",
         "@types/uuid": "^8.3.0",
+        "@types/workerpool": "^6.4.7",
         "@typescript-eslint/eslint-plugin": "^6.4.0",
         "@typescript-eslint/parser": "^6.13.1",
         "assert": "^2.0.0",

--- a/typescript/packages/subsurface-viewer/package.json
+++ b/typescript/packages/subsurface-viewer/package.json
@@ -46,7 +46,8 @@
         "gl-matrix": "^3.4.3",
         "lodash": "^4.17.21",
         "mathjs": "^12.2.1",
-        "react-redux": "^8.1.1"
+        "react-redux": "^8.1.1",
+        "workerpool": "^9.1.0"
     },
     "peerDependencies": {
         "@mui/material": "^5.11",

--- a/typescript/packages/subsurface-viewer/src/components/Map.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.tsx
@@ -1651,7 +1651,11 @@ function computeViewState(
             rotationX: 45, // look down z -axis at 45 degrees
             rotationOrbit: 0,
         };
-        return updateViewState(defaultCamera, boundingBox, size);
+        return updateViewState(
+            defaultCamera,
+            boundingBox ?? [0, 0, 0, 1, 1, 1],
+            size
+        );
     } else {
         // If the camera is defined, use it
         if (isCameraPositionDefined) {

--- a/typescript/packages/subsurface-viewer/src/layers/triangle/triangleLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/triangle/triangleLayer.ts
@@ -1,12 +1,16 @@
+import type React from "react";
+import { isEqual } from "lodash";
+
 import type { UpdateParameters } from "@deck.gl/core/typed";
 import { CompositeLayer } from "@deck.gl/core/typed";
+
+import workerpool from "workerpool";
+
 import type { Material } from "./privateTriangleLayer";
 import PrivateTriangleLayer from "./privateTriangleLayer";
 import type { ExtendedLayerProps } from "../utils/layerTools";
 import type { ReportBoundingBoxAction } from "../../components/Map";
-import { isEqual } from "lodash";
 import { makeFullMesh } from "./webworker";
-import type React from "react";
 
 export type Params = {
     vertexArray: Float32Array;
@@ -14,6 +18,12 @@ export type Params = {
     smoothShading: boolean;
     displayNormals: boolean;
 };
+
+// init workerpool
+const pool = workerpool.pool({
+    maxWorkers: 10,
+    workerType: "web",
+});
 
 async function loadData(
     pointsData: string | number[] | Float32Array,
@@ -44,7 +54,7 @@ async function loadData(
     }
 
     //-- Triangle indexes --
-    let indexArray: Uint32Array = new Uint32Array();
+    let indexArray: Uint32Array;
     if (Array.isArray(triangleData)) {
         // Input data is native javascript array.
         indexArray = new Uint32Array(triangleData);
@@ -164,12 +174,6 @@ export default class TriangleLayer extends CompositeLayer<TriangleLayerProps> {
         p.then(([vertexArray, indexArray]) => {
             // Using inline web worker for calculating the triangle mesh from
             // loaded input data so not to halt the GUI thread.
-            const blob = new Blob(
-                ["self.onmessage = ", makeFullMesh.toString()],
-                { type: "text/javascript" }
-            );
-            const url = URL.createObjectURL(blob);
-            const webWorker = new Worker(url);
 
             const webworkerParams: Params = {
                 vertexArray,
@@ -178,9 +182,8 @@ export default class TriangleLayer extends CompositeLayer<TriangleLayerProps> {
                 displayNormals: this.props.debug,
             };
 
-            webWorker.postMessage(webworkerParams);
-            webWorker.onmessage = (e) => {
-                const [geometryTriangles, geometryLines] = e.data;
+            pool.exec(makeFullMesh, [{ data: webworkerParams }]).then((e) => {
+                const [geometryTriangles, geometryLines] = e;
 
                 this.setState({
                     geometryTriangles,
@@ -222,13 +225,11 @@ export default class TriangleLayer extends CompositeLayer<TriangleLayerProps> {
                     });
                 }
 
-                webWorker.terminate();
-
                 this.setState({
                     ...this.state,
                     isFinishedLoading: true,
                 });
-            };
+            });
         });
     }
 

--- a/typescript/packages/subsurface-viewer/src/layers/triangle/webworker.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/triangle/webworker.ts
@@ -3,7 +3,7 @@ import type { Params } from "./triangleLayer";
 
 type Vec = [number, number, number];
 
-export function makeFullMesh(e: { data: Params }): void {
+export function makeFullMesh(e: { data: Params }) {
     const params = e.data;
 
     const t0 = performance.now();
@@ -155,11 +155,7 @@ export function makeFullMesh(e: { data: Params }): void {
     };
 
     const t1 = performance.now();
-    console.debug(`Task makeMesh took ${(t1 - t0) * 0.001}  seconds.`);
+    console.debug(`Task makeMesh took ${(t1 - t0) * 0.001} seconds.`);
 
-    // Note: typescript gives this error "error TS2554: Expected 2-3 arguments, but got 1."
-    // Disabling this for now as the second argument should be optional.
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    postMessage([geometryTriangles, geometryLines]);
+    return [geometryTriangles, geometryLines];
 }

--- a/typescript/packages/subsurface-viewer/src/storybook/layers/Axes2DLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/layers/Axes2DLayer.stories.tsx
@@ -15,6 +15,11 @@ import {
 const stories: Meta = {
     component: SubsurfaceViewer,
     title: "SubsurfaceViewer / Axes2DLayer",
+    args: {
+        // Add a reset button for all the stories.
+        // Somehow, I do not manage to add the triggerHome to the general "unset" controls :/
+        triggerHome: 0,
+    },
 };
 export default stories;
 

--- a/typescript/packages/subsurface-viewer/src/storybook/layers/BoxSelectionLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/layers/BoxSelectionLayer.stories.tsx
@@ -14,6 +14,11 @@ import { volveWellsBounds } from "../sharedSettings";
 const stories: Meta = {
     component: SubsurfaceViewer,
     title: "SubsurfaceViewer / Box Selection Layer",
+    args: {
+        // Add a reset button for all the stories.
+        // Somehow, I do not manage to add the triggerHome to the general "unset" controls :/
+        triggerHome: 0,
+    },
 };
 export default stories;
 
@@ -56,14 +61,17 @@ const DECK_PROPS = {
 };
 
 type BoxSelectionComponentProps = {
+    triggerHome: number;
     enableSelection: boolean;
 };
 const BoxSelectionComponent: React.FC<BoxSelectionComponentProps> = ({
+    triggerHome,
     enableSelection,
 }: BoxSelectionComponentProps) => {
     const deckProps = React.useMemo(
         () => ({
             ...DECK_PROPS,
+            triggerHome,
             layers: [
                 wellsLayer,
                 new BoxSelectionLayer({
@@ -72,7 +80,7 @@ const BoxSelectionComponent: React.FC<BoxSelectionComponentProps> = ({
                 }),
             ],
         }),
-        [enableSelection]
+        [enableSelection, triggerHome]
     );
 
     return (

--- a/typescript/packages/subsurface-viewer/src/storybook/layers/Grid3DLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/layers/Grid3DLayer.stories.tsx
@@ -21,6 +21,11 @@ import { default3DViews, defaultStoryParameters } from "../sharedSettings";
 const stories: Meta = {
     component: SubsurfaceViewer,
     title: "SubsurfaceViewer/Grid3D Layer",
+    args: {
+        // Add a reset button for all the stories.
+        // Somehow, I do not manage to add the triggerHome to the general "unset" controls :/
+        triggerHome: 0,
+    },
 };
 export default stories;
 

--- a/typescript/packages/subsurface-viewer/src/storybook/layers/NorthArrow3DLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/layers/NorthArrow3DLayer.stories.tsx
@@ -14,6 +14,11 @@ import {
 const stories: Meta = {
     component: SubsurfaceViewer,
     title: "SubsurfaceViewer / North Arrow Layer",
+    args: {
+        // Add a reset button for all the stories.
+        // Somehow, I do not manage to add the triggerHome to the general "unset" controls :/
+        triggerHome: 0,
+    },
 };
 export default stories;
 

--- a/typescript/packages/subsurface-viewer/src/storybook/layers/PointsLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/layers/PointsLayer.stories.tsx
@@ -9,6 +9,11 @@ import { default3DViews, defaultStoryParameters } from "../sharedSettings";
 const stories: Meta = {
     component: SubsurfaceViewer,
     title: "SubsurfaceViewer / Points Layer",
+    args: {
+        // Add a reset button for all the stories.
+        // Somehow, I do not manage to add the triggerHome to the general "unset" controls :/
+        triggerHome: 0,
+    },
 };
 export default stories;
 

--- a/typescript/packages/subsurface-viewer/src/storybook/layers/PolylinesLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/layers/PolylinesLayer.stories.tsx
@@ -12,6 +12,11 @@ import { default3DViews, defaultStoryParameters } from "../sharedSettings";
 const stories: Meta = {
     component: SubsurfaceViewer,
     title: "SubsurfaceViewer / Polylines Layer",
+    args: {
+        // Add a reset button for all the stories.
+        // Somehow, I do not manage to add the triggerHome to the general "unset" controls :/
+        triggerHome: 0,
+    },
 };
 export default stories;
 

--- a/typescript/packages/subsurface-viewer/src/storybook/layers/TriangleLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/layers/TriangleLayer.stories.tsx
@@ -1,4 +1,7 @@
+import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
+
+import { create, all } from "mathjs";
 
 import SubsurfaceViewer from "../../SubsurfaceViewer";
 
@@ -14,6 +17,11 @@ import {
 const stories: Meta = {
     component: SubsurfaceViewer,
     title: "SubsurfaceViewer / Triangle Layer",
+    args: {
+        // Add a reset button for all the stories.
+        // Somehow, I do not manage to add the triggerHome to the general "unset" controls :/
+        triggerHome: 0,
+    },
 };
 export default stories;
 
@@ -221,4 +229,116 @@ export const TypedArrayInput: StoryObj<typeof SubsurfaceViewer> = {
             },
         },
     },
+};
+
+const math = create(all, { randomSeed: "12345" });
+
+const bboxSize = 1000;
+const trglSize = 100;
+
+const randomFunc = (size: number): number => {
+    if (math.random) {
+        return math.random() * size;
+    }
+    return Math.random() * size;
+};
+
+const buildTrgl = (count: number = 1): number[] => {
+    count = count || 1;
+    // 9 is 3 points for the triangle * 3 vertices
+    const trglDataSize = 9;
+    const triangles = Array(trglDataSize * count).fill(0);
+    for (let i = 0; i < count; ++i) {
+        // random triangle center
+        const center = Array(3)
+            .fill(0)
+            .map(() => randomFunc(bboxSize));
+        for (let ti = 0; ti < trglDataSize; ++ti) {
+            triangles[i * trglDataSize + ti] =
+                center[ti % 3] + randomFunc(trglSize);
+        }
+    }
+    return triangles;
+};
+
+const TrianglesLayerGenerator: React.FC<{
+    triggerHome: number;
+    triangleCount: number;
+}> = (props) => {
+    const tsurfLayer = React.useMemo(() => {
+        return {
+            "@@type": "TriangleLayer",
+            id: `triangles-layer`,
+
+            pointsData: buildTrgl(props.triangleCount),
+
+            triangleData: Array(3 * props.triangleCount)
+                .fill(0)
+                .map((_, i) => i),
+
+            //color: [randomFunc(255), randomFunc(255), randomFunc(255)], // Surface color.
+            gridLines: true, // If true will draw lines around triangles.
+            material: true, // If true will use triangle normals for shading.
+            ZIncreasingDownwards: true,
+            //contours: [0, 1],          // If used will display contour lines.
+        };
+    }, [props.triangleCount]);
+
+    return (
+        <SubsurfaceViewer
+            triggerHome={props.triggerHome}
+            id="many-triangle-layers"
+            layers={[tsurfLayer]}
+            views={default3DViews}
+        />
+    );
+};
+
+export const BigTriangleLayer: StoryObj<typeof TrianglesLayerGenerator> = {
+    args: {
+        triangleCount: 10,
+    },
+    render: (args) => <TrianglesLayerGenerator {...args} />,
+};
+
+const TriangleLayersGenerator: React.FC<{
+    triggerHome: number;
+    layerCount: number;
+}> = (props) => {
+    const tsurfLayers = React.useMemo(() => {
+        const result: Record<string, unknown>[] = [];
+        for (let i = 0; i <= props.layerCount; ++i) {
+            result.push({
+                "@@type": "TriangleLayer",
+                id: `triangle-layer-${i}`,
+
+                pointsData: buildTrgl(),
+
+                triangleData: [2, 1, 0],
+
+                color: [randomFunc(255), randomFunc(255), randomFunc(255)], // Surface color.
+                gridLines: true, // If true will draw lines around triangles.
+                material: true, // If true will use triangle normals for shading.
+                ZIncreasingDownwards: true,
+                //contours: [0, 1],          // If used will display contour lines.
+            });
+        }
+        return result;
+    }, [props.layerCount]);
+
+    return (
+        <SubsurfaceViewer
+            id="many-triangle-layers"
+            triggerHome={props.triggerHome}
+            layers={tsurfLayers}
+            views={default3DViews}
+        />
+    );
+};
+
+export const ManyTriangleLayers: StoryObj<typeof TriangleLayersGenerator> = {
+    args: {
+        layerCount: 10,
+    },
+    render: (args) => <TriangleLayersGenerator {...args} />,
 };

--- a/typescript/packages/subsurface-viewer/src/storybook/layers/WellMarkersLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/layers/WellMarkersLayer.stories.tsx
@@ -10,6 +10,11 @@ import { defaultStoryParameters } from "../sharedSettings";
 const stories: Meta = {
     component: SubsurfaceViewer,
     title: "SubsurfaceViewer/Well Markers Layer",
+    args: {
+        // Add a reset button for all the stories.
+        // Somehow, I do not manage to add the triggerHome to the general "unset" controls :/
+        triggerHome: 0,
+    },
 };
 export default stories;
 
@@ -20,8 +25,7 @@ type TRandomNumberFunc = (max: number) => number;
 const randomFunc = ((): TRandomNumberFunc => {
     if (math?.random) {
         return (max: number) => {
-            const val = math.random?.(max);
-            return val ? val : 0.0;
+            return math.random(max);
         };
     }
     return (max: number) => Math.random() * max;

--- a/typescript/packages/subsurface-viewer/src/storybook/layers/WellsLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/layers/WellsLayer.stories.tsx
@@ -32,6 +32,11 @@ import {
 const stories: Meta = {
     component: SubsurfaceViewer,
     title: "SubsurfaceViewer / Wells Layer",
+    args: {
+        // Add a reset button for all the stories.
+        // Somehow, I do not manage to add the triggerHome to the general "unset" controls :/
+        triggerHome: 0,
+    },
 };
 export default stories;
 


### PR DESCRIPTION
Creating too many webworkers is bad and leads to out of memory (OOM) errors (more or less quickly, depending on the web bundle size).

This work is about moving to controller web worker pools, first for triangle layer.

It contains:

* reproducing the issue in storybook
  - Add story generating many TriangleLayers with 1 triangle each
    The goal is to force spanning may webworkers to reach an OOM issue.
    I got the OOM with 1200+ layers (note that client reached it with ~200 layers, probably of bigger web bundles)
  - Add story with 1 TriangleLayers displaying many triangles
    The goal is to check behavior if 1 triangle layer takes a lot of time
  - Add triggerHome to all the stories

* Fix endless rendering (in fact no rendering at all), thus never ending "Loading assets..."
  Issue revealed by the new story...

* Use a workerpool to limit the number of workers to 10
  BTW, this also achieves a good performance raise in the case of this extreme use case (each layer has only 1 triangle)
  Using https://github.com/josdejong/workerpool


