### PR TITLE
fix: bump @deck.gl-community/editable-layers

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -2178,9 +2178,10 @@
       }
     },
     "node_modules/@deck.gl-community/editable-layers": {
-      "version": "9.1.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@deck.gl-community/editable-layers/-/editable-layers-9.1.0-beta.4.tgz",
-      "integrity": "sha512-h5Vf+QnpIIBvWcY78biV2Oc1Smjq8wb1KVVeKWghS2VuwQvXJVwIvEk5et0ulKN54lkXmBlub27xzeVvBwyMog==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@deck.gl-community/editable-layers/-/editable-layers-9.1.1.tgz",
+      "integrity": "sha512-NOmyLdOB8i2MSingwzY6i7H/KSF9si8zPhHGMjXZIwtAgc4TrA3Fi3IZA8+bL1CiB7JnXUcBTHeielBCfr+FDQ==",
+      "license": "MIT",
       "dependencies": {
         "@turf/along": "^6.5.0",
         "@turf/area": "^6.5.0",
@@ -2214,20 +2215,21 @@
         "@types/geojson": "^7946.0.14",
         "cubic-hermite-spline": "^1.0.1",
         "eventemitter3": "^5.0.0",
+        "lodash.omit": "^4.1.1",
         "lodash.throttle": "^4.1.1",
         "uuid": "9.0.0",
         "viewport-mercator-project": ">=6.2.3"
       },
       "peerDependencies": {
         "@deck.gl-community/layers": "^9.1.0-beta.2",
-        "@deck.gl/core": "^9.1.0",
+        "@deck.gl/core": "^9.1.12",
         "@deck.gl/extensions": "^9.1.0",
         "@deck.gl/geo-layers": "^9.1.0",
         "@deck.gl/layers": "^9.1.0",
         "@deck.gl/mesh-layers": "^9.1.0",
-        "@luma.gl/constants": ">=9.1.0",
-        "@luma.gl/core": ">=9.1.0",
-        "@luma.gl/engine": ">=9.1.0",
+        "@luma.gl/constants": "^9.1.0",
+        "@luma.gl/core": "^9.1.0",
+        "@luma.gl/engine": "^9.1.0",
         "@math.gl/core": ">=4.0.1"
       }
     },
@@ -23049,6 +23051,13 @@
       "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.3.0.tgz",
       "integrity": "sha512-NpSm8HRm1WkBBWHUveDukLF4Kfb5P5E3fjHc9Qre9A11nNubozLWD2wH3UBTZbu+KSuX8aSUvy9b+PUyEceJ8g=="
     },
+    "node_modules/lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
+      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
+      "license": "MIT"
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -32087,7 +32096,7 @@
       "version": "1.13.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "@deck.gl-community/editable-layers": "^9.1.0-beta.4",
+        "@deck.gl-community/editable-layers": "^9.1.1",
         "@deck.gl/aggregation-layers": "^9.1.14",
         "@deck.gl/core": "^9.1.14",
         "@deck.gl/extensions": "^9.1.14",

--- a/typescript/packages/subsurface-viewer/package.json
+++ b/typescript/packages/subsurface-viewer/package.json
@@ -32,7 +32,7 @@
   "author": "Equinor <opensource@equinor.com>",
   "license": "MPL-2.0",
   "dependencies": {
-    "@deck.gl-community/editable-layers": "^9.1.0-beta.4",
+    "@deck.gl-community/editable-layers": "^9.1.1",
     "@deck.gl/aggregation-layers": "^9.1.14",
     "@deck.gl/core": "^9.1.14",
     "@deck.gl/extensions": "^9.1.14",


### PR DESCRIPTION
Bump @deck.gl-community/editable-layers from 9.1.0-beta.4 to 9.1.1