### PR TITLE
fix: make triangle line shader consistent with triangle shader

### DIFF
--- a/typescript/packages/subsurface-viewer/src/layers/triangle/line.fs.glsl.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/triangle/line.fs.glsl.ts
@@ -1,6 +1,6 @@
 export default `\
 #version 300 es
-#define SHADER_NAME triangle-lines-fragment-shader
+#define SHADER_NAME triangle-line-fragment-shader
 
 precision highp float;
 

--- a/typescript/packages/subsurface-viewer/src/layers/triangle/line.vs.glsl.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/triangle/line.vs.glsl.ts
@@ -1,6 +1,6 @@
 export default `\
 #version 300 es
-#define SHADER_NAME triangle-lines-vertex-shader
+#define SHADER_NAME triangle-line-vertex-shader
 
 precision highp float;
 
@@ -14,6 +14,8 @@ void main(void) {
 
    vec3 position_commonspace = project_position(position);
    gl_Position = project_common_position_to_clipspace(vec4(position_commonspace, 0.0));
+
+   DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
    vColor = vec4(0.0, 0.0, 0.0, layer.opacity);
    DECKGL_FILTER_COLOR(vColor, geometry);


### PR DESCRIPTION
Add DECKGL_FILTER_GL_POSITION to triangle line vertex shader for consistency with triangle vertex shader 