### PR TITLE
fix: Made Well Log Viewer set correct bounds even if no tracks are present

### DIFF
--- a/typescript/packages/well-log-viewer/src/utils/tracks.ts
+++ b/typescript/packages/well-log-viewer/src/utils/tracks.ts
@@ -205,7 +205,7 @@ export function createWellLogTracks(
         const data = wellLog[0].data;
         const { primary } = getAxisIndices(curves, axes);
 
-        const firstAxisValue = data[0][primary];
+        const firstAxisValue = data[0]?.[primary];
         if (typeof firstAxisValue === "number")
             info.minmaxPrimaryAxis[0] = firstAxisValue;
     }
@@ -215,7 +215,7 @@ export function createWellLogTracks(
         const data = wellLog[0].data;
         const { primary } = getAxisIndices(curves, axes);
 
-        const lastAxisValue = data[data.length - 1][primary];
+        const lastAxisValue = data[data.length - 1]?.[primary];
         if (typeof lastAxisValue === "number")
             info.minmaxPrimaryAxis[1] = lastAxisValue;
     }

--- a/typescript/packages/well-log-viewer/src/utils/tracks.ts
+++ b/typescript/packages/well-log-viewer/src/utils/tracks.ts
@@ -198,6 +198,28 @@ export function createWellLogTracks(
         }
     }
 
+    // If no bounds have been defined (for example, if no tracks were added),
+    // we default to using the axis curve's min/max as bounds
+    if (!isFinite(info.minmaxPrimaryAxis[0])) {
+        const curves = wellLog[0].curves;
+        const data = wellLog[0].data;
+        const { primary } = getAxisIndices(curves, axes);
+
+        const firstAxisValue = data[0][primary];
+        if (typeof firstAxisValue === "number")
+            info.minmaxPrimaryAxis[0] = firstAxisValue;
+    }
+
+    if (!isFinite(info.minmaxPrimaryAxis[1])) {
+        const curves = wellLog[0].curves;
+        const data = wellLog[0].data;
+        const { primary } = getAxisIndices(curves, axes);
+
+        const lastAxisValue = data[data.length - 1][primary];
+        if (typeof lastAxisValue === "number")
+            info.minmaxPrimaryAxis[1] = lastAxisValue;
+    }
+
     return info;
 }
 


### PR DESCRIPTION
This PR adds a small fix to make it so a well log viewer without any tracks still renders the full axis curves and any potential well-picks. Would be helpful for some user flows in our webviz project

Before             |  After
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/fd9a69e1-14cd-433a-aadd-454496846a52)  | ![image](https://github.com/user-attachments/assets/d60f04e2-eeeb-475b-8c37-fe1cd9400724)



