### PR TITLE
fix: [NGRM]: Grid3DLayer reports wrong x,y,z and dept values in readout for undefined property values. #2474

### DIFF
--- a/typescript/packages/subsurface-viewer/src/layers/grid3d/cellProperty.fs.glsl.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/grid3d/cellProperty.fs.glsl.ts
@@ -79,8 +79,6 @@ vec4 getContinuousPropertyColor (float propertyValue) {
    return color;
 }
 
-
-
 void main(void) {
 
    if (picking.isActive > 0.5 && !(picking.isAttribute > 0.5)) {
@@ -90,7 +88,8 @@ void main(void) {
 
    if (isnan(property)) {
       vec3 lightColor = getPhongLightColor(undefinedPropertyColor.rgb, cameraPosition, position_commonspace.xyz, normal);
-      fragColor = vec4(lightColor, 1.0);      
+      fragColor = vec4(lightColor, 1.0);
+      DECKGL_FILTER_COLOR(fragColor, geometry);
       return;
    } 
 


### PR DESCRIPTION
Can be reproduced by using the for example following properties on Grid3DLayer:
 

```
                .
                .
                undefinedPropertyValue: 4,
                undefinedPropertyColor: [255, 0, 0],
                .
                .

```
Or any other value specifying undefined properties.

