### PR TITLE
fix: add support for double click

### DIFF
--- a/typescript/packages/subsurface-viewer/src/components/Map.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.tsx
@@ -884,6 +884,7 @@ const Map: React.FC<MapProps> = ({
                 onDrag={onDrag}
                 onResize={onResize}
                 pickingRadius={pickingRadius}
+                eventRecognizerOptions={{ dblclick: { taps: 3 } }} // Add double click recognizer
             >
                 {children}
             </DeckGL>


### PR DESCRIPTION
This is a workaround to be able to handle double click by onClick callback

Fix for #2538 