### PR TITLE
test: Make snapshot test a little more lenient

### DIFF
--- a/typescript/.storybook/test-runner.ts
+++ b/typescript/.storybook/test-runner.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error TS7016
 import { toMatchImageSnapshot } from "jest-image-snapshot";
 
 import { getStoryContext, type TestRunnerConfig } from "@storybook/test-runner";
@@ -5,6 +6,7 @@ import { getStoryContext, type TestRunnerConfig } from "@storybook/test-runner";
 // https://github.com/mapbox/pixelmatch#pixelmatchimg1-img2-output-width-height-options
 const customDiffConfig = {};
 
+// @ts-expect-error TS7006
 const screenshotTest = async (page, context) => {
     let previousScreenshot: Buffer = Buffer.from("");
 


### PR DESCRIPTION
Snapshot tests are frustratingly flaky; and are usually fixed by just rerunning the Github action until it succeeds.

The current config has a failure threshold of 50 pixels, but I'd argue this is way too aggressive, and pixel differences will vary based on screenshot resolutions (I've had flows fail by 60 pixels, which was 0.006 percent of the image...). 

This PR changes the threshold to a percentage difference instead, allowing a difference of 0.01 