### PR TITLE
fix: prevent update of scroll position when component is hidden

### DIFF
--- a/typescript/packages/well-log-viewer/src/components/WellLogView.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogView.tsx
@@ -1318,7 +1318,11 @@ class WellLogView
                     if (this.logController)
                         posWellPickTitles(this.logController, this);
 
-                    this.onContentRescale();
+                    if (
+                        entry.contentRect.width > 0 &&
+                        entry.contentRect.height > 0
+                    )
+                        this.onContentRescale();
                 }
             }
         );


### PR DESCRIPTION
Vertical scroll position is updated every time the component is resized, when the component is hidden its size becomes zero which triggers an update of the scroll position - however in this case the position updates to 0,0 due to all sizes equal to 0 while hidden. This causes the scroll position to be "forgotten" and reset to 0 upon show and then hide of the component. 
The problem could be clearly visible in story "welllogviewer-demo-classificationlayout--rtc-tabs-layout" where the component is positioned in a tab container. When switching to a tab2 to see the component and then to tab3 or tab1 and then back to tab2 the scroll position is reset.