### PR TITLE
[Subsurface Viewer] Patch: Fix picking radius for multi-picking and clamp interpolation

### DIFF
--- a/typescript/packages/subsurface-viewer/src/components/Map.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.tsx
@@ -606,6 +606,7 @@ const Map: React.FC<MapProps> = ({
                         y: event.offsetCenter.y,
                         depth: pickingDepth,
                         unproject3D: true,
+                        radius: pickingRadius,
                     });
 
                 pickInfos.forEach((itemPick) => {

--- a/typescript/packages/subsurface-viewer/src/layers/wells/types.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/wells/types.ts
@@ -13,7 +13,10 @@ export type WellFeature = Feature<GeometryCollection, GeoJsonWellProperties>;
 export type WellFeatureCollection = FeatureCollection<
     GeometryCollection,
     GeoJsonWellProperties
->;
+> & {
+    // ? This is used in the example volve-well feature-collection, but is not part of the standard. Should we include it?
+    unit?: string;
+};
 
 export interface WellsPickInfo extends LayerPickInfo<WellFeature> {
     featureType?: string;

--- a/typescript/packages/subsurface-viewer/src/layers/wells/wellsLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/wells/wellsLayer.ts
@@ -1255,7 +1255,13 @@ function getMd(
         trajectory = trajectory3D;
     }
 
-    return interpolateDataOnTrajectory(coord, measured_depths, trajectory);
+    const interpolatedMd = interpolateDataOnTrajectory(
+        coord,
+        measured_depths,
+        trajectory
+    );
+
+    return Math.min(interpolatedMd, measured_depths.at(-1)!);
 }
 
 function getMdProperty(
@@ -1302,7 +1308,10 @@ function getTvd(
         return v[2];
     }) as number[];
 
-    return interpolateDataOnTrajectory(coord, tvds, trajectory);
+    const interpolatedMd = interpolateDataOnTrajectory(coord, tvds, trajectory);
+
+    // TVD goes downards, so it's reversed
+    return Math.max(interpolatedMd, tvds.at(-1)!);
 }
 
 function getTvdProperty(


### PR DESCRIPTION
* Fixes a bug where multipicking would ignore the set picking-radius
* Updates some typing and cleans up the map picking code
* Made the interpolated MD and TVD values given when picking wellbores not exceed the actual wellbore path.
* deprecated the `coords` prop, as the name is un-intuitive, and made it more cumbersome to customize the picking settings. The prop has been split into three more clear properties instead:
   * `pickingDepth`
   * `multiPicking`
   * `showReadout`

