### PR TITLE
fix: bump workerpool from 9.1.3 to 9.2.0 in subsurface-viewer

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -35840,9 +35840,9 @@
             "dev": true
         },
         "node_modules/workerpool": {
-            "version": "9.1.3",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.1.3.tgz",
-            "integrity": "sha512-LhUrk4tbxJRDQmRrrFWA9EnboXI79fe0ZNTy3u8m+dqPN1EkVSIsQYAB8OF/fkyhG8Rtup+c/bzj/+bzbG8fqg=="
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.2.0.tgz",
+            "integrity": "sha512-PKZqBOCo6CYkVOwAxWxQaSF2Fvb5Iv2fCeTP7buyWI2GiynWr46NcXSgK/idoV6e60dgCBfgYc+Un3HMvmqP8w=="
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
@@ -36204,7 +36204,7 @@
                 "math.gl": "^4.0.1",
                 "mathjs": "^13.2.0",
                 "merge-refs": "^1.2.2",
-                "workerpool": "^9.1.3"
+                "workerpool": "^9.2.0"
             },
             "devDependencies": {
                 "@reduxjs/toolkit": "^2.2.8",

--- a/typescript/packages/subsurface-viewer/package.json
+++ b/typescript/packages/subsurface-viewer/package.json
@@ -57,7 +57,7 @@
         "math.gl": "^4.0.1",
         "mathjs": "^13.2.0",
         "merge-refs": "^1.2.2",
-        "workerpool": "^9.1.3"
+        "workerpool": "^9.2.0"
     },
     "peerDependencies": {
         "@mui/material": "^5.11",


### PR DESCRIPTION
Bumps workerpool from 9.1.3 to 9.2.0 in subsurface-viewer.