### PR TITLE
chore: use regular GITHUB_TOKEN for semantic release

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -14,12 +14,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }} 
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure git
         run: |
-          git config --global user.name "hkfb"
-          git config --global user.email "hkfb@users.noreply.github.com"
+          git config --global user.name "Semantic Release"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -28,7 +28,6 @@ jobs:
           registry-url: https://registry.npmjs.org/
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
 
       - name: 📦 Install build dependencies
         working-directory: ./typescript
@@ -44,8 +43,7 @@ jobs:
         working-directory: ./typescript
         run: npx nx release --yes
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://nx.dev/docs/guides/nx-release/automate-github-releases
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          npm_config_legacy_peer_deps: false  # `nx release version` corrupts package-lock.json. See https://github.com/nrwl/nx/issues/22066#issuecomment-2576366862
+          npm_config_legacy_peer_deps: false # `nx release version` corrupts package-lock.json. See https://github.com/nrwl/nx/issues/22066#issuecomment-2576366862

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -202,7 +202,6 @@ jobs:
         working-directory: ./typescript
         run: npx nx release --dry-run --yes
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://nx.dev/docs/guides/nx-release/automate-github-releases
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Semantic release is broken, probably caused by expired custom token. The fix tentative is to use the regular GITHUB_TOKEN (one shot, more secure).

Also update the git user for semantic release, to have a clearer info.