### PR TITLE
feat: Trigger release for new well-completions-plot package

### DIFF
--- a/typescript/packages/well-completions-plot/src/components/WellsPlot.tsx
+++ b/typescript/packages/well-completions-plot/src/components/WellsPlot.tsx
@@ -22,7 +22,6 @@ const WellTooltipContent: React.FC<WellTooltipContentProps> = (
     return (
         <table style={{ color: "#fff" }}>
             <tbody>
-                {/* earliest completion date */}
                 <tr key={`well-tooltip-${props.name}-earliest-comp`}>
                     <td>
                         <b>

--- a/typescript/packages/well-completions-plot/src/utility-lib/stringUtils.ts
+++ b/typescript/packages/well-completions-plot/src/utility-lib/stringUtils.ts
@@ -27,6 +27,7 @@ export const createWellNameRegexMatcher = (
         const prevChar = index === 0 ? undefined : pattern.charAt(index - 1);
 
         if (prevChar === undefined || !SPECIAL_ESCAPE.includes(prevChar)) {
+            // Add a dot before each "*" and "?" unless it's preceded by a dot already or a closing brace
             if (SPECIAL_CHARACTERS.includes(character)) {
                 processed.push(".");
                 if (character === "?") continue; // '?' is replaced with '.'


### PR DESCRIPTION
Adjusted comments, with "feat:" prefix to trigger release of `well-completions-plot` package.

Previous commit to master with "feat!:" prefix did not trigger release of package.