### PR TITLE
Add example to show that SyncLogViewer component with width greater than parent component causes strange layout behavior

### DIFF
--- a/typescript/packages/well-log-viewer/src/Storybook/ExternalLayout.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/Storybook/ExternalLayout.stories.tsx
@@ -17,7 +17,10 @@ const RTCWellLogViewer: React.FunctionComponent = () => {
             <div style={{ width: "100%", height: "100%" }}>
                 <div
                     data-testid="well-log-views"
-                    style={{ width: "100%", height: "90vh" }}
+                    style={{
+                        width: "1700px",
+                        height: "80vh",
+                    }}
                 >
                     <SyncLogViewer {...{ ...args, id: "c1" }} />
                 </div>

--- a/typescript/packages/well-log-viewer/src/Storybook/helpers/MuiComponentsTabHelper.tsx
+++ b/typescript/packages/well-log-viewer/src/Storybook/helpers/MuiComponentsTabHelper.tsx
@@ -58,7 +58,6 @@ const TestComponentArea: React.FC<React.PropsWithChildren> = ({ children }) => {
     //---------------------------------------------------------------------------------
     // The Page rendering
     //---------------------------------------------------------------------------------
-
     const direction: GridDirection = "column";
 
     const ref = React.useRef(null);
@@ -72,7 +71,7 @@ const TestComponentArea: React.FC<React.PropsWithChildren> = ({ children }) => {
     const testComponent = renderTestComponent(renderer, ref, tab);
 
     return (
-        <div>
+        <div style={{ overflow: "auto" }}>
             <Grid container direction={direction} justifyContent="flex-start">
                 <div>tab title</div>
                 {testComponent}


### PR DESCRIPTION
@hkfb, Per your request here is a draft PR with my story changes to recreate the issue:  

When SyncLogView is rendered in a parent component that has overflow set to "auto" and that has a size smaller than SLV could fit in, we see strange layout behavior:
![image](https://github.com/user-attachments/assets/f898550c-b3bb-4876-8ab7-2133e9b65cf4)
First we see that there are two horizontal scrollbars - the inner one is the one we added to the parent component containing SLV and its width is the width of the storybook frame. The outer one belongs to storybook iframe itself.
When we scroll the inner scrollbar we see that the some of the components (title, WLV scrollbars, info are and zoom controller) move with the scroller, however the tracks themselves remain stationary. Lookin with browser debugger it appears that the tracks are styled with position: "absolute". This is position defined in component "Scroller" which sets the size and position of the internal component it wraps according to scroll position and zoom level.

Please note that the story structure mimics almost exactly the layout of an application which uses this component.

What is the correct way to fix this component such that the internal elements would not be positioned absolutely and if they, must be, how can we detach the internal components from and external parent component (similar to what storybook does) so that we could fit the component inside a larger layout such that it will have a horizontal scrollbar and will move correctly with it?