### PR TITLE
feat: move vertical scale to SubsurfaceViewer props

### DIFF
--- a/typescript/packages/subsurface-viewer/src/SubsurfaceViewer.tsx
+++ b/typescript/packages/subsurface-viewer/src/SubsurfaceViewer.tsx
@@ -135,6 +135,9 @@ export interface SubsurfaceViewerProps {
     lights?: LightsType;
 
     children?: React.ReactNode;
+
+    /** A vertical scale factor, used to scale items in the view vertically */
+    verticalScale?: number;
 }
 
 const SubsurfaceViewer: React.FC<SubsurfaceViewerProps> = ({
@@ -162,6 +165,7 @@ const SubsurfaceViewer: React.FC<SubsurfaceViewerProps> = ({
     triggerResetMultipleWells,
     lights,
     children,
+    verticalScale,
 }: SubsurfaceViewerProps) => {
     // Contains layers data received from map layers by user interaction
     const [layerEditedData, setLayerEditedData] = React.useState(editedData);
@@ -240,6 +244,7 @@ const SubsurfaceViewer: React.FC<SubsurfaceViewerProps> = ({
             triggerHome={triggerHome}
             triggerResetMultipleWells={triggerResetMultipleWells}
             lights={lights}
+            verticalScale={verticalScale}
         >
             {children}
         </Map>

--- a/typescript/packages/subsurface-viewer/src/components/Map.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.tsx
@@ -356,6 +356,9 @@ export interface MapProps {
     children?: React.ReactNode;
 
     getTooltip?: TooltipCallback;
+
+    /** A vertical scale factor, used to scale items in the view vertically */
+    verticalScale?: number;
 }
 
 function defaultTooltip(info: PickingInfo) {
@@ -391,6 +394,7 @@ const Map: React.FC<MapProps> = ({
     onDragEnd,
     lights,
     triggerResetMultipleWells,
+    verticalScale,
 }: MapProps) => {
     // From react doc, ref should not be read nor modified during rendering.
     const deckRef = React.useRef<DeckGLRef>(null);
@@ -425,11 +429,12 @@ const Map: React.FC<MapProps> = ({
     );
 
     // Get vertical scaling factor defined in viewports.
-    const verticalScale = useVerticalScale(views?.viewports);
+    const viewportVerticalScale = useVerticalScale(views?.viewports);
 
     // Used for scaling in z direction using arrow keys.
-    const { zScale: zReScale, divRef: zScaleRef } =
-        useHandleRescale(!!verticalScale);
+    const { zScale: zReScale, divRef: zScaleRef } = useHandleRescale(
+        !!(verticalScale ?? viewportVerticalScale)
+    );
 
     const { shiftHeld, divRef: shiftHeldRef } = useShiftHeld();
 
@@ -438,7 +443,7 @@ const Map: React.FC<MapProps> = ({
         shiftHeldRef
     ) as React.Ref<HTMLDivElement>;
 
-    const zScale = verticalScale ?? zReScale;
+    const zScale = verticalScale ?? viewportVerticalScale ?? zReScale;
 
     // compute the viewport margins
     const viewPortMargins = React.useMemo<MarginsType>(() => {
@@ -1086,6 +1091,9 @@ class ViewController {
                     state.deckSize != this.state_.deckSize));
         const needUpdate = updateZScale || updateTarget || updateViewState;
 
+        console.log("getDeckGlViewState: viewsChanged: ", viewsChanged);
+        console.log("getDeckGlViewState: updateViewState: ", updateViewState);
+
         const isCacheEmpty = isEmpty(this.result_.viewState);
         if (!isCacheEmpty && !needUpdate) {
             return this.result_.viewState;
@@ -1096,6 +1104,7 @@ class ViewController {
         let viewState = prevViewState;
 
         if (updateViewState || isCacheEmpty) {
+            console.log("getDeckGlViewState: buildDeckGlViewSTates");
             viewState = buildDeckGlViewStates(
                 views,
                 state.viewPortMargins,

--- a/typescript/packages/subsurface-viewer/src/components/Map.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.tsx
@@ -1091,9 +1091,6 @@ class ViewController {
                     state.deckSize != this.state_.deckSize));
         const needUpdate = updateZScale || updateTarget || updateViewState;
 
-        console.log("getDeckGlViewState: viewsChanged: ", viewsChanged);
-        console.log("getDeckGlViewState: updateViewState: ", updateViewState);
-
         const isCacheEmpty = isEmpty(this.result_.viewState);
         if (!isCacheEmpty && !needUpdate) {
             return this.result_.viewState;
@@ -1104,7 +1101,6 @@ class ViewController {
         let viewState = prevViewState;
 
         if (updateViewState || isCacheEmpty) {
-            console.log("getDeckGlViewState: buildDeckGlViewSTates");
             viewState = buildDeckGlViewStates(
                 views,
                 state.viewPortMargins,

--- a/typescript/packages/subsurface-viewer/src/storybook/examples/CameraControlExamples.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/examples/CameraControlExamples.stories.tsx
@@ -59,6 +59,13 @@ const Root = styled("div")({
     },
 });
 
+const SIDE_CAMERA = {
+    rotationX: 0,
+    target: [],
+    rotationOrbit: 90,
+    zoom: -3,
+};
+
 const SQUARE = {
     type: "Feature",
     geometry: {
@@ -623,22 +630,9 @@ const ScaleVertical3dComponent = ({
         id: "ScaleY",
         bounds: volveWellsBounds,
         layers: [huginAxes3DLayer, hugin25mDepthMapLayer],
-        views: {
-            layout: [1, 1],
-            viewports: [
-                {
-                    id: "section",
-                    verticalScale,
-                    show3D: true,
-                },
-            ],
-        },
-        cameraPosition: {
-            rotationX: 0,
-            target: [],
-            rotationOrbit: 90,
-            zoom: -3,
-        },
+        views: default3DViews,
+        cameraPosition: SIDE_CAMERA,
+        verticalScale,
     };
     return <SubsurfaceViewer {...viewerProps} />;
 };

--- a/typescript/packages/subsurface-viewer/src/views/viewport.ts
+++ b/typescript/packages/subsurface-viewer/src/views/viewport.ts
@@ -29,7 +29,8 @@ export interface ViewportType {
     rotationX?: number;
     rotationOrbit?: number;
 
-    /** A vertical scale factor, used to scale items in the viewport vertically */
+    /** @deprecated Please use top-level verticalScale instead for 3D and cameraPosition.zoom for 2D.
+     * A vertical scale factor, used to scale items in the viewport vertically. */
     verticalScale?: number;
 
     isSync?: boolean;


### PR DESCRIPTION
Changing `verticalScale` in the `views` prop does not work, as it will reset the camera target when `view` changes.