### PR TITLE
feat: add support for react-redux v9 and @reduxjs/toolkit v2 as optional peer dependencies

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -39,7 +39,7 @@
                 "@types/lodash": "^4.17.5",
                 "@types/react": "^18.3.3",
                 "@types/react-dom": "^18.3.0",
-                "@types/react-redux": "^7.1.25",
+                "@types/react-redux": "^7.1.33",
                 "@types/uuid": "^8.3.0",
                 "@types/workerpool": "^6.4.7",
                 "@typescript-eslint/eslint-plugin": "^7.16.1",
@@ -6372,29 +6372,6 @@
                 "@babel/runtime": "^7.0.0"
             }
         },
-        "node_modules/@reduxjs/toolkit": {
-            "version": "1.9.7",
-            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
-            "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
-            "dependencies": {
-                "immer": "^9.0.21",
-                "redux": "^4.2.1",
-                "redux-thunk": "^2.4.2",
-                "reselect": "^4.1.8"
-            },
-            "peerDependencies": {
-                "react": "^16.9.0 || ^17.0.0 || ^18",
-                "react-redux": "^7.2.1 || ^8.0.2"
-            },
-            "peerDependenciesMeta": {
-                "react": {
-                    "optional": true
-                },
-                "react-redux": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@semantic-release/changelog": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
@@ -10855,6 +10832,7 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
             "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+            "dev": true,
             "dependencies": {
                 "@types/react": "*",
                 "hoist-non-react-statics": "^3.3.0"
@@ -11052,15 +11030,15 @@
             "version": "18.3.0",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
             "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "@types/react": "*"
             }
         },
         "node_modules/@types/react-redux": {
-            "version": "7.1.25",
-            "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.25.tgz",
-            "integrity": "sha512-bAGh4e+w5D8dajd6InASVIyCo4pZLJ66oLb80F9OBLO1gKESbZcRCJpTT6uLXX+HAB57zw1WTdwJdAsewuTweg==",
+            "version": "7.1.33",
+            "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.33.tgz",
+            "integrity": "sha512-NF8m5AjWCkert+fosDsN3hAlHzpjSiXlVy9EgQEmLoBhaNXbmyeGs/aj5dQzKuF+/q+S7JQagorGDW8pJ28Hmg==",
             "dev": true,
             "dependencies": {
                 "@types/hoist-non-react-statics": "^3.3.0",
@@ -11148,7 +11126,8 @@
         "node_modules/@types/use-sync-external-store": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-            "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+            "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
+            "dev": true
         },
         "node_modules/@types/uuid": {
             "version": "8.3.4",
@@ -19479,9 +19458,10 @@
             }
         },
         "node_modules/immer": {
-            "version": "9.0.21",
-            "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-            "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+            "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+            "dev": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/immer"
@@ -31560,49 +31540,6 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         },
-        "node_modules/react-redux": {
-            "version": "8.1.3",
-            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
-            "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
-            "dependencies": {
-                "@babel/runtime": "^7.12.1",
-                "@types/hoist-non-react-statics": "^3.3.1",
-                "@types/use-sync-external-store": "^0.0.3",
-                "hoist-non-react-statics": "^3.3.2",
-                "react-is": "^18.0.0",
-                "use-sync-external-store": "^1.0.0"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8 || ^17.0 || ^18.0",
-                "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
-                "react": "^16.8 || ^17.0 || ^18.0",
-                "react-dom": "^16.8 || ^17.0 || ^18.0",
-                "react-native": ">=0.59",
-                "redux": "^4 || ^5.0.0-beta.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                },
-                "@types/react-dom": {
-                    "optional": true
-                },
-                "react-dom": {
-                    "optional": true
-                },
-                "react-native": {
-                    "optional": true
-                },
-                "redux": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/react-redux/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
-        },
         "node_modules/react-resize-detector": {
             "version": "9.1.1",
             "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-9.1.1.tgz",
@@ -31906,6 +31843,7 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
             "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.9.2"
             }
@@ -31917,14 +31855,6 @@
             "dev": true,
             "dependencies": {
                 "lodash.isplainobject": "^4.0.6"
-            }
-        },
-        "node_modules/redux-thunk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
-            "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
-            "peerDependencies": {
-                "redux": "^4"
             }
         },
         "node_modules/reflect.getprototypeof": {
@@ -32331,9 +32261,10 @@
             "dev": true
         },
         "node_modules/reselect": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
-            "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+            "dev": true
         },
         "node_modules/resolve": {
             "version": "1.22.8",
@@ -36269,6 +36200,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
             "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+            "dev": true,
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
@@ -37336,7 +37268,6 @@
                 "@equinor/eds-core-react": "^0.36.0",
                 "@equinor/eds-icons": "^0.21.0",
                 "@nebula.gl/layers": "^1.0.4",
-                "@reduxjs/toolkit": "^1.7.2",
                 "@turf/simplify": "^7.0.0",
                 "@vivaxy/png": "^1.3.0",
                 "@webviz/wsc-common": "*",
@@ -37349,14 +37280,19 @@
                 "lodash": "^4.17.21",
                 "mathjs": "^13.0.0",
                 "merge-refs": "^1.2.2",
-                "react-redux": "^8.1.1",
                 "workerpool": "^9.1.1"
+            },
+            "devDependencies": {
+                "@reduxjs/toolkit": "^2.2.6",
+                "react-redux": "^9.1.2"
             },
             "peerDependencies": {
                 "@mui/material": "^5.11",
                 "@mui/system": "^5.11",
+                "@reduxjs/toolkit": "^1.7.2 || ^2",
                 "react": "^17 || ^18",
-                "react-dom": "^17 || ^18"
+                "react-dom": "^17 || ^18",
+                "react-redux": "^8.1.1 || ^9"
             }
         },
         "packages/subsurface-viewer/node_modules/@equinor/eds-core-react": {
@@ -37437,6 +37373,30 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
             "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
         },
+        "packages/subsurface-viewer/node_modules/@reduxjs/toolkit": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.6.tgz",
+            "integrity": "sha512-kH0r495c5z1t0g796eDQAkYbEQ3a1OLYN9o8jQQVZyKyw367pfRGS+qZLkHYvFHiUUdafpoSlQ2QYObIApjPWA==",
+            "dev": true,
+            "dependencies": {
+                "immer": "^10.0.3",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
+            }
+        },
         "packages/subsurface-viewer/node_modules/@tanstack/react-virtual": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.1.3.tgz",
@@ -37486,6 +37446,44 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+        },
+        "packages/subsurface-viewer/node_modules/react-redux": {
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.2.tgz",
+            "integrity": "sha512-0OA4dhM1W48l3uzmv6B7TXPCGmokUU4p1M44DGN2/D9a1FjVPukVjER1PcPX97jIg6aUeLq1XJo1IpfbgULn0w==",
+            "dev": true,
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.3",
+                "use-sync-external-store": "^1.0.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25",
+                "react": "^18.0",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/subsurface-viewer/node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "dev": true
+        },
+        "packages/subsurface-viewer/node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "dev": true,
+            "peerDependencies": {
+                "redux": "^5.0.0"
+            }
         },
         "packages/well-completions-plot": {
             "name": "@webviz/well-completions-plot",
@@ -37550,10 +37548,76 @@
                 "convert-units": "^2.3.4",
                 "d3": "^7.8.2"
             },
+            "devDependencies": {
+                "@reduxjs/toolkit": "^2.2.6",
+                "react-redux": "^9.1.2"
+            },
             "peerDependencies": {
                 "@mui/material": "^5.11",
                 "react": "^17 || ^18",
                 "react-dom": "^17 || ^18"
+            }
+        },
+        "packages/well-log-viewer/node_modules/@reduxjs/toolkit": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.6.tgz",
+            "integrity": "sha512-kH0r495c5z1t0g796eDQAkYbEQ3a1OLYN9o8jQQVZyKyw367pfRGS+qZLkHYvFHiUUdafpoSlQ2QYObIApjPWA==",
+            "dev": true,
+            "dependencies": {
+                "immer": "^10.0.3",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/well-log-viewer/node_modules/react-redux": {
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.2.tgz",
+            "integrity": "sha512-0OA4dhM1W48l3uzmv6B7TXPCGmokUU4p1M44DGN2/D9a1FjVPukVjER1PcPX97jIg6aUeLq1XJo1IpfbgULn0w==",
+            "dev": true,
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.3",
+                "use-sync-external-store": "^1.0.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25",
+                "react": "^18.0",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/well-log-viewer/node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "dev": true
+        },
+        "packages/well-log-viewer/node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "dev": true,
+            "peerDependencies": {
+                "redux": "^5.0.0"
             }
         },
         "packages/wsc-common": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -72,7 +72,7 @@
         "@types/lodash": "^4.17.5",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
-        "@types/react-redux": "^7.1.25",
+        "@types/react-redux": "^7.1.33",
         "@types/uuid": "^8.3.0",
         "@types/workerpool": "^6.4.7",
         "@typescript-eslint/eslint-plugin": "^7.16.1",

--- a/typescript/packages/subsurface-viewer/package.json
+++ b/typescript/packages/subsurface-viewer/package.json
@@ -44,7 +44,6 @@
         "@equinor/eds-core-react": "^0.36.0",
         "@equinor/eds-icons": "^0.21.0",
         "@nebula.gl/layers": "^1.0.4",
-        "@reduxjs/toolkit": "^1.7.2",
         "@turf/simplify": "^7.0.0",
         "@vivaxy/png": "^1.3.0",
         "@webviz/wsc-common": "*",
@@ -57,14 +56,27 @@
         "lodash": "^4.17.21",
         "mathjs": "^13.0.0",
         "merge-refs": "^1.2.2",
-        "react-redux": "^8.1.1",
         "workerpool": "^9.1.1"
     },
     "peerDependencies": {
         "@mui/material": "^5.11",
         "@mui/system": "^5.11",
+        "@reduxjs/toolkit": "^1.7.2 || ^2",
         "react": "^17 || ^18",
-        "react-dom": "^17 || ^18"
+        "react-dom": "^17 || ^18",
+        "react-redux": "^8.1.1 || ^9"
+    },
+    "peerDependenciesMeta": {
+        "@reduxjs/toolkit": {
+            "optional": true
+        },
+        "react-redux": {
+            "optional": true
+        }
+    },
+    "devDependencies": {
+        "@reduxjs/toolkit": "^2.2.6",
+        "react-redux": "^9.1.2"
     },
     "volta": {
         "node": "18.19.0"

--- a/typescript/packages/well-log-viewer/package.json
+++ b/typescript/packages/well-log-viewer/package.json
@@ -32,6 +32,10 @@
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
     },
+    "devDependencies": {
+        "@reduxjs/toolkit": "^2.2.6",
+        "react-redux": "^9.1.2"
+    },
     "volta": {
         "node": "18.19.0"
     }


### PR DESCRIPTION
@webviz/subsurface-viewer clients are now responsible to install both react-redux and @reduxjs/toolkit. Both packages are now handled as peer dependencies.