### PR TITLE
feat: Fixes: [NGRM]: Slow readout caused by high pick depth when displaying readout data.

### DIFF
--- a/typescript/packages/subsurface-viewer/src/components/Map.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.tsx
@@ -407,7 +407,7 @@ const Map: React.FC<MapProps> = ({
     cameraPosition,
     triggerHome,
     views = DEFAULT_VIEWS,
-    coords = { visible: true, multiPicking: true, pickDepth: 10 },
+    coords = { visible: true, multiPicking: true, pickDepth: 2 },
     scale = { visible: true, cssStyle: { top: 10, left: 10 } },
     coordinateUnit = "m",
     colorTables = defaultColorTables,


### PR DESCRIPTION
Consider the following webviz react property that controls the readout popup:

    /**
     * Parameters for the InfoCard component
     */
    coords?: {
        visible?: boolean | null;
        multiPicking?: boolean | null; 
        pickDepth?: number | null;
    };
The pickDepth has a default value of 10. This slows down the readout considerably for large sets of data like for instance a big map.

When hovering over object in the view, pickDepth larger than one will cause the readout to also display values for objects hidden behind the closest.

I'm am changing the default value to 2. This will remedy the slow readout and will be enough to show readout for for instance a well and a map behind it. Or 2 wells on top of each other. If one wants more pickDepth one will explicitly have to set this property.
