### PR TITLE
chore: bump `@equinor/eds-core-react` to `0.42.5`

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -2576,6 +2576,67 @@
             "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
             "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
         },
+        "node_modules/@equinor/eds-core-react": {
+            "version": "0.42.5",
+            "resolved": "https://registry.npmjs.org/@equinor/eds-core-react/-/eds-core-react-0.42.5.tgz",
+            "integrity": "sha512-Js5mgPhLrrOYCx8FbFds+ZhX4vru1qq+nXEjw8rQGrIGzEZQGGBMyLXnvVZ5nM/mSjx061aMv2CPL3Eeu82qcQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.25.0",
+                "@equinor/eds-icons": "^0.21.0",
+                "@equinor/eds-tokens": "0.9.2",
+                "@equinor/eds-utils": "0.8.5",
+                "@floating-ui/react": "^0.26.22",
+                "@internationalized/date": "^3.5.5",
+                "@react-aria/utils": "^3.25.1",
+                "@react-stately/calendar": "^3.5.3",
+                "@react-stately/datepicker": "^3.10.1",
+                "@react-types/shared": "^3.24.1",
+                "@tanstack/react-virtual": "3.10.8",
+                "downshift": "9.0.8",
+                "react-aria": "^3.34.1"
+            },
+            "peerDependencies": {
+                "react": ">=16.8",
+                "react-dom": ">=16.8",
+                "styled-components": ">=5.1"
+            }
+        },
+        "node_modules/@equinor/eds-core-react/node_modules/@equinor/eds-icons": {
+            "version": "0.21.0",
+            "resolved": "https://registry.npmjs.org/@equinor/eds-icons/-/eds-icons-0.21.0.tgz",
+            "integrity": "sha512-k2keACHou9h9D5QLfSBeojTApqbPCkHNBWplUA/B9FQv8FMCMSBbjJAo2L/3yAExMylQN9LdwKo81T2tijRXoA==",
+            "engines": {
+                "node": ">=10.0.0",
+                "pnpm": ">=4"
+            }
+        },
+        "node_modules/@equinor/eds-tokens": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/@equinor/eds-tokens/-/eds-tokens-0.9.2.tgz",
+            "integrity": "sha512-pDIFei0vsfN3GN12NKWqxskAkYBQd6+Dzjga2liuY81LfnlJs5g9NblamU9WY5w5YdVE5Z8FNjsMKDLs2JIWcw==",
+            "engines": {
+                "node": ">=10.0.0",
+                "pnpm": ">=4"
+            }
+        },
+        "node_modules/@equinor/eds-utils": {
+            "version": "0.8.5",
+            "resolved": "https://registry.npmjs.org/@equinor/eds-utils/-/eds-utils-0.8.5.tgz",
+            "integrity": "sha512-4AwltyJg51rjBBB4a4g4dGh9JlR+9mc/1AvRsV+nJqdpjjUgDeVBXukLN8Dh2CgyX1+0q3iH3TWq7bwOzd7n5Q==",
+            "dependencies": {
+                "@babel/runtime": "^7.24.0",
+                "@equinor/eds-tokens": "0.9.2"
+            },
+            "engines": {
+                "node": ">=10.0.0",
+                "pnpm": ">=4"
+            },
+            "peerDependencies": {
+                "react": ">=16.8",
+                "react-dom": ">=16.8",
+                "styled-components": ">=4.2"
+            }
+        },
         "node_modules/@equinor/videx-math": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@equinor/videx-math/-/videx-math-1.1.0.tgz",
@@ -3147,10 +3208,24 @@
                 "@floating-ui/utils": "^0.2.0"
             }
         },
+        "node_modules/@floating-ui/react": {
+            "version": "0.26.28",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+            "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+            "dependencies": {
+                "@floating-ui/react-dom": "^2.1.2",
+                "@floating-ui/utils": "^0.2.8",
+                "tabbable": "^6.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
         "node_modules/@floating-ui/react-dom": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.0.tgz",
-            "integrity": "sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+            "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
             "dependencies": {
                 "@floating-ui/dom": "^1.0.0"
             },
@@ -3163,6 +3238,52 @@
             "version": "0.2.8",
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
             "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
+        },
+        "node_modules/@formatjs/ecma402-abstract": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.2.tgz",
+            "integrity": "sha512-6sE5nyvDloULiyOMbOTJEEgWL32w+VHkZQs8S02Lnn8Y/O5aQhjOEXwWzvR7SsBE/exxlSpY2EsWZgqHbtLatg==",
+            "dependencies": {
+                "@formatjs/fast-memoize": "2.2.6",
+                "@formatjs/intl-localematcher": "0.5.10",
+                "decimal.js": "10",
+                "tslib": "2"
+            }
+        },
+        "node_modules/@formatjs/fast-memoize": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.6.tgz",
+            "integrity": "sha512-luIXeE2LJbQnnzotY1f2U2m7xuQNj2DA8Vq4ce1BY9ebRZaoPB1+8eZ6nXpLzsxuW5spQxr7LdCg+CApZwkqkw==",
+            "dependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@formatjs/icu-messageformat-parser": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.0.tgz",
+            "integrity": "sha512-Hp81uTjjdTk3FLh/dggU5NK7EIsVWc5/ZDWrIldmf2rBuPejuZ13CZ/wpVE2SToyi4EiroPTQ1XJcJuZFIxTtw==",
+            "dependencies": {
+                "@formatjs/ecma402-abstract": "2.3.2",
+                "@formatjs/icu-skeleton-parser": "1.8.12",
+                "tslib": "2"
+            }
+        },
+        "node_modules/@formatjs/icu-skeleton-parser": {
+            "version": "1.8.12",
+            "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.12.tgz",
+            "integrity": "sha512-QRAY2jC1BomFQHYDMcZtClqHR55EEnB96V7Xbk/UiBodsuFc5kujybzt87+qj1KqmJozFhk6n4KiT1HKwAkcfg==",
+            "dependencies": {
+                "@formatjs/ecma402-abstract": "2.3.2",
+                "tslib": "2"
+            }
+        },
+        "node_modules/@formatjs/intl-localematcher": {
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+            "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+            "dependencies": {
+                "tslib": "2"
+            }
         },
         "node_modules/@gar/promisify": {
             "version": "1.1.3",
@@ -3228,6 +3349,39 @@
             "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
             "peerDependencies": {
                 "react": "*"
+            }
+        },
+        "node_modules/@internationalized/date": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.7.0.tgz",
+            "integrity": "sha512-VJ5WS3fcVx0bejE/YHfbDKR/yawZgKqn/if+oEeLqNwBtPzVB06olkfcnojTmEMX+gTpH+FlQ69SHNitJ8/erQ==",
+            "dependencies": {
+                "@swc/helpers": "^0.5.0"
+            }
+        },
+        "node_modules/@internationalized/message": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.6.tgz",
+            "integrity": "sha512-JxbK3iAcTIeNr1p0WIFg/wQJjIzJt9l/2KNY/48vXV7GRGZSv3zMxJsce008fZclk2cDC8y0Ig3odceHO7EfNQ==",
+            "dependencies": {
+                "@swc/helpers": "^0.5.0",
+                "intl-messageformat": "^10.1.0"
+            }
+        },
+        "node_modules/@internationalized/number": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.0.tgz",
+            "integrity": "sha512-PtrRcJVy7nw++wn4W2OuePQQfTqDzfusSuY1QTtui4wa7r+rGVtR75pO8CyKvHvzyQYi3Q1uO5sY0AsB4e65Bw==",
+            "dependencies": {
+                "@swc/helpers": "^0.5.0"
+            }
+        },
+        "node_modules/@internationalized/string": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.5.tgz",
+            "integrity": "sha512-rKs71Zvl2OKOHM+mzAFMIyqR5hI1d1O6BBkMK2/lkfg3fkmVh9Eeg0awcA8W2WqYqDOv6a86DIOlFpggwLtbuw==",
+            "dependencies": {
+                "@swc/helpers": "^0.5.0"
             }
         },
         "node_modules/@isaacs/cliui": {
@@ -6532,6 +6686,1489 @@
             "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.9.tgz",
             "integrity": "sha512-Q9Xt/sJUQaMsbjRKjOscv2t7wXIymTrOEJ4a3da4FTCn7bkKvcdxdyFAQySCrtPxE+YZ5I5lXpWPgv9BwmpE1g=="
         },
+        "node_modules/@react-aria/breadcrumbs": {
+            "version": "3.5.20",
+            "resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.5.20.tgz",
+            "integrity": "sha512-xqVSSDPpQuUFpJyIXMQv8L7zumk5CeGX7qTzo4XRvqm5T9qnNAX4XpYEMdktnLrQRY/OemCBScbx7SEwr0B3Kg==",
+            "dependencies": {
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/link": "^3.7.8",
+                "@react-aria/utils": "^3.27.0",
+                "@react-types/breadcrumbs": "^3.7.10",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/button": {
+            "version": "3.11.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.11.1.tgz",
+            "integrity": "sha512-NSs2HxHSSPSuYy5bN+PMJzsCNDVsbm1fZ/nrWM2WWWHTBrx9OqyrEXZVV9ebzQCN9q0nzhwpf6D42zHIivWtJA==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/toolbar": "3.0.0-beta.12",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/toggle": "^3.8.1",
+                "@react-types/button": "^3.10.2",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/calendar": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.7.0.tgz",
+            "integrity": "sha512-9YUbgcox7cQgvZfQtL2BLLRsIuX4mJeclk9HkFoOsAu3RGO5HNsteah8FV54W8BMjm/bNRXIPUxtjTTP+1L6jg==",
+            "dependencies": {
+                "@internationalized/date": "^3.7.0",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/live-announcer": "^3.4.1",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/calendar": "^3.7.0",
+                "@react-types/button": "^3.10.2",
+                "@react-types/calendar": "^3.6.0",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/checkbox": {
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.15.1.tgz",
+            "integrity": "sha512-ETgsMDZ0IZzRXy/OVlGkazm8T+PcMHoTvsxp0c+U82c8iqdITA+VJ615eBPOQh6OkkYIIn4cRn/e+69RmGzXng==",
+            "dependencies": {
+                "@react-aria/form": "^3.0.12",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/label": "^3.7.14",
+                "@react-aria/toggle": "^3.10.11",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/checkbox": "^3.6.11",
+                "@react-stately/form": "^3.1.1",
+                "@react-stately/toggle": "^3.8.1",
+                "@react-types/checkbox": "^3.9.1",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/color": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@react-aria/color/-/color-3.0.3.tgz",
+            "integrity": "sha512-DDVma2107VHBfSuEnnmy+KJvXvxEXWSAooii2vlHHmQNb5x4rv4YTk+dP5GZl/7MgT8OgPTB9UHoC83bXFMDRA==",
+            "dependencies": {
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/numberfield": "^3.11.10",
+                "@react-aria/slider": "^3.7.15",
+                "@react-aria/spinbutton": "^3.6.11",
+                "@react-aria/textfield": "^3.16.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-aria/visually-hidden": "^3.8.19",
+                "@react-stately/color": "^3.8.2",
+                "@react-stately/form": "^3.1.1",
+                "@react-types/color": "^3.0.2",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/combobox": {
+            "version": "3.11.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.11.1.tgz",
+            "integrity": "sha512-TTNbGhUuqxzPcJzd6hufOxuHzX0UARkw+0bl+TuCwNPQnqrcPf20EoOZvd3MHZwGq6GCP4QV+qo0uGx83RpUvA==",
+            "dependencies": {
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/listbox": "^3.14.0",
+                "@react-aria/live-announcer": "^3.4.1",
+                "@react-aria/menu": "^3.17.0",
+                "@react-aria/overlays": "^3.25.0",
+                "@react-aria/selection": "^3.22.0",
+                "@react-aria/textfield": "^3.16.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/collections": "^3.12.1",
+                "@react-stately/combobox": "^3.10.2",
+                "@react-stately/form": "^3.1.1",
+                "@react-types/button": "^3.10.2",
+                "@react-types/combobox": "^3.13.2",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/datepicker": {
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.13.0.tgz",
+            "integrity": "sha512-TmJan65P3Vk7VDBNW5rH9Z25cAn0vk8TEtaP3boCs8wJFE+HbEuB8EqLxBFu47khtuKTEqDP3dTlUh2Vt/f7Xw==",
+            "dependencies": {
+                "@internationalized/date": "^3.7.0",
+                "@internationalized/number": "^3.6.0",
+                "@internationalized/string": "^3.2.5",
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/form": "^3.0.12",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/label": "^3.7.14",
+                "@react-aria/spinbutton": "^3.6.11",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/datepicker": "^3.12.0",
+                "@react-stately/form": "^3.1.1",
+                "@react-types/button": "^3.10.2",
+                "@react-types/calendar": "^3.6.0",
+                "@react-types/datepicker": "^3.10.0",
+                "@react-types/dialog": "^3.5.15",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/dialog": {
+            "version": "3.5.21",
+            "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.21.tgz",
+            "integrity": "sha512-tBsn9swBhcptJ9QIm0+ur0PVR799N6qmGguva3rUdd+gfitknFScyT08d7AoMr9AbXYdJ+2R9XNSZ3H3uIWQMw==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/overlays": "^3.25.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-types/dialog": "^3.5.15",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/disclosure": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/disclosure/-/disclosure-3.0.1.tgz",
+            "integrity": "sha512-rNH8RFcePoAQizcqB7KuHbBOr7sPsysFKCUwbVSOXLPgvCfXKafIhjgFJVqekfsbn5zWvkcTupnzGVJj/F9p+g==",
+            "dependencies": {
+                "@react-aria/ssr": "^3.9.7",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/disclosure": "^3.0.1",
+                "@react-types/button": "^3.10.2",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/dnd": {
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/dnd/-/dnd-3.8.1.tgz",
+            "integrity": "sha512-FoXYQ4z33E9YBzIGRJM1B1oZep6CvEWgXvjCZGURatjr3qG7vf95mOqA5kVd9bjLL7QK4w0ujJWEBfog3WmufA==",
+            "dependencies": {
+                "@internationalized/string": "^3.2.5",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/live-announcer": "^3.4.1",
+                "@react-aria/overlays": "^3.25.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/dnd": "^3.5.1",
+                "@react-types/button": "^3.10.2",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/focus": {
+            "version": "3.19.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.19.1.tgz",
+            "integrity": "sha512-bix9Bu1Ue7RPcYmjwcjhB14BMu2qzfJ3tMQLqDc9pweJA66nOw8DThy3IfVr8Z7j2PHktOLf9kcbiZpydKHqzg==",
+            "dependencies": {
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0",
+                "clsx": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/form": {
+            "version": "3.0.12",
+            "resolved": "https://registry.npmjs.org/@react-aria/form/-/form-3.0.12.tgz",
+            "integrity": "sha512-8uvPYEd3GDyGt5NRJIzdWW1Ry5HLZq37vzRZKUW8alZ2upFMH3KJJG55L9GP59KiF6zBrYBebvI/YK1Ye1PE1g==",
+            "dependencies": {
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/form": "^3.1.1",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/grid": {
+            "version": "3.11.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.11.1.tgz",
+            "integrity": "sha512-Wg8m68RtNWfkhP3Qjrrsl1q1et8QCjXPMRsYgKBahYRS0kq2MDcQ+UBdG1fiCQn/MfNImhTUGVeQX276dy1lww==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/live-announcer": "^3.4.1",
+                "@react-aria/selection": "^3.22.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/collections": "^3.12.1",
+                "@react-stately/grid": "^3.10.1",
+                "@react-stately/selection": "^3.19.0",
+                "@react-types/checkbox": "^3.9.1",
+                "@react-types/grid": "^3.2.11",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/gridlist": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/gridlist/-/gridlist-3.10.1.tgz",
+            "integrity": "sha512-11FlupBg5C9ehs7R6OjqMPWEOLK/4IuSrq7D1xU+Hnm7ZYI/KKcCXvNMjMmnOz/gGzOmfgVwz5PIKaY9aZarEg==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/grid": "^3.11.1",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/selection": "^3.22.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/collections": "^3.12.1",
+                "@react-stately/list": "^3.11.2",
+                "@react-stately/tree": "^3.8.7",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/i18n": {
+            "version": "3.12.5",
+            "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.5.tgz",
+            "integrity": "sha512-ooeop2pTG94PuaHoN2OTk2hpkqVuoqgEYxRvnc1t7DVAtsskfhS/gVOTqyWGsxvwAvRi7m/CnDu6FYdeQ/bK5w==",
+            "dependencies": {
+                "@internationalized/date": "^3.7.0",
+                "@internationalized/message": "^3.1.6",
+                "@internationalized/number": "^3.6.0",
+                "@internationalized/string": "^3.2.5",
+                "@react-aria/ssr": "^3.9.7",
+                "@react-aria/utils": "^3.27.0",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/interactions": {
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.23.0.tgz",
+            "integrity": "sha512-0qR1atBIWrb7FzQ+Tmr3s8uH5mQdyRH78n0krYaG8tng9+u1JlSi8DGRSaC9ezKyNB84m7vHT207xnHXGeJ3Fg==",
+            "dependencies": {
+                "@react-aria/ssr": "^3.9.7",
+                "@react-aria/utils": "^3.27.0",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/label": {
+            "version": "3.7.14",
+            "resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.7.14.tgz",
+            "integrity": "sha512-EN1Md2YvcC4sMqBoggsGYUEGlTNqUfJZWzduSt29fbQp1rKU2KlybTe+TWxKq/r2fFd+4JsRXxMeJiwB3w2AQA==",
+            "dependencies": {
+                "@react-aria/utils": "^3.27.0",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/link": {
+            "version": "3.7.8",
+            "resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.7.8.tgz",
+            "integrity": "sha512-oiXUPQLZmf9Q9Xehb/sG1QRxfo28NFKdh9w+unD12sHI6NdLMETl5MA4CYyTgI0dfMtTjtfrF68GCnWfc7JvXQ==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-types/link": "^3.5.10",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/listbox": {
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.14.0.tgz",
+            "integrity": "sha512-pyVbKavh8N8iyiwOx6I3JIcICvAzFXkKSFni1yarfgngJsJV3KSyOkzLomOfN9UhbjcV4sX61/fccwJuvlurlA==",
+            "dependencies": {
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/label": "^3.7.14",
+                "@react-aria/selection": "^3.22.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/collections": "^3.12.1",
+                "@react-stately/list": "^3.11.2",
+                "@react-types/listbox": "^3.5.4",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/live-announcer": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.4.1.tgz",
+            "integrity": "sha512-4X2mcxgqLvvkqxv2l1n00jTzUxxe0kkLiapBGH1LHX/CxA1oQcHDqv8etJ2ZOwmS/MSBBiWnv3DwYHDOF6ubig==",
+            "dependencies": {
+                "@swc/helpers": "^0.5.0"
+            }
+        },
+        "node_modules/@react-aria/menu": {
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.17.0.tgz",
+            "integrity": "sha512-aiFvSv3G1YvPC0klJQ/9quB05xIDZzJ5Lt6/CykP0UwGK5i8GCqm6/cyFLwEXsS5ooUPxS3bqmdOsgdADSSgqg==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/overlays": "^3.25.0",
+                "@react-aria/selection": "^3.22.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/collections": "^3.12.1",
+                "@react-stately/menu": "^3.9.1",
+                "@react-stately/selection": "^3.19.0",
+                "@react-stately/tree": "^3.8.7",
+                "@react-types/button": "^3.10.2",
+                "@react-types/menu": "^3.9.14",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/meter": {
+            "version": "3.4.19",
+            "resolved": "https://registry.npmjs.org/@react-aria/meter/-/meter-3.4.19.tgz",
+            "integrity": "sha512-IIA+gTHrNVbMuBgcqdGLEKd/ZiKM2hOUqS6uztbT15dwPJTmtfJiTWA2872PiY52p+gqPSanZuTc2TXYJa+rew==",
+            "dependencies": {
+                "@react-aria/progress": "^3.4.19",
+                "@react-types/meter": "^3.4.6",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/numberfield": {
+            "version": "3.11.10",
+            "resolved": "https://registry.npmjs.org/@react-aria/numberfield/-/numberfield-3.11.10.tgz",
+            "integrity": "sha512-bYbTfO9NbAKMFOfEGGs+lvlxk0I9L0lU3WD2PFQZWdaoBz9TCkL+vK0fJk1zsuKaVjeGsmHP9VesBPRmaP0MiA==",
+            "dependencies": {
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/spinbutton": "^3.6.11",
+                "@react-aria/textfield": "^3.16.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/form": "^3.1.1",
+                "@react-stately/numberfield": "^3.9.9",
+                "@react-types/button": "^3.10.2",
+                "@react-types/numberfield": "^3.8.8",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/overlays": {
+            "version": "3.25.0",
+            "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.25.0.tgz",
+            "integrity": "sha512-UEqJJ4duowrD1JvwXpPZreBuK79pbyNjNxFUVpFSskpGEJe3oCWwsSDKz7P1O7xbx5OYp+rDiY8fk/sE5rkaKw==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/ssr": "^3.9.7",
+                "@react-aria/utils": "^3.27.0",
+                "@react-aria/visually-hidden": "^3.8.19",
+                "@react-stately/overlays": "^3.6.13",
+                "@react-types/button": "^3.10.2",
+                "@react-types/overlays": "^3.8.12",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/progress": {
+            "version": "3.4.19",
+            "resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.4.19.tgz",
+            "integrity": "sha512-5HHnBJHqEUuY+dYsjIZDYsENeKr49VCuxeaDZ0OSahbOlloIOB1baCo/6jLBv1O1rwrAzZ2gCCPcVGed/cjrcw==",
+            "dependencies": {
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/label": "^3.7.14",
+                "@react-aria/utils": "^3.27.0",
+                "@react-types/progress": "^3.5.9",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/radio": {
+            "version": "3.10.11",
+            "resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.10.11.tgz",
+            "integrity": "sha512-R150HsBFPr1jLMShI4aBM8heCa1k6h0KEvnFRfTAOBu+B9hMSZOPB+d6GQOwGPysNlbset90Kej8G15FGHjqiA==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/form": "^3.0.12",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/label": "^3.7.14",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/radio": "^3.10.10",
+                "@react-types/radio": "^3.8.6",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/searchfield": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/@react-aria/searchfield/-/searchfield-3.8.0.tgz",
+            "integrity": "sha512-AaZuH9YIWlMyE1m7cSjHCfOuQmlWN+w8HVW32TxeGGGL1kJsYAlSYWYHUyYFIKh245kq/m5zUxAxmw5Ygmnx5w==",
+            "dependencies": {
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/textfield": "^3.16.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/searchfield": "^3.5.9",
+                "@react-types/button": "^3.10.2",
+                "@react-types/searchfield": "^3.5.11",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/select": {
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/select/-/select-3.15.1.tgz",
+            "integrity": "sha512-FOtY1tuHt0YTHwOEy/sf7LEIL+Nnkho3wJmfpWQuTxsvMCF7UJdQPYPd6/jGCcCdiqW7H4iqyjUkSp6nk/XRWQ==",
+            "dependencies": {
+                "@react-aria/form": "^3.0.12",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/label": "^3.7.14",
+                "@react-aria/listbox": "^3.14.0",
+                "@react-aria/menu": "^3.17.0",
+                "@react-aria/selection": "^3.22.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-aria/visually-hidden": "^3.8.19",
+                "@react-stately/select": "^3.6.10",
+                "@react-types/button": "^3.10.2",
+                "@react-types/select": "^3.9.9",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/selection": {
+            "version": "3.22.0",
+            "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.22.0.tgz",
+            "integrity": "sha512-XFOrK525HX2eeWeLZcZscUAs5qsuC1ZxsInDXMjvLeAaUPtQNEhUKHj3psDAl6XDU4VV1IJo0qCmFTVqTTMZSg==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/selection": "^3.19.0",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/separator": {
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/@react-aria/separator/-/separator-3.4.5.tgz",
+            "integrity": "sha512-RQA9sKZdAEjP1Yrv0GpDdXgmXd56kXDE8atPDHEC0/A4lpYh/YFLfXcv1JW0Hlg4kBocdX2pB2INyDGhiD+yfw==",
+            "dependencies": {
+                "@react-aria/utils": "^3.27.0",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/slider": {
+            "version": "3.7.15",
+            "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.7.15.tgz",
+            "integrity": "sha512-v9tujsuvJYRX0vE/vMYBzTT9FXbzrLsjkOrouNq+UdBIr7wRjIWTHHM0j+khb2swyCWNTbdv6Ce316Zqx2qWFg==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/label": "^3.7.14",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/slider": "^3.6.1",
+                "@react-types/shared": "^3.27.0",
+                "@react-types/slider": "^3.7.8",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/spinbutton": {
+            "version": "3.6.11",
+            "resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.6.11.tgz",
+            "integrity": "sha512-RM+gYS9tf9Wb+GegV18n4ArK3NBKgcsak7Nx1CkEgX9BjJ0yayWUHdfEjRRvxGXl+1z1n84cJVkZ6FUlWOWEZA==",
+            "dependencies": {
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/live-announcer": "^3.4.1",
+                "@react-aria/utils": "^3.27.0",
+                "@react-types/button": "^3.10.2",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/ssr": {
+            "version": "3.9.7",
+            "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.7.tgz",
+            "integrity": "sha512-GQygZaGlmYjmYM+tiNBA5C6acmiDWF52Nqd40bBp0Znk4M4hP+LTmI0lpI1BuKMw45T8RIhrAsICIfKwZvi2Gg==",
+            "dependencies": {
+                "@swc/helpers": "^0.5.0"
+            },
+            "engines": {
+                "node": ">= 12"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/switch": {
+            "version": "3.6.11",
+            "resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.6.11.tgz",
+            "integrity": "sha512-paYCpH+oeL+8rgQK+cBJ+IaZ1sXSh3+50WPlg2LvLBta0QVfQhPR4juPvfXRpfHHhCjFBgF4/RGbV8q5zpl3vA==",
+            "dependencies": {
+                "@react-aria/toggle": "^3.10.11",
+                "@react-stately/toggle": "^3.8.1",
+                "@react-types/shared": "^3.27.0",
+                "@react-types/switch": "^3.5.8",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/table": {
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.16.1.tgz",
+            "integrity": "sha512-T28TIGnKnPBunyErDBmm5jUX7AyzT7NVWBo9pDSt9wUuEnz0rVNd7p9sjmP2+u7I645feGG9klcdpCvFeqrk8A==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/grid": "^3.11.1",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/live-announcer": "^3.4.1",
+                "@react-aria/utils": "^3.27.0",
+                "@react-aria/visually-hidden": "^3.8.19",
+                "@react-stately/collections": "^3.12.1",
+                "@react-stately/flags": "^3.0.5",
+                "@react-stately/table": "^3.13.1",
+                "@react-types/checkbox": "^3.9.1",
+                "@react-types/grid": "^3.2.11",
+                "@react-types/shared": "^3.27.0",
+                "@react-types/table": "^3.10.4",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/tabs": {
+            "version": "3.9.9",
+            "resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.9.9.tgz",
+            "integrity": "sha512-oXPtANs16xu6MdMGLHjGV/2Zupvyp9CJEt7ORPLv5xAzSY5hSjuQHJLZ0te3Lh/KSG5/0o3RW/W5yEqo7pBQQQ==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/selection": "^3.22.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/tabs": "^3.7.1",
+                "@react-types/shared": "^3.27.0",
+                "@react-types/tabs": "^3.3.12",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/tag": {
+            "version": "3.4.9",
+            "resolved": "https://registry.npmjs.org/@react-aria/tag/-/tag-3.4.9.tgz",
+            "integrity": "sha512-Vnps+zk8vYyjevv2Bc6vc9kSp9HFLKrKUDmrWMc0DfseypwJMc3Ya6F965ZVTjF9nuWrojNmvgusNu7qyXFShQ==",
+            "dependencies": {
+                "@react-aria/gridlist": "^3.10.1",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/label": "^3.7.14",
+                "@react-aria/selection": "^3.22.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/list": "^3.11.2",
+                "@react-types/button": "^3.10.2",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/textfield": {
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.16.0.tgz",
+            "integrity": "sha512-53RVpMeMDN/QoabqnYZ1lxTh1xTQ3IBYQARuayq5EGGMafyxoFHzttxUdSqkZGK/+zdSF2GfmjOYJVm2nDKuDQ==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/form": "^3.0.12",
+                "@react-aria/label": "^3.7.14",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/form": "^3.1.1",
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/shared": "^3.27.0",
+                "@react-types/textfield": "^3.11.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/toggle": {
+            "version": "3.10.11",
+            "resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.10.11.tgz",
+            "integrity": "sha512-J3jO3KJiUbaYVDEpeXSBwqcyKxpi9OreiHRGiaxb6VwB+FWCj7Gb2WKajByXNyfs8jc6kX9VUFaXa7jze60oEQ==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/toggle": "^3.8.1",
+                "@react-types/checkbox": "^3.9.1",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/toolbar": {
+            "version": "3.0.0-beta.12",
+            "resolved": "https://registry.npmjs.org/@react-aria/toolbar/-/toolbar-3.0.0-beta.12.tgz",
+            "integrity": "sha512-a+Be27BtM2lzEdTzm19FikPbitfW65g/JZln3kyAvgpswhU6Ljl8lztaVw4ixjG4H0nqnKvVggMy4AlWwDUaVQ==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/utils": "^3.27.0",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/tooltip": {
+            "version": "3.7.11",
+            "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.7.11.tgz",
+            "integrity": "sha512-mhZgAWUj7bUWipDeJXaVPZdqnzoBCd/uaEbdafnvgETmov1udVqPTh9w4ZKX2Oh1wa2+OdLFrBOk+8vC6QbWag==",
+            "dependencies": {
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-stately/tooltip": "^3.5.1",
+                "@react-types/shared": "^3.27.0",
+                "@react-types/tooltip": "^3.4.14",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/utils": {
+            "version": "3.27.0",
+            "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.27.0.tgz",
+            "integrity": "sha512-p681OtApnKOdbeN8ITfnnYqfdHS0z7GE+4l8EXlfLnr70Rp/9xicBO6d2rU+V/B3JujDw2gPWxYKEnEeh0CGCw==",
+            "dependencies": {
+                "@react-aria/ssr": "^3.9.7",
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0",
+                "clsx": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-aria/visually-hidden": {
+            "version": "3.8.19",
+            "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.19.tgz",
+            "integrity": "sha512-MZgCCyQ3sdG94J5iJz7I7Ai3IxoN0U5d/+EaUnA1mfK7jf2fSYQBqi6Eyp8sWUYzBTLw4giXB5h0RGAnWzk9hA==",
+            "dependencies": {
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/utils": "^3.27.0",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/calendar": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.7.0.tgz",
+            "integrity": "sha512-N15zKubP2S7eWfPSJjKVlmJA7YpWzrIGx52BFhwLSQAZcV+OPcMgvOs71WtB7PLwl6DUYQGsgc0B3tcHzzvdvQ==",
+            "dependencies": {
+                "@internationalized/date": "^3.7.0",
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/calendar": "^3.6.0",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/checkbox": {
+            "version": "3.6.11",
+            "resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.6.11.tgz",
+            "integrity": "sha512-jApdBis+Q1sXLivg+f7krcVaP/AMMMiQcVqcz5gwxlweQN+dRZ/NpL0BYaDOuGc26Mp0lcuVaET3jIZeHwtyxA==",
+            "dependencies": {
+                "@react-stately/form": "^3.1.1",
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/checkbox": "^3.9.1",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/collections": {
+            "version": "3.12.1",
+            "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.1.tgz",
+            "integrity": "sha512-8QmFBL7f+P64dEP4o35pYH61/lP0T/ziSdZAvNMrCqaM+fXcMfUp2yu1E63kADVX7WRDsFJWE3CVMeqirPH6Xg==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/color": {
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@react-stately/color/-/color-3.8.2.tgz",
+            "integrity": "sha512-GXwLmv1Eos2OwOiRsGFrXBKx8+uZh2q0qzLZEVYrWsedNhIdTm7nnpwO68nCYZPHkqhv6rhhVSlOOFmDLY++ow==",
+            "dependencies": {
+                "@internationalized/number": "^3.6.0",
+                "@internationalized/string": "^3.2.5",
+                "@react-stately/form": "^3.1.1",
+                "@react-stately/numberfield": "^3.9.9",
+                "@react-stately/slider": "^3.6.1",
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/color": "^3.0.2",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/combobox": {
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.10.2.tgz",
+            "integrity": "sha512-uT642Dool4tQBh+8UQjlJnTisrJVtg3LqmiP/HqLQ4O3pW0O+ImbG+2r6c9dUzlAnH4kEfmEwCp9dxkBkmFWsg==",
+            "dependencies": {
+                "@react-stately/collections": "^3.12.1",
+                "@react-stately/form": "^3.1.1",
+                "@react-stately/list": "^3.11.2",
+                "@react-stately/overlays": "^3.6.13",
+                "@react-stately/select": "^3.6.10",
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/combobox": "^3.13.2",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/datepicker": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.12.0.tgz",
+            "integrity": "sha512-AfJEP36d+QgQ30GfacXtYdGsJvqY2yuCJ+JrjHct+m1nYuTkMvMMnhwNBFasgDJPLCDyHzyANlWkl2kQGfsBFw==",
+            "dependencies": {
+                "@internationalized/date": "^3.7.0",
+                "@internationalized/string": "^3.2.5",
+                "@react-stately/form": "^3.1.1",
+                "@react-stately/overlays": "^3.6.13",
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/datepicker": "^3.10.0",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/disclosure": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@react-stately/disclosure/-/disclosure-3.0.1.tgz",
+            "integrity": "sha512-afpNy5b0UcqRGjU/W5OD0xkx4PbymvhMrgQZ4o4OdtDVMMvr9T5UqMF8/j3J591DxgQfXM872tJu0kotqT0L6Q==",
+            "dependencies": {
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/dnd": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/@react-stately/dnd/-/dnd-3.5.1.tgz",
+            "integrity": "sha512-N18wt6fka9ngJJqxfAzmdtyrk9whAnqWUxZn22CatjNQsqukI4a6KRYwZTXM9x/wm7KamhVOp+GBl85zM8GLdA==",
+            "dependencies": {
+                "@react-stately/selection": "^3.19.0",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/flags": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.0.5.tgz",
+            "integrity": "sha512-6wks4csxUwPCp23LgJSnkBRhrWpd9jGd64DjcCTNB2AHIFu7Ab1W59pJpUL6TW7uAxVxdNKjgn6D1hlBy8qWsA==",
+            "dependencies": {
+                "@swc/helpers": "^0.5.0"
+            }
+        },
+        "node_modules/@react-stately/form": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.1.1.tgz",
+            "integrity": "sha512-qavrz5X5Mdf/Q1v/QJRxc0F8UTNEyRCNSM1we/nnF7GV64+aYSDLOtaRGmzq+09RSwo1c8ZYnIkK5CnwsPhTsQ==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/grid": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.10.1.tgz",
+            "integrity": "sha512-MOIy//AdxZxIXIzvWSKpvMvaPEMZGQNj+/cOsElHepv/Veh0psNURZMh2TP6Mr0+MnDTZbX+5XIeinGkWYO3JQ==",
+            "dependencies": {
+                "@react-stately/collections": "^3.12.1",
+                "@react-stately/selection": "^3.19.0",
+                "@react-types/grid": "^3.2.11",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/list": {
+            "version": "3.11.2",
+            "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.11.2.tgz",
+            "integrity": "sha512-eU2tY3aWj0SEeC7lH9AQoeAB4LL9mwS54FvTgHHoOgc1ZIwRJUaZoiuETyWQe98AL8KMgR1nrnDJ1I+CcT1Y7g==",
+            "dependencies": {
+                "@react-stately/collections": "^3.12.1",
+                "@react-stately/selection": "^3.19.0",
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/menu": {
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.9.1.tgz",
+            "integrity": "sha512-WRjGGImhQlQaer/hhahGytwd1BDq3fjpTkY/04wv3cQJPJR6lkVI5nSvGFMHfCaErsA1bNyB8/T9Y5F5u4u9ng==",
+            "dependencies": {
+                "@react-stately/overlays": "^3.6.13",
+                "@react-types/menu": "^3.9.14",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/numberfield": {
+            "version": "3.9.9",
+            "resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.9.9.tgz",
+            "integrity": "sha512-hZsLiGGHTHmffjFymbH1qVmA633rU2GNjMFQTuSsN4lqqaP8fgxngd5pPCoTCUFEkUgWjdHenw+ZFByw8lIE+g==",
+            "dependencies": {
+                "@internationalized/number": "^3.6.0",
+                "@react-stately/form": "^3.1.1",
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/numberfield": "^3.8.8",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/overlays": {
+            "version": "3.6.13",
+            "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.13.tgz",
+            "integrity": "sha512-WsU85Gf/b+HbWsnnYw7P/Ila3wD+C37Uk/WbU4/fHgJ26IEOWsPE6wlul8j54NZ1PnLNhV9Fn+Kffi+PaJMQXQ==",
+            "dependencies": {
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/overlays": "^3.8.12",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/radio": {
+            "version": "3.10.10",
+            "resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.10.10.tgz",
+            "integrity": "sha512-9x3bpq87uV8iYA4NaioTTWjriQSlSdp+Huqlxll0T3W3okpyraTTejE91PbIoRTUmL5qByIh2WzxYmr4QdBgAA==",
+            "dependencies": {
+                "@react-stately/form": "^3.1.1",
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/radio": "^3.8.6",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/searchfield": {
+            "version": "3.5.9",
+            "resolved": "https://registry.npmjs.org/@react-stately/searchfield/-/searchfield-3.5.9.tgz",
+            "integrity": "sha512-7/aO/oLJ4czKEji0taI/lbHKqPJRag9p3YmRaZ4yqjIMpKxzmJCWQcov5lzWeFhG/1hINKndYlxFnVIKV/urpg==",
+            "dependencies": {
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/searchfield": "^3.5.11",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/select": {
+            "version": "3.6.10",
+            "resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.6.10.tgz",
+            "integrity": "sha512-V7V0FCL9T+GzLjyfnJB6PUaKldFyT/8Rj6M+R9ura1A0O+s/FEOesy0pdMXFoL1l5zeUpGlCnhJrsI5HFWHfDw==",
+            "dependencies": {
+                "@react-stately/form": "^3.1.1",
+                "@react-stately/list": "^3.11.2",
+                "@react-stately/overlays": "^3.6.13",
+                "@react-types/select": "^3.9.9",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/selection": {
+            "version": "3.19.0",
+            "resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.19.0.tgz",
+            "integrity": "sha512-AvbUqnWjqVQC48RD39S9BpMKMLl55Zo5l/yx5JQFPl55cFwe9Tpku1KY0wzt3fXXiXWaqjDn/7Gkg1VJYy8esQ==",
+            "dependencies": {
+                "@react-stately/collections": "^3.12.1",
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/slider": {
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.6.1.tgz",
+            "integrity": "sha512-8kij5O82Xe233vZZ6qNGqPXidnlNQiSnyF1q613c7ktFmzAyGjkIWVUapHi23T1fqm7H2Rs3RWlmwE9bo2KecA==",
+            "dependencies": {
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/shared": "^3.27.0",
+                "@react-types/slider": "^3.7.8",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/table": {
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.13.1.tgz",
+            "integrity": "sha512-Im8W+F8o9EhglY5kqRa3xcMGXl8zBi6W5phGpAjXb+UGDL1tBIlAcYj733bw8g/ITCnaSz9ubsmON0HekPd6Jg==",
+            "dependencies": {
+                "@react-stately/collections": "^3.12.1",
+                "@react-stately/flags": "^3.0.5",
+                "@react-stately/grid": "^3.10.1",
+                "@react-stately/selection": "^3.19.0",
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/grid": "^3.2.11",
+                "@react-types/shared": "^3.27.0",
+                "@react-types/table": "^3.10.4",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/tabs": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.7.1.tgz",
+            "integrity": "sha512-gr9ACyuWrYuc727h7WaHdmNw8yxVlUyQlguziR94MdeRtFGQnf3V6fNQG3kxyB77Ljko69tgDF7Nf6kfPUPAQQ==",
+            "dependencies": {
+                "@react-stately/list": "^3.11.2",
+                "@react-types/shared": "^3.27.0",
+                "@react-types/tabs": "^3.3.12",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/toggle": {
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.8.1.tgz",
+            "integrity": "sha512-MVpe79ghVQiwLmVzIPhF/O/UJAUc9B+ZSylVTyJiEPi0cwhbkKGQv9thOF0ebkkRkace5lojASqUAYtSTZHQJA==",
+            "dependencies": {
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/checkbox": "^3.9.1",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/tooltip": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.1.tgz",
+            "integrity": "sha512-0aI3U5kB7Cop9OCW9/Bag04zkivFSdUcQgy/TWL4JtpXidVWmOha8txI1WySawFSjZhH83KIyPc+wKm1msfLMQ==",
+            "dependencies": {
+                "@react-stately/overlays": "^3.6.13",
+                "@react-types/tooltip": "^3.4.14",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/tree": {
+            "version": "3.8.7",
+            "resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.8.7.tgz",
+            "integrity": "sha512-hpc3pyuXWeQV5ufQ02AeNQg/MYhnzZ4NOznlY5OOUoPzpLYiI3ZJubiY3Dot4jw5N/LR7CqvDLHmrHaJPmZlHg==",
+            "dependencies": {
+                "@react-stately/collections": "^3.12.1",
+                "@react-stately/selection": "^3.19.0",
+                "@react-stately/utils": "^3.10.5",
+                "@react-types/shared": "^3.27.0",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-stately/utils": {
+            "version": "3.10.5",
+            "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.5.tgz",
+            "integrity": "sha512-iMQSGcpaecghDIh3mZEpZfoFH3ExBwTtuBEcvZ2XnGzCgQjeYXcMdIUwAfVQLXFTdHUHGF6Gu6/dFrYsCzySBQ==",
+            "dependencies": {
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/breadcrumbs": {
+            "version": "3.7.10",
+            "resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.7.10.tgz",
+            "integrity": "sha512-5HhRxkKHfAQBoyOYzyf4HT+24HgPE/C/QerxJLNNId303LXO03yeYrbvRqhYZSlD1ACLJW9OmpPpREcw5iSqgw==",
+            "dependencies": {
+                "@react-types/link": "^3.5.10",
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/button": {
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.10.2.tgz",
+            "integrity": "sha512-h8SB/BLoCgoBulCpyzaoZ+miKXrolK9XC48+n1dKJXT8g4gImrficurDW6+PRTQWaRai0Q0A6bu8UibZOU4syg==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/calendar": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.6.0.tgz",
+            "integrity": "sha512-BtFh4BFwvsYlsaSqUOVxlqXZSlJ6u4aozgO3PwHykhpemwidlzNwm9qDZhcMWPioNF/w2cU/6EqhvEKUHDnFZg==",
+            "dependencies": {
+                "@internationalized/date": "^3.7.0",
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/checkbox": {
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.9.1.tgz",
+            "integrity": "sha512-0x/KQcipfNM9Nvy6UMwYG25roRLvsiqf0J3woTYylNNWzF+72XT0iI5FdJkE3w2wfa0obmSoeq4WcbFREQrH/A==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/color": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@react-types/color/-/color-3.0.2.tgz",
+            "integrity": "sha512-4k9c0l5SACwTtkHV0dQ0GrF0Kktk/NChkxtyu58BamyUQOsCe8sqny+uul2nPrqQvuVof/dkRjKhv/DVyyx2mw==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0",
+                "@react-types/slider": "^3.7.8"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/combobox": {
+            "version": "3.13.2",
+            "resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.13.2.tgz",
+            "integrity": "sha512-yl2yMcM5/v3lJiNZWjpAhQ9vRW6dD55CD4rYmO2K7XvzYJaFVT4WYI/AymPYD8RqomMp7coBmBHfHW0oupk8gg==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/datepicker": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.10.0.tgz",
+            "integrity": "sha512-Att7y4NedNH1CogMDIX9URXgMLxGbZgnFCZ8oxgFAVndWzbh3TBcc4s7uoJDPvgRMAalq+z+SrlFFeoBeJmvvg==",
+            "dependencies": {
+                "@internationalized/date": "^3.7.0",
+                "@react-types/calendar": "^3.6.0",
+                "@react-types/overlays": "^3.8.12",
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/dialog": {
+            "version": "3.5.15",
+            "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.15.tgz",
+            "integrity": "sha512-BX1+mV35Oa0aIlhu98OzJaSB7uiCWDPQbr0AkpFBajSSlESUoAjntN+4N+QJmj24z2v6UE9zxGQ85/U/0Le+bw==",
+            "dependencies": {
+                "@react-types/overlays": "^3.8.12",
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/grid": {
+            "version": "3.2.11",
+            "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.2.11.tgz",
+            "integrity": "sha512-Mww9nrasppvPbsBi+uUqFnf7ya8fXN0cTVzDNG+SveD8mhW+sbtuy+gPtEpnFD2Oyi8qLuObefzt4gdekJX2Yw==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/link": {
+            "version": "3.5.10",
+            "resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.5.10.tgz",
+            "integrity": "sha512-IM2mbSpB0qP44Jh1Iqpevo7bQdZAr0iDyDi13OhsiUYJeWgPMHzGEnQqdBMkrfQeOTXLtZtUyOYLXE2v39bhzQ==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/listbox": {
+            "version": "3.5.4",
+            "resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.5.4.tgz",
+            "integrity": "sha512-5otTes0zOwRZwNtqysPD/aW4qFJSxd5znjwoWTLnzDXXOBHXPyR83IJf8ITgvIE5C0y+EFadsWR/BBO3k9Pj7g==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/menu": {
+            "version": "3.9.14",
+            "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.9.14.tgz",
+            "integrity": "sha512-RJW/S8IPwbRuohJ/A9HJ7W8QaAY816tm7Nv6+H/TLXG76zu2AS5vEgq+0TcCAWvJJwUdLDpJWJMlo0iIoIBtcg==",
+            "dependencies": {
+                "@react-types/overlays": "^3.8.12",
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/meter": {
+            "version": "3.4.6",
+            "resolved": "https://registry.npmjs.org/@react-types/meter/-/meter-3.4.6.tgz",
+            "integrity": "sha512-YczAht1VXy3s4fR6Dq0ibGsjulGHzS/A/K4tOruSNTL6EkYH9ktHX62Xk/OhCiKHxV315EbZ136WJaCeO4BgHw==",
+            "dependencies": {
+                "@react-types/progress": "^3.5.9"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/numberfield": {
+            "version": "3.8.8",
+            "resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.8.8.tgz",
+            "integrity": "sha512-825JPppxDaWh0Zxb0Q+wSslgRQYOtQPCAuhszPuWEy6d2F/M+hLR+qQqvQm9+LfMbdwiTg6QK5wxdWFCp2t7jw==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/overlays": {
+            "version": "3.8.12",
+            "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.12.tgz",
+            "integrity": "sha512-ZvR1t0YV7/6j+6OD8VozKYjvsXT92+C/2LOIKozy7YUNS5KI4MkXbRZzJvkuRECVZOmx8JXKTUzhghWJM/3QuQ==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/progress": {
+            "version": "3.5.9",
+            "resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.5.9.tgz",
+            "integrity": "sha512-zFxOzx3G8XUmHgpm037Hcayls5bqzXVa182E3iM7YWTmrjxJPKZ58XL0WWBgpTd+mJD7fTpnFdAZqSmFbtDOdA==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/radio": {
+            "version": "3.8.6",
+            "resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.8.6.tgz",
+            "integrity": "sha512-woTQYdRFjPzuml4qcIf+2zmycRuM5w3fDS5vk6CQmComVUjOFPtD28zX3Z9kc9lSNzaBQz9ONZfFqkZ1gqfICA==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/searchfield": {
+            "version": "3.5.11",
+            "resolved": "https://registry.npmjs.org/@react-types/searchfield/-/searchfield-3.5.11.tgz",
+            "integrity": "sha512-MX8d9pgvxZxmgDwI0tiDaf6ijOY8XcRj0HM8Ocfttlk7PEFJK44p51WsUC+fPX1GmZni2JpFkx/haPOSLUECdw==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0",
+                "@react-types/textfield": "^3.11.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/select": {
+            "version": "3.9.9",
+            "resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.9.9.tgz",
+            "integrity": "sha512-/hCd0o+ztn29FKCmVec+v7t4JpOzz56o+KrG7NDq2pcRWqUR9kNwCjrPhSbJIIEDm4ubtrfPu41ysIuDvRd2Bg==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/shared": {
+            "version": "3.27.0",
+            "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.27.0.tgz",
+            "integrity": "sha512-gvznmLhi6JPEf0bsq7SwRYTHAKKq/wcmKqFez9sRdbED+SPMUmK5omfZ6w3EwUFQHbYUa4zPBYedQ7Knv70RMw==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/slider": {
+            "version": "3.7.8",
+            "resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.7.8.tgz",
+            "integrity": "sha512-utW1o9KT70hqFwu1zqMtyEWmP0kSATk4yx+Fm/peSR4iZa+BasRqH83yzir5GKc8OfqfE1kmEsSlO98/k986+w==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/switch": {
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.5.8.tgz",
+            "integrity": "sha512-sL7jmh8llF8BxzY4HXkSU4bwU8YU6gx45P85D0AdYXgRHxU9Cp7BQPOMF4pJoQ8TTej05MymY5q7xvJVmxUTAQ==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/table": {
+            "version": "3.10.4",
+            "resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.10.4.tgz",
+            "integrity": "sha512-d0tLz/whxVteqr1rophtuuxqyknHHfTKeXrCgDjt8pAyd9U8GPDbfcFSfYPUhWdELRt7aLVyQw6VblZHioVEgQ==",
+            "dependencies": {
+                "@react-types/grid": "^3.2.11",
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/tabs": {
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.3.12.tgz",
+            "integrity": "sha512-E9O9G+wf9kaQ8UbDEDliW/oxYlJnh7oDCW1zaMOySwnG4yeCh7Wu02EOCvlQW4xvgn/i+lbEWgirf7L+yj5nRg==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/textfield": {
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.11.0.tgz",
+            "integrity": "sha512-YORBgr6wlu2xfvr4MqjKFHGpj+z8LBzk14FbWDbYnnhGnv0I10pj+m2KeOHgDNFHrfkDdDOQmMIKn1UCqeUuEg==",
+            "dependencies": {
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
+        "node_modules/@react-types/tooltip": {
+            "version": "3.4.14",
+            "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.4.14.tgz",
+            "integrity": "sha512-J7CeYL2yPeKIasx1rPaEefyCHGEx2DOCx+7bM3XcKGmCxvNdVQLjimNJOt8IHlUA0nFJQOjmSW/mz9P0f2/kUw==",
+            "dependencies": {
+                "@react-types/overlays": "^3.8.12",
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
         "node_modules/@reduxjs/toolkit": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.3.0.tgz",
@@ -8263,6 +9900,14 @@
             "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
             "dev": true
         },
+        "node_modules/@swc/helpers": {
+            "version": "0.5.15",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+            "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+            "dependencies": {
+                "tslib": "^2.8.0"
+            }
+        },
         "node_modules/@swc/jest": {
             "version": "0.2.29",
             "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.29.tgz",
@@ -8286,6 +9931,31 @@
             "dev": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3"
+            }
+        },
+        "node_modules/@tanstack/react-virtual": {
+            "version": "3.10.8",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.10.8.tgz",
+            "integrity": "sha512-VbzbVGSsZlQktyLrP5nxE+vE1ZR+U0NFAWPbJLoG2+DKPwd2D7dVICTVIIaYlJqX1ZCEnYDbaOpmMwbsyhBoIA==",
+            "dependencies": {
+                "@tanstack/virtual-core": "3.10.8"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@tanstack/virtual-core": {
+            "version": "3.10.8",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.10.8.tgz",
+            "integrity": "sha512-PBu00mtt95jbKFi6Llk9aik8bnR3tR/oQP1o3TSi+iG//+Q2RTIzCEgKkHG8BB86kxMNW6O8wku+Lmi+QFR6jA==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
             }
         },
         "node_modules/@testing-library/dom": {
@@ -13050,6 +14720,11 @@
                 "url": "https://www.patreon.com/infusion"
             }
         },
+        "node_modules/compute-scroll-into-view": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+            "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -14834,6 +16509,26 @@
             "funding": {
                 "url": "https://dotenvx.com"
             }
+        },
+        "node_modules/downshift": {
+            "version": "9.0.8",
+            "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.0.8.tgz",
+            "integrity": "sha512-59BWD7+hSUQIM1DeNPLirNNnZIO9qMdIK5GQ/Uo8q34gT4B78RBlb9dhzgnh0HfQTJj4T/JKYD8KoLAlMWnTsA==",
+            "dependencies": {
+                "@babel/runtime": "^7.24.5",
+                "compute-scroll-into-view": "^3.1.0",
+                "prop-types": "^15.8.1",
+                "react-is": "18.2.0",
+                "tslib": "^2.6.2"
+            },
+            "peerDependencies": {
+                "react": ">=16.12.0"
+            }
+        },
+        "node_modules/downshift/node_modules/react-is": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         },
         "node_modules/draco3d": {
             "version": "1.5.7",
@@ -18555,6 +20250,17 @@
             "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/intl-messageformat": {
+            "version": "10.7.14",
+            "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.14.tgz",
+            "integrity": "sha512-mMGnE4E1otdEutV5vLUdCxRJygHB5ozUBxsPB5qhitewssrS/qGruq9bmvIRkkGsNeK5ZWLfYRld18UHGTIifQ==",
+            "dependencies": {
+                "@formatjs/ecma402-abstract": "2.3.2",
+                "@formatjs/fast-memoize": "2.2.6",
+                "@formatjs/icu-messageformat-parser": "2.11.0",
+                "tslib": "2"
             }
         },
         "node_modules/into-stream": {
@@ -29769,6 +31475,56 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/react-aria": {
+            "version": "3.37.0",
+            "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.37.0.tgz",
+            "integrity": "sha512-u3WUEMTcbQFaoHauHO3KhPaBYzEv1o42EdPcLAs05GBw9Q6Axlqwo73UFgMrsc2ElwLAZ4EKpSdWHLo1R5gfiw==",
+            "dependencies": {
+                "@internationalized/string": "^3.2.5",
+                "@react-aria/breadcrumbs": "^3.5.20",
+                "@react-aria/button": "^3.11.1",
+                "@react-aria/calendar": "^3.7.0",
+                "@react-aria/checkbox": "^3.15.1",
+                "@react-aria/color": "^3.0.3",
+                "@react-aria/combobox": "^3.11.1",
+                "@react-aria/datepicker": "^3.13.0",
+                "@react-aria/dialog": "^3.5.21",
+                "@react-aria/disclosure": "^3.0.1",
+                "@react-aria/dnd": "^3.8.1",
+                "@react-aria/focus": "^3.19.1",
+                "@react-aria/gridlist": "^3.10.1",
+                "@react-aria/i18n": "^3.12.5",
+                "@react-aria/interactions": "^3.23.0",
+                "@react-aria/label": "^3.7.14",
+                "@react-aria/link": "^3.7.8",
+                "@react-aria/listbox": "^3.14.0",
+                "@react-aria/menu": "^3.17.0",
+                "@react-aria/meter": "^3.4.19",
+                "@react-aria/numberfield": "^3.11.10",
+                "@react-aria/overlays": "^3.25.0",
+                "@react-aria/progress": "^3.4.19",
+                "@react-aria/radio": "^3.10.11",
+                "@react-aria/searchfield": "^3.8.0",
+                "@react-aria/select": "^3.15.1",
+                "@react-aria/selection": "^3.22.0",
+                "@react-aria/separator": "^3.4.5",
+                "@react-aria/slider": "^3.7.15",
+                "@react-aria/ssr": "^3.9.7",
+                "@react-aria/switch": "^3.6.11",
+                "@react-aria/table": "^3.16.1",
+                "@react-aria/tabs": "^3.9.9",
+                "@react-aria/tag": "^3.4.9",
+                "@react-aria/textfield": "^3.16.0",
+                "@react-aria/tooltip": "^3.7.11",
+                "@react-aria/utils": "^3.27.0",
+                "@react-aria/visually-hidden": "^3.8.19",
+                "@react-types/shared": "^3.27.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+                "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
         "node_modules/react-color": {
             "version": "2.19.3",
             "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
@@ -33250,9 +35006,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/tunnel": {
             "version": "0.0.6",
@@ -35165,7 +36921,7 @@
                 "@deck.gl/mesh-layers": "9.0.40",
                 "@deck.gl/react": "9.0.40",
                 "@emerson-eps/color-tables": "^0.4.85",
-                "@equinor/eds-core-react": "^0.36.0",
+                "@equinor/eds-core-react": "^0.42.5",
                 "@equinor/eds-icons": "^0.21.0",
                 "@turf/simplify": "^7.1.0",
                 "@vivaxy/png": "^1.3.0",
@@ -35203,29 +36959,6 @@
                 }
             }
         },
-        "packages/subsurface-viewer/node_modules/@equinor/eds-core-react": {
-            "version": "0.36.1",
-            "resolved": "https://registry.npmjs.org/@equinor/eds-core-react/-/eds-core-react-0.36.1.tgz",
-            "integrity": "sha512-cFpmsT4+EEFDhGE1DLNDT9Scr6SNBF4xnIfAgkMZcK6wmmZZT30lV2zdGgFC1JN9FfyvlisQukgpurynuBoJTw==",
-            "dependencies": {
-                "@babel/runtime": "^7.24.0",
-                "@equinor/eds-icons": "^0.21.0",
-                "@equinor/eds-tokens": "0.9.2",
-                "@equinor/eds-utils": "0.8.4",
-                "@floating-ui/react": "^0.26.9",
-                "@tanstack/react-virtual": "3.1.3",
-                "downshift": "8.3.3"
-            },
-            "engines": {
-                "node": ">=10.0.0",
-                "pnpm": ">=4"
-            },
-            "peerDependencies": {
-                "react": ">=16.8",
-                "react-dom": ">=16.8",
-                "styled-components": ">=4.2"
-            }
-        },
         "packages/subsurface-viewer/node_modules/@equinor/eds-icons": {
             "version": "0.21.0",
             "resolved": "https://registry.npmjs.org/@equinor/eds-icons/-/eds-icons-0.21.0.tgz",
@@ -35235,92 +36968,6 @@
                 "pnpm": ">=4"
             }
         },
-        "packages/subsurface-viewer/node_modules/@equinor/eds-tokens": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@equinor/eds-tokens/-/eds-tokens-0.9.2.tgz",
-            "integrity": "sha512-pDIFei0vsfN3GN12NKWqxskAkYBQd6+Dzjga2liuY81LfnlJs5g9NblamU9WY5w5YdVE5Z8FNjsMKDLs2JIWcw==",
-            "engines": {
-                "node": ">=10.0.0",
-                "pnpm": ">=4"
-            }
-        },
-        "packages/subsurface-viewer/node_modules/@equinor/eds-utils": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/@equinor/eds-utils/-/eds-utils-0.8.4.tgz",
-            "integrity": "sha512-njvqXd3Hzfy5vkEqnx+uEBAu00vnG/5R+gDgWCReVDjjUoHdQNcrqfjBLsGF2UungtO0LbYV8YuBP+9l4V7ywQ==",
-            "dependencies": {
-                "@babel/runtime": "^7.23.8",
-                "@equinor/eds-tokens": "0.9.2"
-            },
-            "engines": {
-                "node": ">=10.0.0",
-                "pnpm": ">=4"
-            },
-            "peerDependencies": {
-                "react": ">=16.8",
-                "react-dom": ">=16.8",
-                "styled-components": ">=4.2"
-            }
-        },
-        "packages/subsurface-viewer/node_modules/@floating-ui/react": {
-            "version": "0.26.16",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.16.tgz",
-            "integrity": "sha512-HEf43zxZNAI/E781QIVpYSF3K2VH4TTYZpqecjdsFkjsaU1EbaWcM++kw0HXFffj7gDUcBFevX8s0rQGQpxkow==",
-            "dependencies": {
-                "@floating-ui/react-dom": "^2.1.0",
-                "@floating-ui/utils": "^0.2.0",
-                "tabbable": "^6.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=16.8.0",
-                "react-dom": ">=16.8.0"
-            }
-        },
-        "packages/subsurface-viewer/node_modules/@tanstack/react-virtual": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.1.3.tgz",
-            "integrity": "sha512-YCzcbF/Ws/uZ0q3Z6fagH+JVhx4JLvbSflgldMgLsuvB8aXjZLLb3HvrEVxY480F9wFlBiXlvQxOyXb5ENPrNA==",
-            "dependencies": {
-                "@tanstack/virtual-core": "3.1.3"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/tannerlinsley"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-            }
-        },
-        "packages/subsurface-viewer/node_modules/@tanstack/virtual-core": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.1.3.tgz",
-            "integrity": "sha512-Y5B4EYyv1j9V8LzeAoOVeTg0LI7Fo5InYKgAjkY1Pu9GjtUwX/EKxNcU7ng3sKr99WEf+bPTcktAeybyMOYo+g==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/tannerlinsley"
-            }
-        },
-        "packages/subsurface-viewer/node_modules/compute-scroll-into-view": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
-            "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg=="
-        },
-        "packages/subsurface-viewer/node_modules/downshift": {
-            "version": "8.3.3",
-            "resolved": "https://registry.npmjs.org/downshift/-/downshift-8.3.3.tgz",
-            "integrity": "sha512-f9znQFYF/3AWBkFiEc4H05Vdh41XFgJ80IatLBKIFoA3p86mAXc/iM9/XJ24loF9djtABD5NBEYL7b1b7xh2pw==",
-            "dependencies": {
-                "@babel/runtime": "^7.22.15",
-                "compute-scroll-into-view": "^3.0.3",
-                "prop-types": "^15.8.1",
-                "react-is": "^18.2.0",
-                "tslib": "^2.6.2"
-            },
-            "peerDependencies": {
-                "react": ">=16.12.0"
-            }
-        },
         "packages/subsurface-viewer/node_modules/math.gl": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-4.0.1.tgz",
@@ -35328,11 +36975,6 @@
             "dependencies": {
                 "@math.gl/core": "4.0.1"
             }
-        },
-        "packages/subsurface-viewer/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
         },
         "packages/subsurface-viewer/node_modules/react-redux": {
             "version": "9.1.2",

--- a/typescript/packages/subsurface-viewer/jest.config.js
+++ b/typescript/packages/subsurface-viewer/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('jest').Config} */
 
 const config = {
+    setupFilesAfterEnv: ["./jest.setup.ts"],
     preset: "../../jest.config.js",
 };
 

--- a/typescript/packages/subsurface-viewer/jest.setup.ts
+++ b/typescript/packages/subsurface-viewer/jest.setup.ts
@@ -1,0 +1,2 @@
+HTMLElement.prototype.showPopover = jest.fn();
+HTMLElement.prototype.hidePopover = jest.fn();

--- a/typescript/packages/subsurface-viewer/package.json
+++ b/typescript/packages/subsurface-viewer/package.json
@@ -42,7 +42,7 @@
         "@deck.gl/mesh-layers": "9.0.40",
         "@deck.gl/react": "9.0.40",
         "@emerson-eps/color-tables": "^0.4.85",
-        "@equinor/eds-core-react": "^0.36.0",
+        "@equinor/eds-core-react": "^0.42.5",
         "@equinor/eds-icons": "^0.21.0",
         "@turf/simplify": "^7.1.0",
         "@vivaxy/png": "^1.3.0",

--- a/typescript/packages/subsurface-viewer/src/components/__snapshots__/InfoCard.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/__snapshots__/InfoCard.test.tsx.snap
@@ -51,15 +51,6 @@ exports[`Test Info Card snapshot test when property value provided 1`] = `
   justify-self: center;
 }
 
-.c0::before {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: auto;
-  min-height: auto;
-  content: '';
-}
-
 .c0::after {
   position: absolute;
   top: -7px;
@@ -417,15 +408,6 @@ exports[`Test Info Card snapshot test with no props 1`] = `
 
 .c0 svg {
   justify-self: center;
-}
-
-.c0::before {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: auto;
-  min-height: auto;
-  content: '';
 }
 
 .c0::after {

--- a/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/DrawModeSelector.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/DrawModeSelector.test.tsx.snap
@@ -10,6 +10,10 @@ exports[`Test draw-mode menu snapshot test 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
   position: relative;
   margin: 0;
   color: var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));

--- a/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/LayerProperty.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/LayerProperty.test.tsx.snap
@@ -10,6 +10,10 @@ exports[`Test Layer Property snapshot test 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
   position: relative;
   margin: 0;
   color: var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));

--- a/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/LayerSettingsButton.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/LayerSettingsButton.test.tsx.snap
@@ -1,10 +1,147 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`test layers settings button snapshot test 1`] = `
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  position: relative;
+  margin: 0;
+  color: var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));
+  font-family: Equinor;
+  font-size: 0.750rem;
+  font-weight: 500;
+  line-height: 1.333em;
+  text-align: left;
+  margin-left: 8px;
+  margin-right: 8px;
+  color: var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));
+}
+
+.c7 {
+  margin: 0;
+}
+
 .c0 {
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
+}
+
+.c2 {
+  background: var(--eds_ui_background__default,rgba(255,255,255,1));
+  box-shadow: 0 1px 5px rgba(0,0,0,0.2),0 3px 4px rgba(0,0,0,0.12),0 2px 4px rgba(0,0,0,0.14);
+}
+
+.c4 {
+  position: relative;
+  list-style: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin: 0;
+  padding-left: 0px;
+  padding-top: 8px;
+  padding-right: 0px;
+  padding-bottom: 8px;
+}
+
+.c4 li:first-child {
+  z-index: 3;
+}
+
+.c3 {
+  width: 100%;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  border-radius: 4px;
+}
+
+.c1 {
+  inset: unset;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  background-color: transparent;
+}
+
+.c1::backdrop {
+  background-color: transparent;
+}
+
+.c5 {
+  min-width: 100px;
+  width: 100%;
+}
+
+.c8 {
+  border: none;
+  border-radius: 0;
+  box-shadow: inset 0 -1px 0 0 var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));
+  margin: 0;
+  color: var(--eds_text__static_icons__default,rgba(61,61,61,1));
+  font-family: Equinor;
+  font-size: 1.000rem;
+  font-weight: 400;
+  line-height: 1.500em;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-align: left;
+  padding-left: 8px;
+  padding-top: 6px;
+  padding-right: 8px;
+  padding-bottom: 6px;
+  padding-right: calc(8px *2 + 24px);
+  display: block;
+  margin: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%236f6f6f' d='M7 9.5l5 5 5-5H7z'/%3E%3C/svg%3E"),linear-gradient( to bottom,var(--eds_ui_background__light,rgba(247,247,247,1)) 0%,var(--eds_ui_background__light,rgba(247,247,247,1)) 100% );
+  background-repeat: no-repeat,repeat;
+  background-position: right 8px top 50%;
+  width: 100%;
+}
+
+.c8:active,
+.c8:focus {
+  box-shadow: none;
+  outline: 2px solid var(--eds_interactive_primary__resting,rgba(0,112,121,1));
+  outline-offset: 0px;
+}
+
+.c8:disabled {
+  color: var(--eds_interactive__disabled__text,rgba(190,190,190,1));
+  background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%23bebebe' d='M7 9.5l5 5 5-5H7z'/%3E%3C/svg%3E"),linear-gradient( to bottom,var(--eds_ui_background__light,rgba(247,247,247,1)) 0%,var(--eds_ui_background__light,rgba(247,247,247,1)) 100% );
+  cursor: not-allowed;
+  box-shadow: none;
+  outline: none;
+}
+
+.c8:disabled .arrow-icon {
+  fill: red;
+}
+
+.c8:disabled:focus,
+.c8:disabled:active {
+  outline: none;
 }
 
 <div
@@ -37,5 +174,57 @@ exports[`test layers settings button snapshot test 1`] = `
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
+  <div
+    class="c1"
+    data-floating-ui-focusable=""
+    popover="manual"
+    style="position: absolute; top: 0px; left: 0px;"
+    tabindex="-1"
+  >
+    <div
+      class="c2 c3 LayerSettingsButton-menu"
+    >
+      <div
+        aria-labelledby="drawing-layer-button"
+        class="c4"
+        role="menu"
+      >
+        <div
+          class="c5"
+        >
+          <label
+            class="c6"
+            for="drawing-layer-mode-selector"
+          >
+            <span
+              class="c7"
+            >
+              Draw mode
+            </span>
+          </label>
+          <select
+            class="c8"
+            id="drawing-layer-mode-selector"
+          >
+            <option>
+              View
+            </option>
+            <option>
+              Edit
+            </option>
+            <option>
+              Create point
+            </option>
+            <option>
+              Create polyline
+            </option>
+            <option>
+              Create polygon
+            </option>
+          </select>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/LayersButton.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/LayersButton.test.tsx.snap
@@ -1,10 +1,188 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`test 'layers' button snapshot test 1`] = `
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  position: relative;
+  margin: 0;
+  color: var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));
+  font-family: Equinor;
+  font-size: 0.750rem;
+  font-weight: 500;
+  line-height: 1.333em;
+  text-align: left;
+  margin-left: 8px;
+  margin-right: 8px;
+  color: var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));
+}
+
+.c6 {
+  margin: 0;
+}
+
 .c0 {
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
+}
+
+.c2 {
+  background: var(--eds_ui_background__default,rgba(255,255,255,1));
+  box-shadow: 0 1px 5px rgba(0,0,0,0.2),0 3px 4px rgba(0,0,0,0.12),0 2px 4px rgba(0,0,0,0.14);
+}
+
+.c4 {
+  position: relative;
+  list-style: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin: 0;
+  padding-left: 0px;
+  padding-top: 8px;
+  padding-right: 0px;
+  padding-bottom: 8px;
+}
+
+.c4 li:first-child {
+  z-index: 3;
+}
+
+.c3 {
+  width: 100%;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  border-radius: 4px;
+}
+
+.c1 {
+  inset: unset;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  background-color: transparent;
+}
+
+.c1::backdrop {
+  background-color: transparent;
+}
+
+.c10 {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  position: relative;
+  grid-area: input;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 100%;
+  grid-area: input;
+  margin: 0;
+  position: relative;
+  z-index: 1;
+  cursor: pointer;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8[data-focus-visible-added]:focus + span {
+  outline: 2px dashed var(--eds_interactive__focus,rgba(0,112,121,1));
+  outline-offset: 0px;
+}
+
+.c8:focus-visible + span {
+  outline: 2px dashed var(--eds_interactive__focus,rgba(0,112,121,1));
+  outline-offset: 0px;
+}
+
+.c7 {
+  display: inline-grid;
+  vertical-align: middle;
+  grid: [input] 1fr / [input] 1fr;
+  place-items: center;
+  isolation: isolate;
+}
+
+.c9 {
+  width: 48px;
+  aspect-ratio: 1/1;
+}
+
+.c9:checked + span > span {
+  background-color: var(--eds_interactive_primary__selected_highlight,rgba(230,250,236,1));
+}
+
+.c9:checked + span > span:last-child {
+  -webkit-transform: translate(105%,-50%);
+  -ms-transform: translate(105%,-50%);
+  transform: translate(105%,-50%);
+  background-color: var(--eds_interactive_primary__resting,rgba(0,112,121,1));
+}
+
+.c9:hover + span {
+  background-color: var(--eds_interactive_primary__hover_alt,rgba(222,237,238,1));
+}
+
+.c9:hover + span > span:last-child {
+  background-color: var(--eds_interactive_primary__hover,rgba(0,79,85,1));
+}
+
+.c11 {
+  border-radius: 4px;
+  border: none;
+  width: 32px;
+  height: 8px;
+  background-color: var(--eds_ui_background__medium,rgba(220,220,220,1));
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  -webkit-transition: background 0.36s;
+  transition: background 0.36s;
+}
+
+.c12 {
+  background-color: var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));
+  box-shadow: 0 1px 5px rgba(0,0,0,0.2),0 3px 4px rgba(0,0,0,0.12),0 2px 4px rgba(0,0,0,0.14);
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  display: inline-block;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translate(0,-50%);
+  -ms-transform: translate(0,-50%);
+  transform: translate(0,-50%);
+  left: 4px;
+  -webkit-transition: -webkit-transform 0.36s cubic-bezier(0.78,0.14,0.15,0.86);
+  -webkit-transition: transform 0.36s cubic-bezier(0.78,0.14,0.15,0.86);
+  transition: transform 0.36s cubic-bezier(0.78,0.14,0.15,0.86);
 }
 
 <div
@@ -38,14 +216,443 @@ exports[`test 'layers' button snapshot test 1`] = `
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
+  <div
+    class="c1"
+    data-floating-ui-focusable=""
+    popover="manual"
+    style="position: absolute; top: 0px; left: 0px;"
+    tabindex="-1"
+  >
+    <div
+      class="c2 c3 LayersButton-root"
+    >
+      <div
+        aria-labelledby="layers-selector-button"
+        class="c4"
+        id="layers-selector"
+        role="menu"
+      >
+        <div
+          style="display: flex; justify-content: space-between;"
+        >
+          <label
+            class="c5"
+            id="undefined-switch-label"
+            style="padding-top: 15px; font-size: 15px;"
+          >
+            <span
+              class="c6"
+            />
+          </label>
+          <span
+            class="c7"
+            style="padding-right: 10px; width: 3rem;"
+          >
+            <input
+              class="c8 c9"
+              id="undefined-switch"
+              type="checkbox"
+            />
+            <span
+              class="c10"
+            >
+              <span
+                class="c11"
+              />
+              <span
+                class="c12"
+              />
+            </span>
+          </span>
+        </div>
+        <div
+          style="display: flex; justify-content: space-between;"
+        >
+          <label
+            class="c5"
+            id="undefined-switch-label"
+            style="padding-top: 15px; font-size: 15px;"
+          >
+            <span
+              class="c6"
+            />
+          </label>
+          <span
+            class="c7"
+            style="padding-right: 10px; width: 3rem;"
+          >
+            <input
+              checked=""
+              class="c8 c9"
+              id="undefined-switch"
+              type="checkbox"
+            />
+            <span
+              class="c10"
+            >
+              <span
+                class="c11"
+              />
+              <span
+                class="c12"
+              />
+            </span>
+          </span>
+        </div>
+        <div
+          style="display: flex; justify-content: space-between;"
+        >
+          <label
+            class="c5"
+            id="undefined-switch-label"
+            style="padding-top: 15px; font-size: 15px;"
+          >
+            <span
+              class="c6"
+            />
+          </label>
+          <span
+            class="c7"
+            style="padding-right: 10px; width: 3rem;"
+          >
+            <input
+              class="c8 c9"
+              id="undefined-switch"
+              type="checkbox"
+            />
+            <span
+              class="c10"
+            >
+              <span
+                class="c11"
+              />
+              <span
+                class="c12"
+              />
+            </span>
+          </span>
+        </div>
+        <div
+          style="display: flex; justify-content: space-between;"
+        >
+          <label
+            class="c5"
+            id="undefined-switch-label"
+            style="padding-top: 15px; font-size: 15px;"
+          >
+            <span
+              class="c6"
+            />
+          </label>
+          <span
+            class="c7"
+            style="padding-right: 10px; width: 3rem;"
+          >
+            <input
+              class="c8 c9"
+              id="undefined-switch"
+              type="checkbox"
+            />
+            <span
+              class="c10"
+            >
+              <span
+                class="c11"
+              />
+              <span
+                class="c12"
+              />
+            </span>
+          </span>
+        </div>
+        <div
+          style="display: flex; justify-content: space-between;"
+        >
+          <label
+            class="c5"
+            id="undefined-switch-label"
+            style="padding-top: 15px; font-size: 15px;"
+          >
+            <span
+              class="c6"
+            />
+          </label>
+          <span
+            class="c7"
+            style="padding-right: 10px; width: 3rem;"
+          >
+            <input
+              class="c8 c9"
+              id="undefined-switch"
+              type="checkbox"
+            />
+            <span
+              class="c10"
+            >
+              <span
+                class="c11"
+              />
+              <span
+                class="c12"
+              />
+            </span>
+          </span>
+        </div>
+        <div
+          style="display: flex; justify-content: space-between;"
+        >
+          <label
+            class="c5"
+            id="undefined-switch-label"
+            style="padding-top: 15px; font-size: 15px;"
+          >
+            <span
+              class="c6"
+            />
+          </label>
+          <span
+            class="c7"
+            style="padding-right: 10px; width: 3rem;"
+          >
+            <input
+              class="c8 c9"
+              id="undefined-switch"
+              type="checkbox"
+            />
+            <span
+              class="c10"
+            >
+              <span
+                class="c11"
+              />
+              <span
+                class="c12"
+              />
+            </span>
+          </span>
+        </div>
+        <div
+          style="display: flex; justify-content: space-between;"
+        >
+          <label
+            class="c5"
+            id="undefined-switch-label"
+            style="padding-top: 15px; font-size: 15px;"
+          >
+            <span
+              class="c6"
+            />
+          </label>
+          <span
+            class="c7"
+            style="padding-right: 10px; width: 3rem;"
+          >
+            <input
+              class="c8 c9"
+              id="undefined-switch"
+              type="checkbox"
+            />
+            <span
+              class="c10"
+            >
+              <span
+                class="c11"
+              />
+              <span
+                class="c12"
+              />
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`test 'layers' button test empty MapState/specbase 1`] = `
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  position: relative;
+  margin: 0;
+  color: var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));
+  font-family: Equinor;
+  font-size: 0.750rem;
+  font-weight: 500;
+  line-height: 1.333em;
+  text-align: left;
+  margin-left: 8px;
+  margin-right: 8px;
+  color: var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));
+}
+
+.c6 {
+  margin: 0;
+}
+
 .c0 {
   -webkit-transform: none;
   -ms-transform: none;
   transform: none;
+}
+
+.c2 {
+  background: var(--eds_ui_background__default,rgba(255,255,255,1));
+  box-shadow: 0 1px 5px rgba(0,0,0,0.2),0 3px 4px rgba(0,0,0,0.12),0 2px 4px rgba(0,0,0,0.14);
+}
+
+.c4 {
+  position: relative;
+  list-style: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin: 0;
+  padding-left: 0px;
+  padding-top: 8px;
+  padding-right: 0px;
+  padding-bottom: 8px;
+}
+
+.c4 li:first-child {
+  z-index: 3;
+}
+
+.c3 {
+  width: 100%;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  border-radius: 4px;
+}
+
+.c1 {
+  inset: unset;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  background-color: transparent;
+}
+
+.c1::backdrop {
+  background-color: transparent;
+}
+
+.c10 {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  position: relative;
+  grid-area: input;
+}
+
+.c8 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 100%;
+  grid-area: input;
+  margin: 0;
+  position: relative;
+  z-index: 1;
+  cursor: pointer;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+.c8[data-focus-visible-added]:focus + span {
+  outline: 2px dashed var(--eds_interactive__focus,rgba(0,112,121,1));
+  outline-offset: 0px;
+}
+
+.c8:focus-visible + span {
+  outline: 2px dashed var(--eds_interactive__focus,rgba(0,112,121,1));
+  outline-offset: 0px;
+}
+
+.c7 {
+  display: inline-grid;
+  vertical-align: middle;
+  grid: [input] 1fr / [input] 1fr;
+  place-items: center;
+  isolation: isolate;
+}
+
+.c9 {
+  width: 48px;
+  aspect-ratio: 1/1;
+}
+
+.c9:checked + span > span {
+  background-color: var(--eds_interactive_primary__selected_highlight,rgba(230,250,236,1));
+}
+
+.c9:checked + span > span:last-child {
+  -webkit-transform: translate(105%,-50%);
+  -ms-transform: translate(105%,-50%);
+  transform: translate(105%,-50%);
+  background-color: var(--eds_interactive_primary__resting,rgba(0,112,121,1));
+}
+
+.c9:hover + span {
+  background-color: var(--eds_interactive_primary__hover_alt,rgba(222,237,238,1));
+}
+
+.c9:hover + span > span:last-child {
+  background-color: var(--eds_interactive_primary__hover,rgba(0,79,85,1));
+}
+
+.c11 {
+  border-radius: 4px;
+  border: none;
+  width: 32px;
+  height: 8px;
+  background-color: var(--eds_ui_background__medium,rgba(220,220,220,1));
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  -webkit-transition: background 0.36s;
+  transition: background 0.36s;
+}
+
+.c12 {
+  background-color: var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));
+  box-shadow: 0 1px 5px rgba(0,0,0,0.2),0 3px 4px rgba(0,0,0,0.12),0 2px 4px rgba(0,0,0,0.14);
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  display: inline-block;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translate(0,-50%);
+  -ms-transform: translate(0,-50%);
+  transform: translate(0,-50%);
+  left: 4px;
+  -webkit-transition: -webkit-transform 0.36s cubic-bezier(0.78,0.14,0.15,0.86);
+  -webkit-transition: transform 0.36s cubic-bezier(0.78,0.14,0.15,0.86);
+  transition: transform 0.36s cubic-bezier(0.78,0.14,0.15,0.86);
 }
 
 <div
@@ -79,6 +686,257 @@ exports[`test 'layers' button test empty MapState/specbase 1`] = `
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </button>
+  <div
+    class="c1"
+    data-floating-ui-focusable=""
+    popover="manual"
+    style="position: absolute; top: 0px; left: 0px;"
+    tabindex="-1"
+  >
+    <div
+      class="c2 c3 LayersButton-root"
+    >
+      <div
+        aria-labelledby="layers-selector-button"
+        class="c4"
+        id="layers-selector"
+        role="menu"
+      >
+        <div
+          style="display: flex; justify-content: space-between;"
+        >
+          <label
+            class="c5"
+            id="undefined-switch-label"
+            style="padding-top: 15px; font-size: 15px;"
+          >
+            <span
+              class="c6"
+            />
+          </label>
+          <span
+            class="c7"
+            style="padding-right: 10px; width: 3rem;"
+          >
+            <input
+              class="c8 c9"
+              id="undefined-switch"
+              type="checkbox"
+            />
+            <span
+              class="c10"
+            >
+              <span
+                class="c11"
+              />
+              <span
+                class="c12"
+              />
+            </span>
+          </span>
+        </div>
+        <div
+          style="display: flex; justify-content: space-between;"
+        >
+          <label
+            class="c5"
+            id="undefined-switch-label"
+            style="padding-top: 15px; font-size: 15px;"
+          >
+            <span
+              class="c6"
+            />
+          </label>
+          <span
+            class="c7"
+            style="padding-right: 10px; width: 3rem;"
+          >
+            <input
+              checked=""
+              class="c8 c9"
+              id="undefined-switch"
+              type="checkbox"
+            />
+            <span
+              class="c10"
+            >
+              <span
+                class="c11"
+              />
+              <span
+                class="c12"
+              />
+            </span>
+          </span>
+        </div>
+        <div
+          style="display: flex; justify-content: space-between;"
+        >
+          <label
+            class="c5"
+            id="undefined-switch-label"
+            style="padding-top: 15px; font-size: 15px;"
+          >
+            <span
+              class="c6"
+            />
+          </label>
+          <span
+            class="c7"
+            style="padding-right: 10px; width: 3rem;"
+          >
+            <input
+              class="c8 c9"
+              id="undefined-switch"
+              type="checkbox"
+            />
+            <span
+              class="c10"
+            >
+              <span
+                class="c11"
+              />
+              <span
+                class="c12"
+              />
+            </span>
+          </span>
+        </div>
+        <div
+          style="display: flex; justify-content: space-between;"
+        >
+          <label
+            class="c5"
+            id="undefined-switch-label"
+            style="padding-top: 15px; font-size: 15px;"
+          >
+            <span
+              class="c6"
+            />
+          </label>
+          <span
+            class="c7"
+            style="padding-right: 10px; width: 3rem;"
+          >
+            <input
+              class="c8 c9"
+              id="undefined-switch"
+              type="checkbox"
+            />
+            <span
+              class="c10"
+            >
+              <span
+                class="c11"
+              />
+              <span
+                class="c12"
+              />
+            </span>
+          </span>
+        </div>
+        <div
+          style="display: flex; justify-content: space-between;"
+        >
+          <label
+            class="c5"
+            id="undefined-switch-label"
+            style="padding-top: 15px; font-size: 15px;"
+          >
+            <span
+              class="c6"
+            />
+          </label>
+          <span
+            class="c7"
+            style="padding-right: 10px; width: 3rem;"
+          >
+            <input
+              class="c8 c9"
+              id="undefined-switch"
+              type="checkbox"
+            />
+            <span
+              class="c10"
+            >
+              <span
+                class="c11"
+              />
+              <span
+                class="c12"
+              />
+            </span>
+          </span>
+        </div>
+        <div
+          style="display: flex; justify-content: space-between;"
+        >
+          <label
+            class="c5"
+            id="undefined-switch-label"
+            style="padding-top: 15px; font-size: 15px;"
+          >
+            <span
+              class="c6"
+            />
+          </label>
+          <span
+            class="c7"
+            style="padding-right: 10px; width: 3rem;"
+          >
+            <input
+              class="c8 c9"
+              id="undefined-switch"
+              type="checkbox"
+            />
+            <span
+              class="c10"
+            >
+              <span
+                class="c11"
+              />
+              <span
+                class="c12"
+              />
+            </span>
+          </span>
+        </div>
+        <div
+          style="display: flex; justify-content: space-between;"
+        >
+          <label
+            class="c5"
+            id="undefined-switch-label"
+            style="padding-top: 15px; font-size: 15px;"
+          >
+            <span
+              class="c6"
+            />
+          </label>
+          <span
+            class="c7"
+            style="padding-right: 10px; width: 3rem;"
+          >
+            <input
+              class="c8 c9"
+              id="undefined-switch"
+              type="checkbox"
+            />
+            <span
+              class="c10"
+            >
+              <span
+                class="c11"
+              />
+              <span
+                class="c12"
+              />
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 

--- a/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/NumericInput.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/NumericInput.test.tsx.snap
@@ -10,6 +10,10 @@ exports[`Test Numeric Input snapshot test 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
   position: relative;
   margin: 0;
   color: var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));

--- a/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/SliderInput.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/SliderInput.test.tsx.snap
@@ -10,6 +10,10 @@ exports[`Test Slider Input snapshot test 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
   position: relative;
   margin: 0;
   color: var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));

--- a/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/ToggleButton.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/ToggleButton.test.tsx.snap
@@ -10,6 +10,10 @@ exports[`Test Toggle Input snapshot test 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
   position: relative;
   margin: 0;
   color: var(--eds_text__static_icons__tertiary,rgba(111,111,111,1));


### PR DESCRIPTION
Some failing tests remaining due to visibility checks giving unexpected results.

Fix fo #2429 