### PR TITLE
fix: Support Python 3.11

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,21 +23,26 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: 📖 Checkout commit locally
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: 🐍 Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: 🐍 Set up Python 3.8
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.8  # For compiling the JavaScript part we need dash<2.5, which is not supported on recent versions of Python
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 18
+
+      - name: 🐍 Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: 📦 Install build dependencies
         # The deckgl types package runs a postscript to setup, but since we ignore scripts, we need to set it up manually.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![PyPI version](https://badge.fury.io/py/webviz-subsurface-components.svg)](https://badge.fury.io/py/webviz-subsurface-components)
 [![Build Status](https://github.com/equinor/webviz-subsurface-components/workflows/webviz-subsurface-components/badge.svg)](https://github.com/equinor/webviz-subsurface-components/actions?query=branch%3Amaster)
-[![Python 3.8 | 3.9 | 3.10](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10-blue.svg)](https://www.python.org/)
+[![Python 3.8 | 3.9 | 3.10 | 3.11 ](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10%20|%203.11-blue.svg)](https://www.python.org/)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 
 # Webviz subsurface components


### PR DESCRIPTION
When moving to use Red Hat Enterprise Linux 8 we would benefit from also moving toward using python version 3.11.
We strongly encourage components part of komodo to add support and testing for this version, to allow this move/upgrade to happen in near future.

Resolves #1909
