### PR TITLE
feat: unify exposed types naming to colormap

### DIFF
--- a/typescript/packages/subsurface-viewer/src/components/ColorLegend.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/ColorLegend.tsx
@@ -10,13 +10,13 @@ import {
 } from "@emerson-eps/color-tables";
 
 import type { ExtendedLegendLayer } from "../layers/utils/layerTools";
-import type { ColorMapFunctionType } from "../layers/utils/colormapTools";
+import type { ColormapFunctionType } from "../layers/utils/colormapTools";
 
 interface LegendBaseData {
     title: string;
     colorName: string;
     discrete: boolean;
-    colorMapFunction?: ColorMapFunctionType;
+    colorMapFunction?: ColormapFunctionType;
 }
 export interface DiscreteLegendDataType extends LegendBaseData {
     metadata: Record<string, [Color, number]>;

--- a/typescript/packages/subsurface-viewer/src/layers/colormap/colormapLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/colormap/colormapLayer.ts
@@ -15,7 +15,7 @@ import type {
 } from "../utils/layerTools";
 import { type DeckGLLayerContext, getModelMatrix } from "../utils/layerTools";
 import {
-    type ColorMapFunctionType,
+    type ColormapFunctionType,
     getImageData,
 } from "../utils/colormapTools";
 import { decodeRGB, type ValueDecoder } from "../utils/propertyMapTools";
@@ -49,7 +49,7 @@ export interface ColormapLayerProps
     // Optional function property.
     // If defined this function will override the color map.
     // Takes a value in the range [0,1] and returns a color.
-    colorMapFunction?: ColorMapFunctionType;
+    colorMapFunction?: ColormapFunctionType;
 
     // Min and max property values.
     valueRange: [number, number];

--- a/typescript/packages/subsurface-viewer/src/layers/grid3d/grid3dLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/grid3d/grid3dLayer.ts
@@ -15,7 +15,7 @@ import type {
     ExtendedLayerProps,
     ReportBoundingBoxAction,
 } from "../utils/layerTools";
-import type { ColorMapFunctionType } from "../utils/colormapTools";
+import type { ColormapFunctionType } from "../utils/colormapTools";
 
 import config from "../../SubsurfaceConfig.json";
 import { findConfig } from "../../utils/configTools";
@@ -232,7 +232,7 @@ export interface Grid3DLayerProps extends ExtendedLayerProps {
      * E.g. [255, 0, 0] for constant red cells.
      * Can be defined as Uint8Array containing [R, G, B] triplets in [0, 255] range each.
      */
-    colorMapFunction?: ColorMapFunctionType | Uint8Array;
+    colorMapFunction?: ColormapFunctionType | Uint8Array;
 
     /**
      * Value in propertiesData indicating that the property is undefined.
@@ -473,7 +473,7 @@ export default class Grid3DLayer extends CompositeLayer<Grid3DLayerProps> {
     }
 
     private isColormapFunctionConstantColor(
-        colorFunc: Uint8Array | ColorMapFunctionType | undefined
+        colorFunc: Uint8Array | ColormapFunctionType | undefined
     ): colorFunc is Uint8Array {
         return (
             (Array.isArray(colorFunc) || colorFunc instanceof Uint8Array) &&

--- a/typescript/packages/subsurface-viewer/src/layers/grid3d/privateGrid3dLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/grid3d/privateGrid3dLayer.ts
@@ -23,7 +23,7 @@ import type {
 } from "../utils/layerTools";
 import { createPropertyData } from "../utils/layerTools";
 import {
-    type ColorMapFunctionType,
+    type ColormapFunctionType,
     createColormapTexture,
 } from "../utils/colormapTools";
 import linearFragmentShader from "./nodeProperty.fs.glsl";
@@ -51,7 +51,7 @@ export interface PrivateLayerProps extends ExtendedLayerProps {
     colormapClampColor: Color | undefined | boolean;
     undefinedPropertyValue: number;
     undefinedPropertyColor: [number, number, number];
-    colormapFunction?: ColorMapFunctionType;
+    colormapFunction?: ColormapFunctionType;
     coloringMode: TGrid3DColoringMode.Property;
     gridLines: boolean;
     propertyValueRange: [number, number];

--- a/typescript/packages/subsurface-viewer/src/layers/map/mapLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/map/mapLayer.ts
@@ -16,7 +16,7 @@ import type {
     ExtendedLayerProps,
 } from "../utils/layerTools";
 import { getModelMatrix } from "../utils/layerTools";
-import type { ColorMapFunctionType } from "../utils/colormapTools";
+import type { ColormapFunctionType } from "../utils/colormapTools";
 import config from "../../SubsurfaceConfig.json";
 import { findConfig } from "../../utils/configTools";
 import { loadFloat32Data } from "../../utils/serialize";
@@ -175,7 +175,7 @@ export interface MapLayerProps extends ExtendedLayerProps {
      * May also be set as constant color:
      * E.g. [255, 0, 0] for constant red surface.
      */
-    colorMapFunction?: ColorMapFunctionType;
+    colorMapFunction?: ColormapFunctionType;
 
     /**  Surface material properties.
      * material: true  = default material, coloring depends on surface orientation and lighting.

--- a/typescript/packages/subsurface-viewer/src/layers/map/privateMapLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/map/privateMapLayer.ts
@@ -24,7 +24,7 @@ import type {
 } from "../utils/layerTools";
 import { createPropertyData } from "../utils/layerTools";
 import {
-    type ColorMapFunctionType,
+    type ColormapFunctionType,
     getImageData,
 } from "../utils/colormapTools";
 
@@ -46,7 +46,7 @@ export interface PrivateMapLayerProps extends ExtendedLayerProps {
     colormapName: string;
     colormapRange: [number, number];
     colormapClampColor: Color | undefined | boolean;
-    colormapFunction?: ColorMapFunctionType;
+    colormapFunction?: ColormapFunctionType;
     propertyValueRange: [number, number];
     smoothShading: boolean;
     depthTest: boolean;

--- a/typescript/packages/subsurface-viewer/src/layers/utils/colormapTools.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/utils/colormapTools.ts
@@ -42,7 +42,7 @@ export interface ColorTableDef extends ColorTableProps {
     colorTables: colorTablesArray;
 }
 
-export type ColormapProps = ColorMapFunctionType | Uint8Array | ColorTableProps;
+export type ColormapProps = ColormapFunctionType | Uint8Array | ColorTableProps;
 
 /**
  * Represents the possible types that can be used as colormap properties.
@@ -68,7 +68,7 @@ export function getImageData(
     type funcType = (x: number) => Color;
 
     if (colormapDef instanceof Uint8Array) {
-        // If colorMapProps is a Uint8Array, return it directly
+        // If colormapProps is a Uint8Array, return it directly
         return colormapDef;
     }
 

--- a/typescript/packages/subsurface-viewer/src/layers/utils/colormapTools.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/utils/colormapTools.ts
@@ -12,9 +12,11 @@ import { createDefaultContinuousColorScale } from "@emerson-eps/color-tables/dis
 import type { DeckGLLayerContext } from "./layerTools";
 
 /** Type of functions returning a color from a value in the [0,1] range. */
-export type ColorMapFunctionType = ReturnType<typeof createColormapFunction>;
-/** @deprecated Use ColorMapFunctionType instead. */
-export type colorMapFunctionType = ColorMapFunctionType;
+export type ColormapFunctionType = ReturnType<typeof createColormapFunction>;
+/** @deprecated Use ColormapFunctionType instead. */
+export type colorMapFunctionType = ColormapFunctionType;
+/** @deprecated Use ColormapFunctionType instead. */
+export type ColorMapFunctionType = ColormapFunctionType;
 
 export interface IColormapHints {
     discreteData: boolean;
@@ -45,11 +47,11 @@ export type ColormapProps = ColorMapFunctionType | Uint8Array | ColorTableProps;
 /**
  * Represents the possible types that can be used as colormap properties.
  *
- * - `ColorMapFunctionType`: A function converting a value to a color.
+ * - `ColormapFunctionType`: A function converting a value to a color.
  * - `Uint8Array`: A typed array containing color data.
  * - `ColorTableDef`: An object representing a color table.
  */
-export type TColormapDef = ColorMapFunctionType | Uint8Array | ColorTableDef;
+export type TColormapDef = ColormapFunctionType | Uint8Array | ColorTableDef;
 
 /**
  * Creates an array of colors as RGB triplets in range [0, 1] using the colormap definition.

--- a/typescript/packages/subsurface-viewer/src/layers/wells/wellsLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/wells/wellsLayer.ts
@@ -32,7 +32,7 @@ import {
     getLayersById,
     isDrawingEnabled,
 } from "../utils/layerTools";
-import type { ColorMapFunctionType } from "../utils/colormapTools";
+import type { ColormapFunctionType } from "../utils/colormapTools";
 
 import type {
     ContinuousLegendDataType,
@@ -110,7 +110,7 @@ export interface WellsLayerProps extends ExtendedLayerProps {
      */
     refine: boolean | number;
     wellHeadStyle: WellHeadStyleAccessor;
-    colorMappingFunction: ColorMapFunctionType;
+    colorMappingFunction: ColormapFunctionType;
     lineStyle: LineStyleAccessor;
 
     /**

--- a/typescript/packages/subsurface-viewer/src/storybook/layers/MapLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/layers/MapLayer.stories.tsx
@@ -15,7 +15,7 @@ import { ViewFooter } from "../../components/ViewFooter";
 import AxesLayer from "../../layers/axes/axesLayer";
 import MapLayer from "../../layers/map/mapLayer";
 import NorthArrow3DLayer from "../../layers/northarrow/northArrow3DLayer";
-import type { ColorMapFunctionType } from "../../layers/utils/colormapTools";
+import type { ColormapFunctionType } from "../../layers/utils/colormapTools";
 
 import {
     default2DViews,
@@ -501,7 +501,7 @@ const TypedArrayInputComponent: React.FC<{
                 material: true,
                 ZIncreasingDownwards: false,
                 contours: [0, 5],
-                colorMapFunction: nearestColormap as ColorMapFunctionType,
+                colorMapFunction: nearestColormap as ColormapFunctionType,
             },
             {
                 "@@type": "AxesLayer",

--- a/typescript/packages/well-log-viewer/src/Storybook/examples/MapAndWellLogViewer.tsx
+++ b/typescript/packages/well-log-viewer/src/Storybook/examples/MapAndWellLogViewer.tsx
@@ -34,16 +34,16 @@ import wellLogsJson from "../../../../../../example-data/volve_logs.json";
 import templateJson from "../../../../../../example-data/welllog_template_2.json";
 import colorTables from "../../../../../../example-data/wellpick_colors.json";
 import wellPicks from "../../../../../../example-data/wellpicks.json";
-import type { ColorMapFunction } from "../../utils/color-function";
+import type { ColormapFunction } from "../../utils/color-function";
 import { indexOfElementByName, isEqualRanges } from "../../utils/arrays";
 import { getDiscreteMeta } from "../../utils/well-log";
 
 const wellLogs = wellLogsJson as unknown as WellLogSet[];
 const template = templateJson as unknown as Template;
 
-const exampleColormapFunctions: ColorMapFunction[] = [
+const exampleColormapFunctions: ColormapFunction[] = [
     // copy color tables and add some color functions
-    ...(colorTables as ColorMapFunction[]),
+    ...(colorTables as ColormapFunction[]),
     {
         name: "Grey scale",
         func: (v: number) => [v * 255, v * 255, v * 255],

--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.stories.tsx
@@ -13,7 +13,7 @@ import {
 import SyncLogViewer, { argTypesSyncLogViewerProp } from "./SyncLogViewer";
 import type { SyncLogViewerProps } from "./SyncLogViewer";
 
-import type { ColorMapFunction } from "./utils/color-function";
+import type { ColormapFunction } from "./utils/color-function";
 import type { Pattern } from "./utils/pattern";
 
 import type {
@@ -37,8 +37,8 @@ import L916MUDJson from "../../../../example-data/L916MUD.json";
 import List1Json from "../../../../example-data/Lis1.json";
 import facies3WellsJson from "../../../../example-data/facies3wells.json";
 
-const exampleColormapFunctions = colorTables as ColorMapFunction[];
-const wellpickColormapFunctions = wellpickColorTablesJson as ColorMapFunction[];
+const exampleColormapFunctions = colorTables as ColormapFunction[];
+const wellpickColormapFunctions = wellpickColorTablesJson as ColormapFunction[];
 const horizonPatterns = horizonPatternsJson as Pattern[];
 
 const syncTemplate = syncTemplateJson as TemplateType;

--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.test.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.test.tsx
@@ -5,14 +5,14 @@ import "jest-styled-components";
 import React from "react";
 import SyncLogViewer from "./SyncLogViewer";
 import { axisMnemos, axisTitles } from "./utils/axes";
-import type { ColorMapFunction } from "./utils/color-function";
+import type { ColormapFunction } from "./utils/color-function";
 import type { WellLogSet } from "./components/WellLogTypes";
 import type { Template } from "./components/WellLogTemplateTypes";
 
 import exampleWellLogJson from "../../../../example-data/L898MUD.json";
 import exampleTemplateJson from "../../../../example-data/welllog_template_1.json";
 
-const exampleColorFunction = colorTables as ColorMapFunction[];
+const exampleColorFunction = colorTables as ColormapFunction[];
 const exampleWellLog = exampleWellLogJson as WellLogSet[];
 const exampleTemplate = exampleTemplateJson as Template;
 

--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
@@ -14,7 +14,7 @@ import defaultLayout from "./components/DefaultSyncLogViewerLayout";
 
 import type { WellLogSet } from "./components/WellLogTypes";
 import type { Template } from "./components/WellLogTemplateTypes";
-import type { ColorMapFunction } from "./utils/color-function";
+import type { ColormapFunction } from "./utils/color-function";
 import { ColorFunctionType } from "./components/CommonPropTypes";
 import type { PatternsTable, Pattern } from "./utils/pattern";
 import { PatternsTableType, PatternsType } from "./components/CommonPropTypes";
@@ -79,7 +79,7 @@ export interface SyncLogViewerProps {
     /**
      * Prop containing color function/table array.
      */
-    colorMapFunctions: ColorMapFunction[];
+    colorMapFunctions: ColormapFunction[];
 
     /**
      * Set to true for default titles or to array of individual well log titles

--- a/typescript/packages/well-log-viewer/src/WellLogViewer.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/WellLogViewer.stories.tsx
@@ -21,7 +21,7 @@ import type {
 import type { MapAndWellLogViewerProps } from "./Storybook/examples/MapAndWellLogViewer";
 import { MapAndWellLogViewer } from "./Storybook/examples/MapAndWellLogViewer";
 import { axisMnemos, axisTitles } from "./utils/axes";
-import type { ColorMapFunction, ColorTable } from "./utils/color-function";
+import type { ColormapFunction, ColorTable } from "./utils/color-function";
 
 import exampleDeckglArgsJson from "../../../../example-data/deckgl-map.json";
 import wellLogsJson from "../../../../example-data/volve_logs.json";
@@ -32,7 +32,7 @@ import templateJson2 from "../../../../example-data/welllog_template_2.json";
 import wellpicksJson from "../../../../example-data/wellpicks.json";
 import colorTablesJson from "../../../../example-data/wellpick_colors.json";
 
-const exampleColorFunctions = colorTablesJson as ColorMapFunction[];
+const exampleColorFunctions = colorTablesJson as ColormapFunction[];
 const exampleColorTables = colorTablesJson as ColorTable[];
 
 const wellLogs = wellLogsJson as unknown as WellLogSet[];
@@ -40,7 +40,7 @@ const wellLogl898MUD = wellLogl898MUDJson as WellLogSet[];
 const template1 = templateJson1 as unknown as Template;
 const template2 = templateJson2 as unknown as Template;
 
-const exampleColormapFunctions: ColorMapFunction[] = [
+const exampleColormapFunctions: ColormapFunction[] = [
     // copy color tables and add some color functions
     ...exampleColorFunctions,
     {

--- a/typescript/packages/well-log-viewer/src/WellLogViewer.test.tsx
+++ b/typescript/packages/well-log-viewer/src/WellLogViewer.test.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import WellLogViewer from "./WellLogViewer";
 import type { WellLogController } from "./components/WellLogView";
 import { axisMnemos, axisTitles } from "./utils/axes";
-import type { ColorMapFunction } from "./utils/color-function";
+import type { ColormapFunction } from "./utils/color-function";
 
 // TODO: Fix this the next time the file is edited.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -14,7 +14,7 @@ const exampleTemplate = require("../../../../example-data/welllog_template_1.jso
 // TODO: Fix this the next time the file is edited.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const exampleWellLog = require("../../../../example-data/L898MUD.json")[0];
-const exampleColormapFunctions = colorTables as ColorMapFunction[];
+const exampleColormapFunctions = colorTables as ColormapFunction[];
 
 window.ResizeObserver =
     window.ResizeObserver ||

--- a/typescript/packages/well-log-viewer/src/WellLogViewer_performance.test.tsx
+++ b/typescript/packages/well-log-viewer/src/WellLogViewer_performance.test.tsx
@@ -7,7 +7,7 @@ import React, { Profiler } from "react";
 import WellLogViewer from "./WellLogViewer";
 import logTimes, { obj } from "./test/performanceMetrics";
 import { axisMnemos, axisTitles } from "./utils/axes";
-import type { ColorMapFunction } from "./utils/color-function";
+import type { ColormapFunction } from "./utils/color-function";
 
 // TODO: Fix this the next time the file is edited.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -18,7 +18,7 @@ const exampleWellLog = {
     curves: [],
     data: [],
 };
-const exampleColormapFunctions = colorTables as ColorMapFunction[];
+const exampleColormapFunctions = colorTables as ColormapFunction[];
 
 window.ResizeObserver =
     window.ResizeObserver ||

--- a/typescript/packages/well-log-viewer/src/components/CommonPropTypes.ts
+++ b/typescript/packages/well-log-viewer/src/components/CommonPropTypes.ts
@@ -9,7 +9,7 @@ export const PatternsTableType = PropTypes.shape({
     patternNames: PropTypes.arrayOf(PropTypes.string),
 });
 
-// see ./ColorMapFunction.ts
+// see color-function.ts
 export const ColorFunctionType = PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.object,

--- a/typescript/packages/well-log-viewer/src/components/PlotDialog.tsx
+++ b/typescript/packages/well-log-viewer/src/components/PlotDialog.tsx
@@ -5,7 +5,7 @@ import type { Track, GraphTrack } from "@equinor/videx-wellog";
 
 import type { WellLogSet } from "./WellLogTypes";
 import type { TemplatePlot, TemplatePlotType } from "./WellLogTemplateTypes";
-import type { ColorMapFunction } from "../utils/color-function";
+import type { ColormapFunction } from "../utils/color-function";
 
 import type WellLogView from "./WellLogView";
 
@@ -90,7 +90,7 @@ export function createBooleanItems(): ReactNode[] {
 }
 
 function createColorFunctionItems(
-    colormapFunctions: ColorMapFunction[]
+    colormapFunctions: ColormapFunction[]
 ): ReactNode[] {
     const nodes: ReactNode[] = [];
     if (!colormapFunctions || !colormapFunctions.length) {

--- a/typescript/packages/well-log-viewer/src/components/WellLogSpacer.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogSpacer.tsx
@@ -5,7 +5,7 @@ import type { WellLogController, WellPickProps } from "./WellLogView";
 import { getWellPicks } from "./WellLogView";
 import type WellLogView from "./WellLogView";
 
-import type { ColorMapFunction } from "../utils/color-function";
+import type { ColormapFunction } from "../utils/color-function";
 import type { PatternsTable, Pattern } from "../utils/pattern";
 import { createDefs, patternId } from "../utils/pattern";
 
@@ -28,7 +28,7 @@ export interface WellLogSpacerProps {
     /**
      * Prop containing color function/table data.
      */
-    colorMapFunctions: ColorMapFunction[];
+    colorMapFunctions: ColormapFunction[];
     /**
      * Well Picks data
      */

--- a/typescript/packages/well-log-viewer/src/components/WellLogView.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogView.stories.tsx
@@ -8,7 +8,7 @@ import type { Template } from "./WellLogTemplateTypes";
 import type { WellLogViewProps } from "./WellLogView";
 import { argTypesWellLogViewProp } from "./WellLogView";
 import { axisTitles, axisMnemos } from "../utils/axes";
-import type { ColorMapFunction } from "../utils/color-function";
+import type { ColormapFunction } from "../utils/color-function";
 
 // Import example data
 import L898MUD from "../../../../../example-data/L898MUD.json";
@@ -22,7 +22,7 @@ const wellLogDiscrete = volve_logs[0] as unknown as WellLogSet;
 const viewerTemplate1 = viewerTemplateJson1 as Template;
 const viewerTemplate2 = viewerTemplateJson2 as Template;
 
-const exampleColormapFunctions = colorTables as ColorMapFunction[];
+const exampleColormapFunctions = colorTables as ColormapFunction[];
 
 const stories: Meta<WellLogViewProps> = {
     component: WellLogView,

--- a/typescript/packages/well-log-viewer/src/components/WellLogView.test.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogView.test.tsx
@@ -4,12 +4,12 @@ import { render } from "@testing-library/react";
 import "jest-styled-components";
 import WellLogView from "./WellLogView";
 import type { Template } from "./WellLogTemplateTypes";
-import type { ColorMapFunction } from "../utils/color-function";
+import type { ColormapFunction } from "../utils/color-function";
 
 import viewerTemplateJson from "../../../../../example-data/welllog_template_1.json";
 
 const viewerTemplate = viewerTemplateJson as Template;
-const exampleColormapFunctions = colorTables as ColorMapFunction[];
+const exampleColormapFunctions = colorTables as ColormapFunction[];
 const exampleWellLog = {
     header: {},
     curves: [],

--- a/typescript/packages/well-log-viewer/src/components/WellLogView.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogView.tsx
@@ -19,7 +19,7 @@ import type { DifferentialPlotLegendInfo } from "@equinor/videx-wellog/dist/plot
 import { validateSchema } from "@webviz/wsc-common";
 
 import type { AxesInfo } from "../utils/axes";
-import type { ColorMapFunction } from "../utils/color-function";
+import type { ColormapFunction } from "../utils/color-function";
 import { deepCopy } from "../utils/deepcopy";
 import {
     createNewViewTrack,
@@ -326,7 +326,7 @@ export interface WellPickProps {
     /**
      * Prop containing color tables or color functions array for well picks
      */
-    colorMapFunctions: ColorMapFunction[];
+    colorMapFunctions: ColormapFunction[];
     colorMapFunctionName: string; // "Stratigraphy" ..., "Step func", ...
 }
 
@@ -690,7 +690,7 @@ function setTracksToController(
     axes: AxesInfo,
     wellLogSets: WellLogSet[], // JSON Log Format
     templateTracks: TemplateTrack[], // JSON
-    colorMapFunctions: ColorMapFunction[] // JS code array or JSON file for pure color tables array without color functions elements
+    colorMapFunctions: ColormapFunction[] // JS code array or JSON file for pure color tables array without color functions elements
 ): ScaleInterpolator {
     const { tracks, minmaxPrimaryAxis: minmaxPrimaryAxis } =
         createWellLogTracks(
@@ -1013,7 +1013,7 @@ export interface WellLogViewProps {
     /**
       Prop containing color table or color functions array for discrete well logs
      */
-    colorMapFunctions: ColorMapFunction[];
+    colorMapFunctions: ColormapFunction[];
 
     /**
      * Well Picks data

--- a/typescript/packages/well-log-viewer/src/components/WellLogViewWithScroller.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogViewWithScroller.stories.tsx
@@ -8,12 +8,12 @@ import WellLogViewWithScroller from "./WellLogViewWithScroller";
 import type { WellLogViewWithScrollerProps } from "./WellLogViewWithScroller";
 import { argTypesWellLogViewScrollerProp } from "./WellLogViewWithScroller";
 import { axisTitles, axisMnemos } from "../utils/axes";
-import type { ColorMapFunction } from "../utils/color-function";
+import type { ColormapFunction } from "../utils/color-function";
 
 import wellLog898MudJson from "../../../../../example-data/L898MUD.json";
 import templateJson1 from "../../../../../example-data/welllog_template_1.json";
 
-const exampleColormapFunctions = colorTables as ColorMapFunction[];
+const exampleColormapFunctions = colorTables as ColormapFunction[];
 
 const ComponentCode =
     '<WellLogViewWithScroller id="WellLogViewWithScroller" \r\n' +

--- a/typescript/packages/well-log-viewer/src/components/WellLogViewWithScroller.test.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogViewWithScroller.test.tsx
@@ -5,12 +5,12 @@ import React from "react";
 
 import type { Template } from "./WellLogTemplateTypes";
 import WellLogViewWithScroller from "./WellLogViewWithScroller";
-import type { ColorMapFunction } from "../utils/color-function";
+import type { ColormapFunction } from "../utils/color-function";
 
 import wellLogJson from "../../../../../example-data/L898MUD.json";
 import templateJson from "../../../../../example-data/welllog_template_1.json";
 
-const exampleColormapFunctions = colorTables as ColorMapFunction[];
+const exampleColormapFunctions = colorTables as ColormapFunction[];
 
 window.ResizeObserver =
     window.ResizeObserver ||

--- a/typescript/packages/well-log-viewer/src/utils/color-function.ts
+++ b/typescript/packages/well-log-viewer/src/utils/color-function.ts
@@ -7,10 +7,12 @@ export type ColorFunction = {
     func: (v: number) => [number, number, number]; // input number is between 0.0 and 1.0; returned numbers are between 0 and 255
 };
 
-export type ColorMapFunction = colorTablesObj | ColorFunction;
+export type ColormapFunction = colorTablesObj | ColorFunction;
+/** @deprecated Use ColormapFunction instead. */
+export type ColorMapFunction = ColormapFunction;
 
 export function isFunction(
-    colormapFunction: ColorMapFunction | undefined
+    colormapFunction: ColormapFunction | undefined
 ): boolean {
     if (!colormapFunction) return false;
     return !!(colormapFunction as ColorFunction).func;
@@ -18,8 +20,8 @@ export function isFunction(
 
 export function getColormapFunction(
     functionName?: string,
-    colormapFunctions?: ColorMapFunction[]
-): ColorMapFunction | undefined {
+    colormapFunctions?: ColormapFunction[]
+): ColormapFunction | undefined {
     if (!functionName) return undefined;
     if (!colormapFunctions) {
         console.error("No color functions provided for graph!");

--- a/typescript/packages/well-log-viewer/src/utils/color-table.ts
+++ b/typescript/packages/well-log-viewer/src/utils/color-table.ts
@@ -1,5 +1,5 @@
 import {
-    type ColorMapFunction,
+    type ColormapFunction,
     type ColorFunction,
     type ColorTable,
     isFunction,
@@ -78,7 +78,7 @@ export function getExactColor(
   get HTML string with interpolated color value in #xxxxxx format
 */
 export function getInterpolatedColor(
-    colormapFunction: ColorMapFunction,
+    colormapFunction: ColormapFunction,
     v: number
 ): [number, number, number] {
     if (isFunction(colormapFunction)) {
@@ -125,7 +125,7 @@ export function getInterpolatedColor(
   get HTML string with interpolated color value in #xxxxxx format
 */
 export function getInterpolatedColorString(
-    colormapFunction: ColorMapFunction,
+    colormapFunction: ColormapFunction,
     v: number
 ): string {
     if (isFunction(colormapFunction)) {

--- a/typescript/packages/well-log-viewer/src/utils/gradientfill-plot-legend.ts
+++ b/typescript/packages/well-log-viewer/src/utils/gradientfill-plot-legend.ts
@@ -10,7 +10,7 @@ declare type D3Selection = any; //import { D3Selection } from "@equinor/videx-we
 import { renderBasicPlotLegend } from "./legend/common"; //import { renderBasicPlotLegend } from "@equinor/videx-wellog/dist/plots/legend/common';
 /* End of missed from "@equinor/videx-wellog */
 
-import type { ColorMapFunction, ColorTable } from "./color-function";
+import type { ColormapFunction, ColorTable } from "./color-function";
 import { isFunction } from "./color-function";
 import { getInterpolatedColorString } from "./color-table";
 
@@ -19,7 +19,7 @@ import { color4ToString } from "./color-table";
 let __idGradient = 0;
 function createGradient(
     g: D3Selection,
-    colormapFunction: ColorMapFunction,
+    colormapFunction: ColormapFunction,
     rLogarithmic?: number
 ): string {
     const id = "grad" + ++__idGradient; // generate unique id
@@ -107,7 +107,7 @@ export default function renderGradientFillPlotLegend(
                 : plot.options.color;
 
         /* Start GradientFill code */
-        let colormapFunction: ColorMapFunction | undefined =
+        let colormapFunction: ColormapFunction | undefined =
             useMinAsBase && minIsLeft
                 ? options.colorMapFunction
                 : options.inverseColorMapFunction;

--- a/typescript/packages/well-log-viewer/src/utils/gradientfill-plot.ts
+++ b/typescript/packages/well-log-viewer/src/utils/gradientfill-plot.ts
@@ -8,11 +8,11 @@ import type {
 
 import renderGradientFillPlotLegend from "./gradientfill-plot-legend";
 import { getInterpolatedColorString } from "./color-table";
-import type { ColorMapFunction } from "./color-function";
+import type { ColormapFunction } from "./color-function";
 
 export interface GradientFillPlotOptions extends AreaPlotOptions {
-    colorMapFunction?: ColorMapFunction;
-    inverseColorMapFunction?: ColorMapFunction;
+    colorMapFunction?: ColormapFunction;
+    inverseColorMapFunction?: ColormapFunction;
     colorScale?: "linear" | "log";
     inverseColorScale?: "linear" | "log";
 }
@@ -26,7 +26,7 @@ function createGradient(
     horizontal: boolean | undefined,
     plotdata: number[][],
     xscale: Scale,
-    colormapFunction: ColorMapFunction,
+    colormapFunction: ColormapFunction,
     scale: undefined | string // "linear" | "log"
 ): CanvasGradient {
     const dataFrom = plotdata[0];

--- a/typescript/packages/well-log-viewer/src/utils/log-viewer.ts
+++ b/typescript/packages/well-log-viewer/src/utils/log-viewer.ts
@@ -11,7 +11,7 @@ import { InterpolatedScaleHandler } from "@equinor/videx-wellog";
 import type { TrackOptions } from "@equinor/videx-wellog/dist/tracks/interfaces";
 
 import type { AxesInfo } from "./axes";
-import type { ColorMapFunction } from "./color-function";
+import type { ColormapFunction } from "./color-function";
 import { getAxisIndices } from "./well-log";
 import { checkMinMax } from "./minmax";
 import { createTrack, isScaleTrack, editTrack } from "../utils/tracks";
@@ -404,7 +404,7 @@ export function createNewViewTrack(
     position: number,
     axesInfo: AxesInfo,
     wellLogSets: WellLogSet[],
-    colormapFunctions: ColorMapFunction[] = []
+    colormapFunctions: ColormapFunction[] = []
 ): Track<TrackOptions> | null {
     const newTrack = createTrack(
         wellLogSets,
@@ -439,7 +439,7 @@ export function editViewTrack(
     newTemplate: TemplateTrack,
     axesInfo: AxesInfo,
     wellLogSets: WellLogSet[],
-    colormapFunctions: ColorMapFunction[] = []
+    colormapFunctions: ColormapFunction[] = []
 ): Track {
     editTrack(track, newTemplate, wellLogSets, axesInfo, colormapFunctions);
     adjustControllerToModifiedTrack(logViewer, track);

--- a/typescript/packages/well-log-viewer/src/utils/plots.ts
+++ b/typescript/packages/well-log-viewer/src/utils/plots.ts
@@ -26,7 +26,7 @@ import type {
 } from "../components/WellLogTypes";
 
 import { type AxesInfo } from "./axes";
-import type { ColorMapFunction } from "./color-function";
+import type { ColormapFunction } from "./color-function";
 import { getColormapFunction } from "./color-function";
 
 import GradientFillPlot, {
@@ -214,7 +214,7 @@ export function buildPlotConfig(
     plotSetup: PlotSetup,
     plotSetup2: PlotSetup | null,
     trackTemplate: TemplateTrack,
-    colormapFunctions: ColorMapFunction[] | undefined,
+    colormapFunctions: ColormapFunction[] | undefined,
     iData: number,
     iData2: number
 ): PlotConfig {
@@ -238,7 +238,7 @@ function buildPlotOptions(
     plotSetup: PlotSetup,
     plotSetup2: PlotSetup | null,
     trackTemplate: TemplateTrack,
-    colormapFunctions: ColorMapFunction[] | undefined,
+    colormapFunctions: ColormapFunction[] | undefined,
     iData: number,
     iData2: number
 ): ExtPlotOptions {
@@ -308,7 +308,7 @@ function createAreaData(
     from: number,
     to: number,
     value: number | string,
-    colormapFunction: ColorMapFunction | undefined,
+    colormapFunction: ColormapFunction | undefined,
     meta?: DiscreteMeta | null
 ): AreaData | null {
     const { color, name } = getDiscreteColorAndName(
@@ -340,7 +340,7 @@ function createAreaData(
  */
 export async function createStackData(
     data: [number | null, number | string | null][],
-    colormapFunction: ColorMapFunction | undefined,
+    colormapFunction: ColormapFunction | undefined,
     meta: DiscreteMeta | undefined | null
 ): Promise<AreaData[]> {
     const arr: AreaData[] = new Array<AreaData>();

--- a/typescript/packages/well-log-viewer/src/utils/tracks.ts
+++ b/typescript/packages/well-log-viewer/src/utils/tracks.ts
@@ -21,7 +21,7 @@ import {
     StackedTrack,
 } from "@equinor/videx-wellog";
 
-import { getColormapFunction, type ColorMapFunction } from "./color-function";
+import { getColormapFunction, type ColormapFunction } from "./color-function";
 import type {
     TemplateTrack,
     TemplatePlot,
@@ -173,7 +173,7 @@ export function createWellLogTracks(
     wellLog: WellLogSet[],
     axes: AxesInfo,
     templateTracks: TemplateTrack[], // Part of JSON
-    colormapFunctions: ColorMapFunction[] // JS code or JSON color table
+    colormapFunctions: ColormapFunction[] // JS code or JSON color table
 ): TracksInfo {
     if (!wellLog?.length) return new TracksInfo();
 
@@ -278,7 +278,7 @@ function maybeGetSecondaryPlotSetup(
 function makeGraphTrackOptions(
     plotSetups: PlotSetup[],
     templateTrack: TemplateTrack,
-    colormapFunctions?: ColorMapFunction[],
+    colormapFunctions?: ColormapFunction[],
     existingOptions: Partial<ExtTrackOptions> = {}
 ): GraphTrackOptions & ExtTrackOptions {
     // Only returns a non-required tracks if there's any plot-setups available
@@ -333,7 +333,7 @@ function makeGraphTrackOptions(
 function makeStackedTrackOptions(
     plotSetups: PlotSetup[],
     templateTrack: TemplateTrack,
-    colormapFunctions?: ColorMapFunction[],
+    colormapFunctions?: ColormapFunction[],
     existingOptions: Partial<ExtTrackOptions> = {}
 ): StackedTrackOptions & ExtTrackOptions {
     // ? Why do we not care about "required" here? (@anders2303)
@@ -383,7 +383,7 @@ export function createTrack(
     wellLog: WellLogSet[],
     axesInfo: AxesInfo,
     templateTrack: TemplateTrack,
-    colormapFunctions?: ColorMapFunction[]
+    colormapFunctions?: ColormapFunction[]
 ): Track | null {
     const plotSetups = setupTrackPlots(wellLog, templateTrack, axesInfo);
 
@@ -429,7 +429,7 @@ export function editTrack(
     newTemplateTrack: TemplateTrack,
     wellLogSets: WellLogSet[],
     axisInfo: AxesInfo,
-    colormapFunctions: ColorMapFunction[]
+    colormapFunctions: ColormapFunction[]
 ): Track {
     const newPlotSetups = setupTrackPlots(
         wellLogSets,
@@ -484,7 +484,7 @@ export function addPlotToTrack(
     templatePlot: TemplatePlot,
     wellLogSets: WellLogSet[],
     axesInfo: AxesInfo,
-    colormapFunctions: ColorMapFunction[]
+    colormapFunctions: ColormapFunction[]
 ) {
     // ! Currently only supporting graph tracks, but keeping the function ambiguous for now
     if (!(track instanceof GraphTrack))
@@ -545,7 +545,7 @@ export function editTrackPlot(
     templatePlot: TemplatePlot,
     wellLogSets: WellLogSet[],
     axesInfo: AxesInfo,
-    colormapFunctions: ColorMapFunction[]
+    colormapFunctions: ColormapFunction[]
 ) {
     if (!(track instanceof GraphTrack))
         throw Error("Can only add tracks to GraphTracks");

--- a/typescript/packages/well-log-viewer/src/utils/well-log.ts
+++ b/typescript/packages/well-log-viewer/src/utils/well-log.ts
@@ -10,7 +10,7 @@ import type {
     WellLogSet,
 } from "../components/WellLogTypes";
 import type { WellLogViewProps } from "../components/WellLogView";
-import type { ColorMapFunction } from "./color-function";
+import type { ColormapFunction } from "./color-function";
 import type { AxesInfo } from "./axes";
 import { indexOfElementByNames } from "./arrays";
 import { getInterpolatedColor } from "./color-table";
@@ -233,7 +233,7 @@ export function getDiscreteMeta(
 
 export function getDiscreteColorAndName(
     value: number | string | null,
-    colormapFunction: ColorMapFunction | undefined,
+    colormapFunction: ColormapFunction | undefined,
     meta?: DiscreteMeta | null
 ): { color: number[]; name: string } {
     let color: number[];


### PR DESCRIPTION
Both colormap and colorMap naming scheme are present, bringing some confusion.
Moving to single notation: colormap.

Exposed part: exported API types
Rename:
- exposed types

Old types are exported as deprecated


Occurrence count, after and before the PR
| | colormap | colorMap |
|--|--|--|
|Published Code (a)| 618 results in 40 files<br>~618~ results in ~40~ files | 143 results in 28 files<br>~143~ results in ~28~ files |
|Full Code (b)| 767 results in 60 files<br>~767~ results in ~60~ files | 267 results in 49 files<br>~267~ results in ~49~ files |
|Overall (c)| 783 results in 66 files<br>~783~ results in ~66~ files | 293 results in 58 files<br>~293~ results in ~58~ files |

PR for #2581 