### PR TITLE
fix: `Grid3DLayer` not including default `shaderModules` and `layer.opacity` not used in fragment shader

### DIFF
--- a/typescript/packages/subsurface-viewer/src/layers/grid3d/cellProperty.fs.glsl.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/grid3d/cellProperty.fs.glsl.ts
@@ -87,7 +87,7 @@ void main(void) {
 
    // Use two sided phong lighting. This has no effect if "material" property is not set.
    vec3 lightColor = lighting_getLightColor(color.rgb, cameraPosition, position_commonspace.xyz, normal);
-   fragColor = vec4(lightColor, 1.0);
+   fragColor = vec4(lightColor, layer.opacity);
    DECKGL_FILTER_COLOR(fragColor, geometry);
 }
 `;

--- a/typescript/packages/subsurface-viewer/src/layers/grid3d/nodeProperty.fs.glsl.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/grid3d/nodeProperty.fs.glsl.ts
@@ -50,7 +50,7 @@ void main(void) {
 
    // Use two sided phong lighting. This has no effect if "material" property is not set.
    vec3 lightColor = lighting_getLightColor(color.rgb, cameraPosition, position_commonspace.xyz, normal);
-   fragColor = vec4(lightColor, 1.0);
+   fragColor = vec4(lightColor, layer.opacity);
    DECKGL_FILTER_COLOR(fragColor, geometry);
 }
 `;

--- a/typescript/packages/subsurface-viewer/src/layers/grid3d/privateGrid3dLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/grid3d/privateGrid3dLayer.ts
@@ -159,8 +159,20 @@ export default class PrivateLayer extends Layer<PrivateLayerProps> {
         const colormap = this.getColormapTexture(context);
         const mesh_model = new Model(context.device, {
             id: `${this.props.id}-mesh`,
-            vs: geometricShading ? linearVertexShader : flatVertexShader,
-            fs: geometricShading ? linearFragmentShader : flatFragmentShader,
+            ...super.getShaders({
+                vs: geometricShading ? linearVertexShader : flatVertexShader,
+                fs: geometricShading
+                    ? linearFragmentShader
+                    : flatFragmentShader,
+                modules: [
+                    project32,
+                    picking,
+                    lighting,
+                    phongMaterial,
+                    utilities,
+                    gridUniforms,
+                ],
+            }),
             geometry: new Geometry({
                 topology: this.props.mesh.drawMode ?? "triangle-list",
                 attributes: {
@@ -178,14 +190,6 @@ export default class PrivateLayer extends Layer<PrivateLayerProps> {
             bindings: {
                 colormap,
             },
-            modules: [
-                project32,
-                picking,
-                lighting,
-                phongMaterial,
-                utilities,
-                gridUniforms,
-            ],
             isInstanced: false,
         });
         mesh_model.shaderInputs.setProps({
@@ -209,7 +213,7 @@ export default class PrivateLayer extends Layer<PrivateLayerProps> {
             },
         });
 
-        return [mesh_model, mesh_lines_model, gridUniforms];
+        return [mesh_model, mesh_lines_model];
     }
 
     draw(args: {

--- a/typescript/packages/subsurface-viewer/src/storybook/layers/Grid3DLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/layers/Grid3DLayer.stories.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import type { Meta, StoryObj } from "@storybook/react";
 
 import SubsurfaceViewer, { TGrid3DColoringMode } from "../../SubsurfaceViewer";
@@ -52,6 +50,7 @@ const grid3dLayer = {
     colorMapName: "Rainbow",
     ZIncreasingDownwards: true,
     pickable: true,
+    opacity: 1.0,
 };
 
 const axes = {


### PR DESCRIPTION
Using `super.getShaderModules({})` injects the default layer modules, e.g. `layerUniforms` which is required to access `props.opacity` in the fragment shader via `layer.opacity`.