### PR TITLE
fix: Well Log Viewer - Moved callback subscription to well-log-viewer mounted hook

### DIFF
--- a/typescript/packages/well-log-viewer/src/WellLogViewer.tsx
+++ b/typescript/packages/well-log-viewer/src/WellLogViewer.tsx
@@ -99,19 +99,6 @@ export default class WellLogViewer extends Component<
         this.onInfoGroupClick = this.onInfoGroupClick.bind(this);
 
         this.onChangePrimaryAxis = this.onChangePrimaryAxis.bind(this);
-
-        this.callbackManager.registerCallback(
-            "onInfoGroupClick",
-            this.onInfoGroupClick,
-            true
-        );
-
-        if (props.onInfoFilled) {
-            this.callbackManager.registerCallback(
-                "onInfoFilled",
-                props.onInfoFilled
-            );
-        }
     }
 
     onInfoGroupClick(info: Info): void {
@@ -192,6 +179,19 @@ export default class WellLogViewer extends Component<
     }
 
     componentDidMount(): void {
+        this.callbackManager.registerCallback(
+            "onInfoGroupClick",
+            this.onInfoGroupClick,
+            true
+        );
+
+        if (this.props.onInfoFilled) {
+            this.callbackManager.registerCallback(
+                "onInfoFilled",
+                this.props.onInfoFilled
+            );
+        }
+
         this.onContentRescale();
         const controller = this.callbackManager?.controller;
         if (controller) {


### PR DESCRIPTION
Resolves issue #2216 

The callback manager events introduced in PR #2196 where being set up in the _constructor_ hook, not in the `componentDidMount()` hook, which is against React guidelines.

This PR fixes that