### PR TITLE
chore: "Typed Array Input" triangle story crash when editing layer settings

### DIFF
--- a/typescript/packages/subsurface-viewer/src/storybook/layers/TriangleLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/layers/TriangleLayer.stories.tsx
@@ -13,6 +13,7 @@ import {
     defaultStoryParameters,
     northArrowLayer,
 } from "../sharedSettings";
+import { replaceNonJsonArgs } from "../sharedHelperFunctions";
 
 const stories: Meta = {
     component: SubsurfaceViewer,
@@ -191,14 +192,24 @@ export const TwoSideLighting: StoryObj<typeof SubsurfaceViewer> = {
     },
 };
 
+// ---------In-place array data handling (storybook fails to rebuild non JSon data)--------------- //
+const typedDataSurfaceLayerId = "typedData_surface_layer";
+
+const nonJsonLayerArgs = {
+    [typedDataSurfaceLayerId]: {
+        pointsData: new Float32Array(SurfacePoints.default),
+        triangleData: new Uint32Array(SurfaceTriangles.default),
+    },
+};
+
 const typedDataSurfaceLayer = {
     "@@type": "TriangleLayer",
     id: "typedData_surface_layer",
     "@@typedArraySupport": true,
 
     /*eslint-disable */
-    pointsData: new Float32Array(SurfacePoints.default),
-    triangleData: new Uint32Array(SurfaceTriangles.default),
+    pointsData: nonJsonLayerArgs[typedDataSurfaceLayerId].pointsData,
+    triangleData: nonJsonLayerArgs[typedDataSurfaceLayerId].triangleData,
 
     color: [100, 100, 255], // Surface color.
     gridLines: true, // If true will draw lines around triangles.
@@ -228,6 +239,9 @@ export const TypedArrayInput: StoryObj<typeof SubsurfaceViewer> = {
             },
         },
     },
+    render: (args) => (
+        <SubsurfaceViewer {...replaceNonJsonArgs(args, nonJsonLayerArgs)} />
+    ),
 };
 
 const math = create(all, { randomSeed: "12345" });

--- a/typescript/packages/subsurface-viewer/src/storybook/sharedHelperFunctions.ts
+++ b/typescript/packages/subsurface-viewer/src/storybook/sharedHelperFunctions.ts
@@ -1,3 +1,4 @@
+import lodash from "lodash";
 import { all, create } from "mathjs";
 
 import type {
@@ -12,36 +13,139 @@ import type {
  * gets corrupted, leading to undefined behavior or possible crashes.
  * This this function is used to replace the possibly corrupted layers' non-json data controls
  * with the initial data.
+ *
+ * @example
+ * ```typescript
+const typedDataLayerId = "typedData_layer";
+
+// Non-json data to be injected into the layers.
+const nonJsonLayerArgs = {
+    [typedDataLayerId]: {
+        pointsData: new Float32Array(pointsDataArray),
+        triangleData: new Uint32Array(trglDataArray),
+        unusedData: new Uint32Array(0),
+    },
+};
+
+const typedDataLayer = {
+    "@@type": "TriangleLayer",
+    id: typedDataLayerId,
+    "@@typedArraySupport": true,
+
+    pointsData: nonJsonLayerArgs[typedDataSurfaceLayerId].pointsData,
+    triangleData: nonJsonLayerArgs[typedDataSurfaceLayerId].triangleData,
+}
+
+export const TypedDataStory: StoryObj<typeof SubsurfaceViewer> = {
+    args: {
+        id: "subsurface_viewer",
+        layers: [typedDataLayer, otherLayer],
+
+    },
+    render: (args) => (
+        // Replace the non-json data in the layers with the initial data.
+        // This is necessary because storybook controls are not typed but handled as Json data.
+        // Editing the controls will corrupt typed arrays, like Float32Array or Uint32Array.
+        // This function replaces the possibly corrupted layers' non-json data controls with the initial data.
+        <SubsurfaceViewer {...replaceNonJsonArgs(args, nonJsonLayerArgs)} />
+    ),
+};
+ * ```
+ * In this example, only the values of the existing pointsData and triangleData properties of the layer(s)
+ * with id "typedData_layer" are replaced with the initial data.
+ * 'unusedData' value is not added to layer, as it is not a value of the layer.
+ * 
+ * @example
+ * ```typescript
+// Non-json data to be injected into the layers.
+const nonJsonLayerArgs = {
+    [typedDataLayerId]: {
+        triangles:  [
+            {
+                vertices: new Float32Array(sectionZ0Vertices),
+                vertexIndices: {
+                    value: new Uint32Array(sectionZ0Indices),
+                },
+            },
+        ],
+    },
+};
+
+const ComplexDataLayer = {
+    "@@type": "GpglTextureLayer",
+    "@@typedArraySupport": true,
+    id: njTextureLayerId,
+    texturedTriangles: [
+        {
+            topology: "triangle-strip",
+            vertices: new Float32Array(sectionZ0Vertices),
+            vertexIndices: {
+                value: new Uint32Array(sectionZ0Indices),
+                size: 4,
+            },
+        },
+    ],
+    showMesh: true,
+    ZIncreasingDownwards: true,
+};
+
+ * ```
+ * This function does also support nested objects and handles arrays of objects.
+ * In this example, only the first entry of the "triangles" array is handled and gets
+ * 'vertices' and 'vertexIndices.value' values replaced with the initial data.
+ * The remaining values are untouched.
+ *
+ * @note For the first rendering, storybook does use the initial, non-corrupted data.
+ *       The data corruption does only happen after editing the controls.
+ * 
  * @param args storybook controls arguments.
  * @param nonJsonLayerProps structure storing non json data to inject into the layers.
+ *        The top level keys are the layer ids.
  * @returns the initial and updated storybook controls arguments.
  */
 export function replaceNonJsonArgs(
     args: SubsurfaceViewerProps,
-    nonJsonLayerProps: Record<string, unknown>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    nonJsonLayerProps: Record<string, any>
 ) {
     args.layers?.forEach((layer: TLayerDefinition) => {
-        replaceLayerNonJson(layer, nonJsonLayerProps);
+        if (layer && layer.id !== undefined) {
+            const layerNonJsonProps = nonJsonLayerProps[layer.id as string];
+            if (layerNonJsonProps && layer) {
+                if (layer["@@typedArraySupport"] !== true) {
+                    console.error(
+                        `Storybook story handles ${layer["@@type"] ?? "layer"} "${layer.id}" as using non-json properties; the layer is missing "@@typedArraySupport" set to true.`
+                    );
+                }
+                lodash.mergeWith(layer, layerNonJsonProps, customizer);
+            }
+        }
     });
     return args;
 }
 
-function replaceLayerNonJson(
-    layer: TLayerDefinition,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    nonJsonLayerProps: Record<string, any>
-) {
-    const localLayer = layer as Record<string, unknown>;
-    const layerId = localLayer["id"] as string | undefined;
-    if (layer && layerId && layerId) {
-        for (const nonJsonKey in nonJsonLayerProps) {
-            if (nonJsonKey === layerId) {
-                for (const key of Object.keys(nonJsonLayerProps[nonJsonKey])) {
-                    localLayer[key] = nonJsonLayerProps[nonJsonKey][key];
-                }
-            }
-        }
+function customizer(objValue, srcValue) {
+    if (lodash.isUndefined(objValue) || lodash.isNull(srcValue)) {
+        return objValue;
     }
+
+    // Check if srcValue is a typed array
+    if (ArrayBuffer.isView(srcValue)) {
+        return srcValue;
+    }
+
+    if (Array.isArray(srcValue) && Array.isArray(objValue)) {
+        for (let i = 0; i < srcValue.length && i < objValue.length; i++) {
+            objValue[i] = lodash.mergeWith(
+                objValue[i],
+                srcValue[i],
+                customizer
+            );
+        }
+        return objValue;
+    }
+
+    return lodash.mergeWith(objValue, srcValue, customizer);
 }
 
 /**


### PR DESCRIPTION
This is a known issue of storybook. Story controls are handled as Json, with stringified version used in the control panel. When edited, the modified string version is transformed to a Json structure and send as arguments to render the story.

This breaks the non Json compatible data, like arrays.

The triangle story was not using the workaround used to avoid crashes.