### PR TITLE
fix: bump @emerson-eps/color-tables to 0.4.85 in subsurface-viewer, well-log-viewer and python

### DIFF
--- a/python/package-lock.json
+++ b/python/package-lock.json
@@ -11,7 +11,7 @@
             "license": "MPL",
             "dependencies": {
                 "@deck.gl/core": "^8.9.35",
-                "@emerson-eps/color-tables": "^0.4.61",
+                "@emerson-eps/color-tables": "^0.4.85",
                 "@equinor/eds-core-react": "0.33.0",
                 "@equinor/eds-icons": "^0.19.1",
                 "@mui/material": "^5.11",
@@ -74,7 +74,7 @@
         },
         "../typescript/packages/group-tree-plot": {
             "name": "@webviz/group-tree-plot",
-            "version": "1.2.2",
+            "version": "1.3.15",
             "license": "MPL-2.0",
             "dependencies": {
                 "d3": "^7.8.2",
@@ -87,23 +87,22 @@
         },
         "../typescript/packages/subsurface-viewer": {
             "name": "@webviz/subsurface-viewer",
-            "version": "0.28.2",
+            "version": "1.1.1",
             "license": "MPL-2.0",
             "dependencies": {
-                "@deck.gl-community/editable-layers": "^9.0.2",
-                "@deck.gl-community/layers": "^9.0.2",
-                "@deck.gl/aggregation-layers": "^9.0.27",
-                "@deck.gl/core": "^9.0.27",
-                "@deck.gl/extensions": "^9.0.27",
-                "@deck.gl/geo-layers": "^9.0.27",
-                "@deck.gl/json": "^9.0.27",
-                "@deck.gl/layers": "^9.0.27",
-                "@deck.gl/mesh-layers": "^9.0.27",
-                "@deck.gl/react": "^9.0.12",
-                "@emerson-eps/color-tables": "^0.4.71",
+                "@deck.gl-community/editable-layers": "^9.0.3",
+                "@deck.gl/aggregation-layers": "^9.0.33",
+                "@deck.gl/core": "^9.0.33",
+                "@deck.gl/extensions": "^9.0.33",
+                "@deck.gl/geo-layers": "^9.0.33",
+                "@deck.gl/json": "^9.0.33",
+                "@deck.gl/layers": "^9.0.33",
+                "@deck.gl/mesh-layers": "^9.0.33",
+                "@deck.gl/react": "^9.0.33",
+                "@emerson-eps/color-tables": "^0.4.85",
                 "@equinor/eds-core-react": "^0.36.0",
                 "@equinor/eds-icons": "^0.21.0",
-                "@turf/simplify": "^7.0.0",
+                "@turf/simplify": "^7.1.0",
                 "@vivaxy/png": "^1.3.0",
                 "@webviz/wsc-common": "*",
                 "ajv": "^8.16.0",
@@ -114,12 +113,12 @@
                 "gl-matrix": "^3.4.3",
                 "lodash": "^4.17.21",
                 "math.gl": "^4.0.1",
-                "mathjs": "^12.4.1",
+                "mathjs": "^13.2.0",
                 "merge-refs": "^1.2.2",
-                "workerpool": "^9.1.1"
+                "workerpool": "^9.1.3"
             },
             "devDependencies": {
-                "@reduxjs/toolkit": "^2.2.6",
+                "@reduxjs/toolkit": "^2.2.8",
                 "react-redux": "^9.1.2"
             },
             "peerDependencies": {
@@ -144,11 +143,11 @@
         },
         "../typescript/packages/well-completions-plot": {
             "name": "@webviz/well-completions-plot",
-            "version": "1.3.2",
+            "version": "1.5.11",
             "license": "MPL-2.0",
             "dependencies": {
-                "react-resize-detector": "^10.0.1",
-                "react-tooltip": "^5.27.0"
+                "react-resize-detector": "^11.0.1",
+                "react-tooltip": "^5.28.0"
             }
         },
         "../typescript/packages/well-completions-plot/dist": {
@@ -156,17 +155,17 @@
         },
         "../typescript/packages/well-log-viewer": {
             "name": "@webviz/well-log-viewer",
-            "version": "1.12.4",
+            "version": "2.1.6",
             "license": "MPL-2.0",
             "dependencies": {
-                "@emerson-eps/color-tables": "^0.4.71",
-                "@equinor/videx-wellog": "^0.10.0",
+                "@emerson-eps/color-tables": "^0.4.85",
+                "@equinor/videx-wellog": "^0.10.6",
                 "@webviz/wsc-common": "*",
                 "convert-units": "^2.3.4",
                 "d3": "^7.8.2"
             },
             "devDependencies": {
-                "@reduxjs/toolkit": "^2.2.6",
+                "@reduxjs/toolkit": "^2.2.8",
                 "react-redux": "^9.1.2"
             },
             "peerDependencies": {
@@ -180,10 +179,10 @@
         },
         "../typescript/packages/wsc-common": {
             "name": "@webviz/wsc-common",
-            "version": "0.7.2",
+            "version": "1.0.6",
             "license": "MPL-2.0",
             "dependencies": {
-                "@deck.gl/core": "^9.0.27",
+                "@deck.gl/core": "^9.0.33",
                 "ajv": "^8.12.0"
             }
         },
@@ -588,17 +587,17 @@
             }
         },
         "node_modules/@emerson-eps/color-tables": {
-            "version": "0.4.61",
-            "resolved": "https://registry.npmjs.org/@emerson-eps/color-tables/-/color-tables-0.4.61.tgz",
-            "integrity": "sha512-hQZgEoTbfllCI6by14RI/Jpqftn9m3wBT6afNOu/ffM4/IxjxpKYaG1ycle310AOAJWoTj9wByIwE7YlkJIFoQ==",
+            "version": "0.4.85",
+            "resolved": "https://registry.npmjs.org/@emerson-eps/color-tables/-/color-tables-0.4.85.tgz",
+            "integrity": "sha512-tR6574hmxSkdsEeepd11hf2DQ3zvLMQPh4pRkTkbQdbaGWa9f66Infpyc6rICaN/aZe9aZ9V5yteCLYDnvdqkw==",
             "dependencies": {
-                "@emotion/react": "^11.10.6",
-                "@emotion/styled": "^11.10.0",
+                "@emotion/react": "^11.11.4",
+                "@emotion/styled": "^11.11.5",
                 "d3": "^7.8.4",
                 "d3-color": "^3.0.1",
                 "d3-interpolate": "^3.0.1",
                 "react-color": "^2.19.3",
-                "react-resize-detector": "^9.1.0"
+                "react-resize-detector": "^9.1.1"
             },
             "peerDependencies": {
                 "@mui/icons-material": "^5.11.16",
@@ -609,15 +608,15 @@
             }
         },
         "node_modules/@emotion/babel-plugin": {
-            "version": "11.11.0",
-            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
-            "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz",
+            "integrity": "sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==",
             "dependencies": {
                 "@babel/helper-module-imports": "^7.16.7",
                 "@babel/runtime": "^7.18.3",
-                "@emotion/hash": "^0.9.1",
-                "@emotion/memoize": "^0.8.1",
-                "@emotion/serialize": "^1.1.2",
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/serialize": "^1.2.0",
                 "babel-plugin-macros": "^3.1.0",
                 "convert-source-map": "^1.5.0",
                 "escape-string-regexp": "^4.0.0",
@@ -646,47 +645,47 @@
             }
         },
         "node_modules/@emotion/cache": {
-            "version": "11.11.0",
-            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
-            "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+            "version": "11.13.1",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.13.1.tgz",
+            "integrity": "sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==",
             "dependencies": {
-                "@emotion/memoize": "^0.8.1",
-                "@emotion/sheet": "^1.2.2",
-                "@emotion/utils": "^1.2.1",
-                "@emotion/weak-memoize": "^0.3.1",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/sheet": "^1.4.0",
+                "@emotion/utils": "^1.4.0",
+                "@emotion/weak-memoize": "^0.4.0",
                 "stylis": "4.2.0"
             }
         },
         "node_modules/@emotion/hash": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-            "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
         },
         "node_modules/@emotion/is-prop-valid": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
-            "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+            "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
             "dependencies": {
-                "@emotion/memoize": "^0.8.1"
+                "@emotion/memoize": "^0.9.0"
             }
         },
         "node_modules/@emotion/memoize": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-            "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
         },
         "node_modules/@emotion/react": {
-            "version": "11.11.1",
-            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
-            "integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
+            "version": "11.13.3",
+            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.3.tgz",
+            "integrity": "sha512-lIsdU6JNrmYfJ5EbUCf4xW1ovy5wKQ2CkPRM4xogziOxH1nXxBSjpC9YqbFAP7circxMfYp+6x676BqWcEiixg==",
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
-                "@emotion/babel-plugin": "^11.11.0",
-                "@emotion/cache": "^11.11.0",
-                "@emotion/serialize": "^1.1.2",
-                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
-                "@emotion/utils": "^1.2.1",
-                "@emotion/weak-memoize": "^0.3.1",
+                "@emotion/babel-plugin": "^11.12.0",
+                "@emotion/cache": "^11.13.0",
+                "@emotion/serialize": "^1.3.1",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
+                "@emotion/utils": "^1.4.0",
+                "@emotion/weak-memoize": "^0.4.0",
                 "hoist-non-react-statics": "^3.3.1"
             },
             "peerDependencies": {
@@ -699,33 +698,33 @@
             }
         },
         "node_modules/@emotion/serialize": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.2.tgz",
-            "integrity": "sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.2.tgz",
+            "integrity": "sha512-grVnMvVPK9yUVE6rkKfAJlYZgo0cu3l9iMC77V7DW6E1DUIrU68pSEXRmFZFOFB1QFo57TncmOcvcbMDWsL4yA==",
             "dependencies": {
-                "@emotion/hash": "^0.9.1",
-                "@emotion/memoize": "^0.8.1",
-                "@emotion/unitless": "^0.8.1",
-                "@emotion/utils": "^1.2.1",
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/unitless": "^0.10.0",
+                "@emotion/utils": "^1.4.1",
                 "csstype": "^3.0.2"
             }
         },
         "node_modules/@emotion/sheet": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
-            "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+            "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
         },
         "node_modules/@emotion/styled": {
-            "version": "11.11.0",
-            "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.0.tgz",
-            "integrity": "sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==",
+            "version": "11.13.0",
+            "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.13.0.tgz",
+            "integrity": "sha512-tkzkY7nQhW/zC4hztlwucpT8QEZ6eUzpXDRhww/Eej4tFfO0FxQYWRyg/c5CCXa4d/f174kqeXYjuQRnhzf6dA==",
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
-                "@emotion/babel-plugin": "^11.11.0",
-                "@emotion/is-prop-valid": "^1.2.1",
-                "@emotion/serialize": "^1.1.2",
-                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
-                "@emotion/utils": "^1.2.1"
+                "@emotion/babel-plugin": "^11.12.0",
+                "@emotion/is-prop-valid": "^1.3.0",
+                "@emotion/serialize": "^1.3.0",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
+                "@emotion/utils": "^1.4.0"
             },
             "peerDependencies": {
                 "@emotion/react": "^11.0.0-rc.0",
@@ -743,27 +742,27 @@
             "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
         },
         "node_modules/@emotion/unitless": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-            "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
         },
         "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
-            "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz",
+            "integrity": "sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==",
             "peerDependencies": {
                 "react": ">=16.8.0"
             }
         },
         "node_modules/@emotion/utils": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-            "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.1.tgz",
+            "integrity": "sha512-BymCXzCG3r72VKJxaYVwOXATqXIZ85cuvg0YOUDxMGNrKc1DJRZk8MgV5wyXRyEayIMd4FuXJIUgTBXvDNW5cA=="
         },
         "node_modules/@emotion/weak-memoize": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
-            "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+            "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
         },
         "node_modules/@equinor/eds-core-react": {
             "version": "0.33.0",
@@ -2353,9 +2352,9 @@
             "integrity": "sha512-+HSrJgjBW77ALieQdMJvXhRZUIRN1597L+BKvsyeiIlHHERnqjcuOLyodK3auJ3Y3zRezNKtKAhuQWYJfEgFHQ=="
         },
         "node_modules/@types/parse-json": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+            "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
         },
         "node_modules/@types/prop-types": {
             "version": "15.7.6",
@@ -9774,9 +9773,9 @@
             }
         },
         "node_modules/react-resize-detector": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-9.1.0.tgz",
-            "integrity": "sha512-vGFbfkIZp4itJqR4yl+GhjrZHtdlQvou1r10ek0yZUMkizKbPdekKTpPb003IV3b8E5BJFThVG0oocjE3lNsug==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-9.1.1.tgz",
+            "integrity": "sha512-siLzop7i4xIvZIACE/PHTvRegA8QRCEt0TfmvJ/qCIFQJ4U+3NuYcF8tNDmDWxfIn+X1eNCyY2rauH4KRxge8w==",
             "dependencies": {
                 "lodash": "^4.17.21"
             },

--- a/python/package.json
+++ b/python/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@deck.gl/core": "^8.9.35",
-        "@emerson-eps/color-tables": "^0.4.61",
+        "@emerson-eps/color-tables": "^0.4.85",
         "@equinor/eds-core-react": "0.33.0",
         "@equinor/eds-icons": "^0.19.1",
         "@mui/material": "^5.11",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -36324,7 +36324,7 @@
                 "@deck.gl/layers": "^9.0.33",
                 "@deck.gl/mesh-layers": "^9.0.33",
                 "@deck.gl/react": "^9.0.33",
-                "@emerson-eps/color-tables": "^0.4.71",
+                "@emerson-eps/color-tables": "^0.4.85",
                 "@equinor/eds-core-react": "^0.36.0",
                 "@equinor/eds-icons": "^0.21.0",
                 "@turf/simplify": "^7.1.0",
@@ -36570,7 +36570,7 @@
             "version": "2.1.6",
             "license": "MPL-2.0",
             "dependencies": {
-                "@emerson-eps/color-tables": "^0.4.71",
+                "@emerson-eps/color-tables": "^0.4.85",
                 "@equinor/videx-wellog": "^0.10.6",
                 "@webviz/wsc-common": "*",
                 "convert-units": "^2.3.4",

--- a/typescript/packages/subsurface-viewer/package.json
+++ b/typescript/packages/subsurface-viewer/package.json
@@ -41,7 +41,7 @@
         "@deck.gl/layers": "^9.0.33",
         "@deck.gl/mesh-layers": "^9.0.33",
         "@deck.gl/react": "^9.0.33",
-        "@emerson-eps/color-tables": "^0.4.71",
+        "@emerson-eps/color-tables": "^0.4.85",
         "@equinor/eds-core-react": "^0.36.0",
         "@equinor/eds-icons": "^0.21.0",
         "@turf/simplify": "^7.1.0",

--- a/typescript/packages/well-log-viewer/package.json
+++ b/typescript/packages/well-log-viewer/package.json
@@ -21,7 +21,7 @@
     "author": "Equinor <opensource@equinor.com>",
     "license": "MPL-2.0",
     "dependencies": {
-        "@emerson-eps/color-tables": "^0.4.71",
+        "@emerson-eps/color-tables": "^0.4.85",
         "@equinor/videx-wellog": "^0.10.6",
         "@webviz/wsc-common": "*",
         "convert-units": "^2.3.4",


### PR DESCRIPTION
Bump @emerson-eps/color-tables from 0.4.61 to 0.4.85 in python
Bump @emerson-eps/color-tables from 0.4.71 to 0.4.85 in subsurface-viewer
Bump @emerson-eps/color-tables from 0.4.71 to 0.4.85 in well-log-viewer