### PR TITLE
docs: storybook, height issues in storybook docs

### DIFF
--- a/typescript/.storybook/preview.tsx
+++ b/typescript/.storybook/preview.tsx
@@ -10,9 +10,9 @@ const preview: Preview = {
         },
         docs: {
             story: {
-                height: "500px"
+                height: "500px",
             },
-        }
+        },
     },
 };
 


### PR DESCRIPTION
Added a 'height' property to the Storybook docs story configuration to improve documentation layout and readability. (acts as default height).

issue: https://github.com/equinor/webviz-subsurface-components/issues/2483
reference: https://storybook.js.org/docs/writing-stories/parameters