### PR TITLE
fix: reloading page fails to reset the camera target correctly if Z s…

### DIFF
--- a/typescript/packages/subsurface-viewer/src/SubsurfaceViewer.tsx
+++ b/typescript/packages/subsurface-viewer/src/SubsurfaceViewer.tsx
@@ -9,6 +9,7 @@ import type {
     BoundsAccessor,
     MapMouseEvent,
     MapProps,
+    Point3D,
     TooltipCallback,
     ViewStateType,
     ViewsType,
@@ -41,7 +42,7 @@ export type LightsType = {
     pointLights?: [
         {
             intensity: number;
-            position: [number, number, number];
+            position: Point3D;
             color?: [number, number, number];
         },
     ];
@@ -49,7 +50,7 @@ export type LightsType = {
     directionalLights?: [
         {
             intensity: number;
-            direction: [number, number, number];
+            direction: Point3D;
             color?: [number, number, number];
         },
     ];

--- a/typescript/packages/subsurface-viewer/src/storybook/sharedDoc.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/sharedDoc.tsx
@@ -30,9 +30,6 @@ export const argTypes = {
 
     triggerHome: {
         description: "Forces resetting to initial home position",
-        control: {
-            type: "number",
-        },
     },
 
     views: {

--- a/typescript/packages/subsurface-viewer/src/utils/BoundingBox2D.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/BoundingBox2D.ts
@@ -31,11 +31,16 @@ export const boxUnion = (
 };
 
 /**
+ * 3D point defined as [x, y].
+ */
+export type Point2D = [number, number];
+
+/**
  * Returns the center of the bounding box.
  * @param box1 bounding box.
  * @returns the center of the bounding box.
  */
-export const boxCenter = (box: BoundingBox2D): [number, number] => {
+export const boxCenter = (box: BoundingBox2D): Point2D => {
     const xmin = box[0];
     const ymin = box[1];
 

--- a/typescript/packages/subsurface-viewer/src/utils/BoundingBox3D.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/BoundingBox3D.ts
@@ -33,11 +33,16 @@ export const boxUnion = (
 };
 
 /**
+ * 3D point defined as [x, y, z].
+ */
+export type Point3D = [number, number, number];
+
+/**
  * Returns the center of the bounding box.
  * @param box1 bounding box.
  * @returns the center of the bounding box.
  */
-export const boxCenter = (box: BoundingBox3D): [number, number, number] => {
+export const boxCenter = (box: BoundingBox3D): Point3D => {
     const xmin = box[0];
     const ymin = box[1];
     const zmin = box[2];


### PR DESCRIPTION
…cale factor is provided

Z scale factor is not applied to the camera target while it is applied to point transformation when displaying objects.