### PR TITLE
fix: pass width prop to spacer component to be used for initial layout calculation

### DIFF
--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.stories.tsx
@@ -408,7 +408,7 @@ export const Default: StoryObj<typeof Template> = {
 
         wellpickFlatting: ["Hor_2", "Hor_4"],
 
-        spacers: [312, 255],
+        spacers: [80, 66],
         wellDistances: {
             units: "m",
             distances: [2048.3, 512.7],

--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
@@ -967,7 +967,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
         if (!this.props.spacers) return null;
         const prev = index - 1;
 
-        let width = 255;
+        let width = 75;
         if (typeof this.props.spacers !== "boolean") {
             width =
                 typeof this.props.spacers === "number"
@@ -975,7 +975,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
                     : this.props.spacers[prev]; // individual width
         }
 
-        if (width === undefined) width = 255; // set some default value
+        if (width === undefined) width = 75; // set some default value
         if (!width) return null;
 
         return (
@@ -1007,6 +1007,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
                               ]
                             : []
                     }
+                    width={width}
                     patternsTable={this.props.patternsTable}
                     patterns={this.props.patterns}
                     options={this.props.spacerOptions}

--- a/typescript/packages/well-log-viewer/src/components/WellLogSpacer.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogSpacer.tsx
@@ -131,6 +131,9 @@ class WellLogSpacer extends Component<WellLogSpacerProps /*, State*/> {
         if (this.props.wellpicks !== nextProps.wellpicks) {
             return true;
         }
+        if (this.props.width !== nextProps.width) {
+            return true;
+        }
 
         if (
             this.props.options?.wellpickColorFill !==
@@ -168,7 +171,7 @@ class WellLogSpacer extends Component<WellLogSpacerProps /*, State*/> {
         let offsetTop = 3000; // try to draw initially out of screen
         let offsetLeft = 3000;
         let height = 1;
-        let width = 1;
+        let width = this.props.width ?? 1;
         const controller = this.props.controllers[0] as unknown as WellLogView;
         const logViewer = controller?.logController;
         const controller2 = this.props.controllers[1] as unknown as WellLogView;


### PR DESCRIPTION
A fix for #2241

Spacer width was not passed down to spacer component thus its width was originally 1 upon initial mounting and then it was calculated from the combination of width of the internal elements.
After the fix, the width is passed down as initial width which (if large enough)has the potential not to be recalculated.

Story with spacers as well as default spacer size was adjusted to provide a more logical spacer size upon rendering (determined from a Full HD 1080p resolution)