### PR TITLE
ci: prevent semantic release from changelog updates

### DIFF
--- a/typescript/nx.json
+++ b/typescript/nx.json
@@ -24,6 +24,9 @@
             "projectChangelogs": {
                 "createRelease": "github"
             }
+        },
+        "git": {
+            "commitMessage": "chore(release): updated version [no ci]"
         }
     }
 }


### PR DESCRIPTION
Cf. https://medium.com/@michadrabikowski/automated-releases-with-nx-and-github-actions-07f574041293:

> If you decide to implement fully automated releasing with versioning, then you will notice that your on-push workflow triggers the on-push once again.

> This is happening because during the on-push workflow, runner is automatically pushing commit with updated package.json to main branch.

> In order to eliminate this, you can configure your nx project to put [no ci] to the commit message that updates the version.