### PR TITLE
fix: pin to deckgl 9.2 to prevent 9.3 being installed

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -2149,58 +2149,63 @@
       }
     },
     "node_modules/@deck.gl-community/editable-layers": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl-community/editable-layers/-/editable-layers-9.1.1.tgz",
-      "integrity": "sha512-NOmyLdOB8i2MSingwzY6i7H/KSF9si8zPhHGMjXZIwtAgc4TrA3Fi3IZA8+bL1CiB7JnXUcBTHeielBCfr+FDQ==",
+      "version": "9.2.8",
+      "resolved": "https://registry.npmjs.org/@deck.gl-community/editable-layers/-/editable-layers-9.2.8.tgz",
+      "integrity": "sha512-E9i4LwstJ+d/BqF46afhKVNHZuQt4gwdWL6jqsD4lfzr0IdWJMGmg+r8xtwHYK+nhbraHfX+ddDNUR03bPvswg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/along": "^6.5.0",
-        "@turf/area": "^6.5.0",
-        "@turf/bbox": "^6.5.0",
-        "@turf/bbox-polygon": "^6.5.0",
-        "@turf/bearing": "^6.5.0",
-        "@turf/boolean-point-in-polygon": "^6.5.0",
-        "@turf/buffer": "^6.5.0",
-        "@turf/center": "^6.5.0",
-        "@turf/centroid": "^6.5.0",
-        "@turf/circle": "^6.5.0",
-        "@turf/clone": "^6.5.0",
-        "@turf/destination": "^6.5.0",
-        "@turf/difference": "^6.5.0",
-        "@turf/distance": "^6.5.0",
-        "@turf/ellipse": "^6.5.0",
-        "@turf/helpers": "^6.5.0",
-        "@turf/intersect": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "@turf/line-intersect": "^6.5.0",
-        "@turf/meta": "^6.5.0",
-        "@turf/midpoint": "^6.5.0",
-        "@turf/nearest-point-on-line": "^6.5.0",
-        "@turf/point-to-line-distance": "^6.5.0",
-        "@turf/polygon-to-line": "^6.5.0",
-        "@turf/rewind": "^6.5.0",
-        "@turf/transform-rotate": "^6.5.0",
-        "@turf/transform-scale": "^6.5.0",
-        "@turf/transform-translate": "^6.5.0",
-        "@turf/union": "^6.5.0",
-        "@types/geojson": "^7946.0.14",
-        "cubic-hermite-spline": "^1.0.1",
+        "@math.gl/web-mercator": ">=4.0.1",
+        "@turf/along": "^7.2.0",
+        "@turf/area": "^7.2.0",
+        "@turf/bbox": "^7.2.0",
+        "@turf/bbox-polygon": "^7.2.0",
+        "@turf/bearing": "^7.2.0",
+        "@turf/boolean-point-in-polygon": "^7.2.0",
+        "@turf/boolean-within": "^7.2.0",
+        "@turf/buffer": "^7.2.0",
+        "@turf/center": "^7.2.0",
+        "@turf/centroid": "^7.2.0",
+        "@turf/circle": "^7.2.0",
+        "@turf/clone": "^7.2.0",
+        "@turf/destination": "^7.2.0",
+        "@turf/difference": "^7.2.0",
+        "@turf/distance": "^7.2.0",
+        "@turf/ellipse": "^7.2.0",
+        "@turf/helpers": "^7.2.0",
+        "@turf/intersect": "^7.2.0",
+        "@turf/invariant": "^7.2.0",
+        "@turf/kinks": "^7.2.0",
+        "@turf/line-intersect": "^7.2.0",
+        "@turf/meta": "^7.2.0",
+        "@turf/midpoint": "^7.2.0",
+        "@turf/nearest-point-on-line": "^7.2.0",
+        "@turf/point-to-line-distance": "^7.2.0",
+        "@turf/polygon-to-line": "^7.2.0",
+        "@turf/rewind": "^7.2.0",
+        "@turf/rhumb-bearing": "^7.2.0",
+        "@turf/rhumb-destination": "^7.2.0",
+        "@turf/rhumb-distance": "^7.2.0",
+        "@turf/transform-rotate": "^7.2.0",
+        "@turf/transform-scale": "^7.2.0",
+        "@turf/transform-translate": "^7.2.0",
+        "@turf/union": "^7.2.0",
+        "@types/geojson": "^7946.0.16",
         "eventemitter3": "^5.0.0",
         "lodash.omit": "^4.1.1",
         "lodash.throttle": "^4.1.1",
-        "uuid": "9.0.0",
-        "viewport-mercator-project": ">=6.2.3"
+        "preact": "^10.17.0",
+        "uuid": "9.0.0"
       },
       "peerDependencies": {
-        "@deck.gl-community/layers": "^9.1.0-beta.2",
-        "@deck.gl/core": "^9.1.12",
-        "@deck.gl/extensions": "^9.1.0",
-        "@deck.gl/geo-layers": "^9.1.0",
-        "@deck.gl/layers": "^9.1.0",
-        "@deck.gl/mesh-layers": "^9.1.0",
-        "@luma.gl/constants": "^9.1.0",
-        "@luma.gl/core": "^9.1.0",
-        "@luma.gl/engine": "^9.1.0",
+        "@deck.gl-community/layers": "^9.2.0-beta",
+        "@deck.gl/core": "~9.2.8",
+        "@deck.gl/extensions": "~9.2.8",
+        "@deck.gl/geo-layers": "~9.2.8",
+        "@deck.gl/layers": "~9.2.8",
+        "@deck.gl/mesh-layers": "~9.2.8",
+        "@luma.gl/constants": "~9.2.6",
+        "@luma.gl/core": "~9.2.6",
+        "@luma.gl/engine": "~9.2.6",
         "@math.gl/core": ">=4.0.1"
       }
     },
@@ -2214,39 +2219,30 @@
       }
     },
     "node_modules/@deck.gl-community/layers": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl-community/layers/-/layers-9.1.1.tgz",
-      "integrity": "sha512-uGyZLmI7ljkaykq6I8pO6AekeIecab1B/hz4gqGGFe4V9PSfI2e5niMkpQwj7HJAmAaYuAyd6hDReKDrAWYcAQ==",
+      "version": "9.2.8",
+      "resolved": "https://registry.npmjs.org/@deck.gl-community/layers/-/layers-9.2.8.tgz",
+      "integrity": "sha512-R2EJy5CgS7fByDBxcz88Ci017jqXjj6OpznhS5eGfzhVhutk+paH9mHJFDvwQCLtqI0Ko90o34nBFO17bxqEKw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deck.gl/core": "^9.1.12",
-        "@deck.gl/extensions": "^9.1.0",
-        "@deck.gl/geo-layers": "^9.1.0",
-        "@deck.gl/layers": "^9.1.0",
-        "@deck.gl/mesh-layers": "^9.1.0",
-        "@deck.gl/react": "^9.1.0",
-        "@loaders.gl/core": "^4.2.0",
-        "@loaders.gl/i3s": "^4.2.0",
-        "@loaders.gl/loader-utils": "^4.2.0",
-        "@loaders.gl/schema": "^4.2.0",
-        "@loaders.gl/tiles": "^4.2.0",
-        "@luma.gl/constants": "^9.1.0",
-        "@luma.gl/core": "^9.1.0",
-        "@luma.gl/engine": "^9.1.0",
-        "@math.gl/core": "^4.0.0",
-        "a5-js": "^0.1.4",
-        "h3-js": "^4.2.1"
+        "@deck.gl/core": "~9.2.8",
+        "@deck.gl/layers": "~9.2.8",
+        "@deck.gl/mesh-layers": "~9.2.8",
+        "@luma.gl/constants": "~9.2.6",
+        "@luma.gl/core": "~9.2.6",
+        "@luma.gl/engine": "~9.2.6",
+        "@luma.gl/shadertools": "~9.2.6",
+        "@math.gl/core": "^4.0.0"
       }
     },
     "node_modules/@deck.gl/aggregation-layers": {
-      "version": "9.2.7",
-      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.2.7.tgz",
-      "integrity": "sha512-dHBHMb8gitQVDNdgHlkPZ0YtxgU/4Ftbuelb6pE+1GiwXA/ie3tw+WWOQIxYiidmKJ5rVO2kr/cct75RhFcT2Q==",
+      "version": "9.2.11",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.2.11.tgz",
+      "integrity": "sha512-MRFbBHtMcDkOthxXnMPm6nF08DjFDACaIQsJSyHkdWtLUTSLHsWnOTn/8QbB4ka86WyNyfJy3dibLu/m3ei2ow==",
       "license": "MIT",
       "dependencies": {
-        "@luma.gl/constants": "^9.2.6",
-        "@luma.gl/shadertools": "^9.2.6",
+        "@luma.gl/constants": "~9.2.6",
+        "@luma.gl/shadertools": "~9.2.6",
         "@math.gl/core": "^4.1.0",
         "@math.gl/web-mercator": "^4.1.0",
         "d3-hexbin": "^0.2.1"
@@ -2259,38 +2255,38 @@
       }
     },
     "node_modules/@deck.gl/core": {
-      "version": "9.2.7",
-      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.2.7.tgz",
-      "integrity": "sha512-mltYFDC2dMtAZPkAaVIadccbM3iy9jjnhLa5obFnWzPtXyc1UBr7OW50Cjy0IlQmAsgDI2BATzcw5a/p4zU8zw==",
+      "version": "9.2.11",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.2.11.tgz",
+      "integrity": "sha512-lpdxXQuFSkd6ET7M6QxPI8QMhsLRY6vzLyk83sPGFb7JSb4OhrNHYt9sfIhcA/hxJW7bdBSMWWphf2GvQetVuA==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/core": "^4.3.4",
-        "@loaders.gl/images": "^4.3.4",
-        "@luma.gl/constants": "^9.2.6",
-        "@luma.gl/core": "^9.2.6",
-        "@luma.gl/engine": "^9.2.6",
-        "@luma.gl/shadertools": "^9.2.6",
-        "@luma.gl/webgl": "^9.2.6",
+        "@loaders.gl/core": "~4.3.4",
+        "@loaders.gl/images": "~4.3.4",
+        "@luma.gl/constants": "~9.2.6",
+        "@luma.gl/core": "~9.2.6",
+        "@luma.gl/engine": "~9.2.6",
+        "@luma.gl/shadertools": "~9.2.6",
+        "@luma.gl/webgl": "~9.2.6",
         "@math.gl/core": "^4.1.0",
         "@math.gl/sun": "^4.1.0",
         "@math.gl/types": "^4.1.0",
         "@math.gl/web-mercator": "^4.1.0",
-        "@probe.gl/env": "^4.1.0",
-        "@probe.gl/log": "^4.1.0",
-        "@probe.gl/stats": "^4.1.0",
+        "@probe.gl/env": "^4.1.1",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1",
         "@types/offscreencanvas": "^2019.6.4",
         "gl-matrix": "^3.0.0",
         "mjolnir.js": "^3.0.0"
       }
     },
     "node_modules/@deck.gl/extensions": {
-      "version": "9.2.7",
-      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.2.7.tgz",
-      "integrity": "sha512-jIsep2NByEimWlScqc/NLjpqWknLk5rd+uP8UAl7qI8CTInXV4KdzaYgujL+bE4lSV4Zlg0oMOAkbcviMKDLNw==",
+      "version": "9.2.11",
+      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.2.11.tgz",
+      "integrity": "sha512-zlpM4Bg1ifBziW1Juiii9NY5gyW2rEhyVTWnhagH/bpTCZ2E73OhnToYt1ouqmoxL6lMtIjhRXz6LPb7tJbHHQ==",
       "license": "MIT",
       "dependencies": {
-        "@luma.gl/constants": "^9.2.6",
-        "@luma.gl/shadertools": "^9.2.6",
+        "@luma.gl/constants": "~9.2.6",
+        "@luma.gl/shadertools": "~9.2.6",
         "@math.gl/core": "^4.1.0"
       },
       "peerDependencies": {
@@ -2300,21 +2296,21 @@
       }
     },
     "node_modules/@deck.gl/geo-layers": {
-      "version": "9.2.7",
-      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.2.7.tgz",
-      "integrity": "sha512-DiEfsmWrW0EIM44FdwzdPAjUr8a8IPelpkt2fPvrgmaS0OSZFB1PkJWLmM3hoYO8mH0vuD0YL//m+Pvtw3bGSw==",
+      "version": "9.2.11",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.2.11.tgz",
+      "integrity": "sha512-Mr3yvKyZMPmQ3ho0hSqcJu1p7a881RqQaq/dRaPs2VP56UAkfk1e10zxXnrZ9/Dmo2MR5PH0j8tkOoGR3zKbfA==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/3d-tiles": "^4.3.4",
-        "@loaders.gl/gis": "^4.3.4",
-        "@loaders.gl/loader-utils": "^4.3.4",
-        "@loaders.gl/mvt": "^4.3.4",
-        "@loaders.gl/schema": "^4.3.4",
-        "@loaders.gl/terrain": "^4.3.4",
-        "@loaders.gl/tiles": "^4.3.4",
-        "@loaders.gl/wms": "^4.3.4",
-        "@luma.gl/gltf": "^9.2.6",
-        "@luma.gl/shadertools": "^9.2.6",
+        "@loaders.gl/3d-tiles": "~4.3.4",
+        "@loaders.gl/gis": "~4.3.4",
+        "@loaders.gl/loader-utils": "~4.3.4",
+        "@loaders.gl/mvt": "~4.3.4",
+        "@loaders.gl/schema": "~4.3.4",
+        "@loaders.gl/terrain": "~4.3.4",
+        "@loaders.gl/tiles": "~4.3.4",
+        "@loaders.gl/wms": "~4.3.4",
+        "@luma.gl/gltf": "~9.2.6",
+        "@luma.gl/shadertools": "~9.2.6",
         "@math.gl/core": "^4.1.0",
         "@math.gl/culling": "^4.1.0",
         "@math.gl/web-mercator": "^4.1.0",
@@ -2328,7 +2324,7 @@
         "@deck.gl/extensions": "~9.2.0",
         "@deck.gl/layers": "~9.2.0",
         "@deck.gl/mesh-layers": "~9.2.0",
-        "@loaders.gl/core": "^4.3.4",
+        "@loaders.gl/core": "~4.3.4",
         "@luma.gl/core": "~9.2.6",
         "@luma.gl/engine": "~9.2.6"
       }
@@ -2343,9 +2339,9 @@
       }
     },
     "node_modules/@deck.gl/json": {
-      "version": "9.2.7",
-      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-9.2.7.tgz",
-      "integrity": "sha512-8XnEOERjtW+BvaRsmWpdK0th5HWmVoaQ2l2G8Y2BdSdJdcOuFQlQamYnoPPDpqhwiqTd1hommQMGbf0/2hliaw==",
+      "version": "9.2.11",
+      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-9.2.11.tgz",
+      "integrity": "sha512-xUc8y79kAQNqDJegDkEFWgdfE3JDaTdLtSerzwX5gR7q8mZMMZ0tcFM5IqE+mB3EoNbUgTY7m/7LnzO58XGP6g==",
       "license": "MIT",
       "dependencies": {
         "jsep": "^0.3.0"
@@ -2355,14 +2351,14 @@
       }
     },
     "node_modules/@deck.gl/layers": {
-      "version": "9.2.7",
-      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.2.7.tgz",
-      "integrity": "sha512-oGRv3s+i+Rq4qQFTfdCBx2S650K4p0gGS/bPYpURCXW0a0LQBHqN8AkKbhdos7b7Lawp1iMwkIggBZSZaNkyXg==",
+      "version": "9.2.11",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.2.11.tgz",
+      "integrity": "sha512-2FSb0Qa6YR+Rg6GWhYOGTUug3vtZ4uKcFdnrdiJoVXGyibKJMScKZIsivY0r/yQQZsaBjYqty5QuVJvdtEHxSA==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/images": "^4.3.4",
-        "@loaders.gl/schema": "^4.3.4",
-        "@luma.gl/shadertools": "^9.2.6",
+        "@loaders.gl/images": "~4.3.4",
+        "@loaders.gl/schema": "~4.3.4",
+        "@luma.gl/shadertools": "~9.2.6",
         "@mapbox/tiny-sdf": "^2.0.5",
         "@math.gl/core": "^4.1.0",
         "@math.gl/polygon": "^4.1.0",
@@ -2371,21 +2367,21 @@
       },
       "peerDependencies": {
         "@deck.gl/core": "~9.2.0",
-        "@loaders.gl/core": "^4.3.4",
+        "@loaders.gl/core": "~4.3.4",
         "@luma.gl/core": "~9.2.6",
         "@luma.gl/engine": "~9.2.6"
       }
     },
     "node_modules/@deck.gl/mesh-layers": {
-      "version": "9.2.7",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.2.7.tgz",
-      "integrity": "sha512-EpWHJ3GaCXELCsYRlabvkXxtgLQwOZYU8YPOmlKUYf+/410B2D89oNGtJinRcfM1/T9TBelBS9CHMYsL1tv9cA==",
+      "version": "9.2.11",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.2.11.tgz",
+      "integrity": "sha512-zPB7TtnPXB3tOEoOfcOkNZo7coIq/ukIQa8HIUQLLiOE8AVSQfz3kbMmMK6rUabXlQbgSw/I/j3kFSYRHg3NGg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/gltf": "^4.3.4",
-        "@loaders.gl/schema": "^4.3.4",
-        "@luma.gl/gltf": "^9.2.6",
-        "@luma.gl/shadertools": "^9.2.6"
+        "@loaders.gl/gltf": "~4.3.4",
+        "@loaders.gl/schema": "~4.3.4",
+        "@luma.gl/gltf": "~9.2.6",
+        "@luma.gl/shadertools": "~9.2.6"
       },
       "peerDependencies": {
         "@deck.gl/core": "~9.2.0",
@@ -2396,9 +2392,9 @@
       }
     },
     "node_modules/@deck.gl/react": {
-      "version": "9.2.7",
-      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-9.2.7.tgz",
-      "integrity": "sha512-ktCDdvGCkyAe1weCcgR78xSi8Jdgtrjql69QRaaJME73i3FrmCdyPqcASwg/XNKTzWrGATX2P579NSX0QFoOBA==",
+      "version": "9.2.11",
+      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-9.2.11.tgz",
+      "integrity": "sha512-7xrXlM++3A7cKZdDKSW2/EPT6sc0ob7J24sTPaHe3YlIIFvCZTkQ1U1rAT9cN2gjhkI6XsE+TugUsqhx4TGwHQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deck.gl/core": "~9.2.0",
@@ -4697,31 +4693,6 @@
         "@loaders.gl/schema": "4.3.4",
         "@loaders.gl/textures": "4.3.4",
         "@math.gl/core": "^4.1.0"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/i3s": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/i3s/-/i3s-4.3.4.tgz",
-      "integrity": "sha512-U71BwsLZ6wqDUxBWPWwdsAhZEwYjEluixmEPdif40KD318YoPEU7CU+w/gEE6JhlTijDhmEgsFCpRC+yvs15qw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@loaders.gl/compression": "4.3.4",
-        "@loaders.gl/crypto": "4.3.4",
-        "@loaders.gl/draco": "4.3.4",
-        "@loaders.gl/images": "4.3.4",
-        "@loaders.gl/loader-utils": "4.3.4",
-        "@loaders.gl/math": "4.3.4",
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/textures": "4.3.4",
-        "@loaders.gl/tiles": "4.3.4",
-        "@loaders.gl/zip": "4.3.4",
-        "@math.gl/core": "^4.1.0",
-        "@math.gl/culling": "^4.1.0",
-        "@math.gl/geospatial": "^4.1.0"
       },
       "peerDependencies": {
         "@loaders.gl/core": "^4.3.0"
@@ -7714,24 +7685,24 @@
       }
     },
     "node_modules/@probe.gl/env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-4.1.0.tgz",
-      "integrity": "sha512-5ac2Jm2K72VCs4eSMsM7ykVRrV47w32xOGMvcgqn8vQdEMF9PRXyBGYEV9YbqRKWNKpNKmQJVi4AHM/fkCxs9w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-4.1.1.tgz",
+      "integrity": "sha512-+68seNDMVsEegRB47pFA/Ws1Fjy8agcFYXxzorKToyPcD6zd+gZ5uhwoLd7TzsSw6Ydns//2KEszWn+EnNHTbA==",
       "license": "MIT"
     },
     "node_modules/@probe.gl/log": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-4.1.0.tgz",
-      "integrity": "sha512-r4gRReNY6f+OZEMgfWEXrAE2qJEt8rX0HsDJQXUBMoc+5H47bdB7f/5HBHAmapK8UydwPKL9wCDoS22rJ0yq7Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-4.1.1.tgz",
+      "integrity": "sha512-kcZs9BT44pL7hS1OkRGKYRXI/SN9KejUlPD+BY40DguRLzdC5tLG/28WGMyfKdn/51GT4a0p+0P8xvDn1Ez+Kg==",
       "license": "MIT",
       "dependencies": {
-        "@probe.gl/env": "4.1.0"
+        "@probe.gl/env": "4.1.1"
       }
     },
     "node_modules/@probe.gl/stats": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.1.0.tgz",
-      "integrity": "sha512-EI413MkWKBDVNIfLdqbeNSJTs7ToBz/KVGkwi3D+dQrSIkRI2IYbWGAU3xX+D6+CI4ls8ehxMhNpUVMaZggDvQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.1.1.tgz",
+      "integrity": "sha512-4VpAyMHOqydSvPlEyHwXaE+AkIdR03nX+Qhlxsk2D/IW4OVmDZgIsvJB1cDzyEEtcfKcnaEbfXeiPgejBceT6g==",
       "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
@@ -9119,6 +9090,18 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@swc/jest": {
       "version": "0.2.29",
       "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.29.tgz",
@@ -9370,150 +9353,206 @@
       }
     },
     "node_modules/@turf/along": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/along/-/along-6.5.0.tgz",
-      "integrity": "sha512-LLyWQ0AARqJCmMcIEAXF4GEu8usmd4Kbz3qk1Oy5HoRNpZX47+i5exQtmIWKdqJ1MMhW26fCTXgpsEs5zgJ5gw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-7.3.4.tgz",
+      "integrity": "sha512-PvIoXin0I1t3nRwJz7uqR6fsxDMqdGwJq90qGOeqkNwlZqlF+5o2wKHPwYwi0RXZhLvxRP5qlbNIvV8ADdbWxw==",
       "license": "MIT",
       "dependencies": {
-        "@turf/bearing": "^6.5.0",
-        "@turf/destination": "^6.5.0",
-        "@turf/distance": "^6.5.0",
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
+        "@turf/bearing": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/area": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.5.0.tgz",
-      "integrity": "sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.4.tgz",
+      "integrity": "sha512-UEQQFw2XwHpozSBAMEtZI3jDsAad4NnHL/poF7/S6zeDCjEBCkt3MYd6DSGH/cvgcOozxH/ky3/rIVSMZdx4vA==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/meta": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/bbox": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
-      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.4.tgz",
+      "integrity": "sha512-D5ErVWtfQbEPh11yzI69uxqrcJmbPU/9Y59f1uTapgwAwQHQztDWgsYpnL3ns8r1GmPWLP8sGJLVTIk2TZSiYA==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/meta": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/bbox-polygon": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-6.5.0.tgz",
-      "integrity": "sha512-+/r0NyL1lOG3zKZmmf6L8ommU07HliP4dgYToMoTxqzsWzyLjaj/OzgQ8rBmv703WJX+aS6yCmLuIhYqyufyuw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-7.3.4.tgz",
+      "integrity": "sha512-XCDYQwCA41Bum3R1xX0Na1nR4ozoe/pCYy5bxqrzyMs87kPJUIfBrD5IWxjnZyLqFpfEpolMHJz5ed1uA2PanQ==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/bearing": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
-      "integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.3.4.tgz",
+      "integrity": "sha512-zvFjapyFaOrM8nBtAND7f4yb0BJV0jyj6cyoXyTYqLY+3Hn0eHgL0M8lwxDLbTom5KfqYDHDVDQC3+VSfypoEA==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/boolean-clockwise": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-6.5.0.tgz",
-      "integrity": "sha512-45+C7LC5RMbRWrxh3Z0Eihsc8db1VGBO5d9BLTOAwU4jR6SgsunTfRWR16X7JUwIDYlCVEmnjcXJNi/kIU3VIw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-7.3.4.tgz",
+      "integrity": "sha512-X/O+u/OsoJ99mujhlqviuB7HX0tdJ5931TBjNSseps43XtROVuB5PwBDgwKfu5lY1B4DSGAxbbxJ795RmPnguQ==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/boolean-point-in-polygon": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.5.0.tgz",
-      "integrity": "sha512-DtSuVFB26SI+hj0SjrvXowGTUCHlgevPAIsukssW6BG5MlNSBQAo70wpICBNJL6RjukXg8d2eXaAWuD/CqL00A==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.4.tgz",
+      "integrity": "sha512-v/4hfyY90Vz9cDgs2GwjQf+Lft8o7mNCLJOTz/iv8SHAIgMMX0czEoIaNVOJr7tBqPqwin1CGwsncrkf5C9n8Q==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.3.4.tgz",
+      "integrity": "sha512-70gm5x6YQOZKcw0b/O4jjMwVWnFj+Zb6TXozLgZFDZShc8pgTQtZku7K+HKZ7Eya+7usHIB4IimZauomOMa+iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-within": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-7.3.4.tgz",
+      "integrity": "sha512-eLgi803gz0KcYkyxnnqnz9Vd6tw2/0eAExe/Rq8sO0dqypaSiomSumxjqu89d/yo24Qz8gW7c0kJ6YihNbMYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/boolean-point-in-polygon": "7.3.4",
+        "@turf/boolean-point-on-line": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-split": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/buffer": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-6.5.0.tgz",
-      "integrity": "sha512-qeX4N6+PPWbKqp1AVkBVWFerGjMYMUyencwfnkCesoznU6qvfugFHNAngNqIBVnJjZ5n8IFyOf+akcxnrt9sNg==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-7.3.4.tgz",
+      "integrity": "sha512-MVOCBDuOl3KGDsh2stW12RmiFaFeSkVjeUbZ+ADUtIVnv+jlFsmjBpFtsEw8s9YQn5g0667QppOshm0FBHA57Q==",
       "license": "MIT",
       "dependencies": {
-        "@turf/bbox": "^6.5.0",
-        "@turf/center": "^6.5.0",
-        "@turf/helpers": "^6.5.0",
-        "@turf/meta": "^6.5.0",
-        "@turf/projection": "^6.5.0",
-        "d3-geo": "1.7.1",
-        "turf-jsts": "*"
+        "@turf/bbox": "7.3.4",
+        "@turf/center": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/jsts": "^2.7.1",
+        "@turf/meta": "7.3.4",
+        "@turf/projection": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "d3-geo": "1.7.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/center": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/center/-/center-6.5.0.tgz",
-      "integrity": "sha512-T8KtMTfSATWcAX088rEDKjyvQCBkUsLnK/Txb6/8WUXIeOZyHu42G7MkdkHRoHtwieLdduDdmPLFyTdG5/e7ZQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.3.4.tgz",
+      "integrity": "sha512-4SsLMDHWthXbyIHsczgFCo4fx+8tC8w2+B5HdEuY+P+cSOOL4T+6QQzd7WWjuN/Y3ndowFssUmwRrvXuwVRxQA==",
       "license": "MIT",
       "dependencies": {
-        "@turf/bbox": "^6.5.0",
-        "@turf/helpers": "^6.5.0"
+        "@turf/bbox": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/centroid": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.5.0.tgz",
-      "integrity": "sha512-MwE1oq5E3isewPprEClbfU5pXljIK/GUOMbn22UM3IFPDJX0KeoyLNwghszkdmFp/qMGL/M13MMWvU+GNLXP/A==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.4.tgz",
+      "integrity": "sha512-6c3kyTSKBrmiPMe75UkHw6MgedroZ6eR5usEvdlDhXgA3MudFPXIZkMFmMd1h9XeJ9xFfkmq+HPCdF0cOzvztA==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/meta": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/circle": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-6.5.0.tgz",
-      "integrity": "sha512-oU1+Kq9DgRnoSbWFHKnnUdTmtcRUMmHoV9DjTXu9vOLNV5OWtAAh1VZ+mzsioGGzoDNT/V5igbFOkMfBQc0B6A==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-7.3.4.tgz",
+      "integrity": "sha512-6ccr5iT51/XONF+pbpkqoRxKX4ZVWLubXb1frGCnClv2suo1UIY9SIlINNctVDupXd2P9PpqZCbrXATrcrokPg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/destination": "^6.5.0",
-        "@turf/helpers": "^6.5.0"
+        "@turf/destination": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -9533,304 +9572,379 @@
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/clean-coords/node_modules/@turf/helpers": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
-      "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
-      "dependencies": {
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/clean-coords/node_modules/@turf/invariant": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.2.0.tgz",
-      "integrity": "sha512-kV4u8e7Gkpq+kPbAKNC21CmyrXzlbBgFjO1PhrHPgEdNqXqDawoZ3i6ivE3ULJj2rSesCjduUaC/wyvH/sNr2Q==",
-      "dependencies": {
-        "@turf/helpers": "^7.2.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.8.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
     "node_modules/@turf/clone": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.5.0.tgz",
-      "integrity": "sha512-mzVtTFj/QycXOn6ig+annKrM6ZlimreKYz6f/GSERytOpgzodbQyOgkfwru100O1KQhhjSudKK4DsQ0oyi9cTw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.4.tgz",
+      "integrity": "sha512-pwQ+RyQw986uu7IulY/18NRAebwZZScb084bvVqVkTrllwLSv4oVBqUxmUMiwtp+PNdiRGRFOvNyZqtRsiD+Jw==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/destination": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-6.5.0.tgz",
-      "integrity": "sha512-4cnWQlNC8d1tItOz9B4pmJdWpXqS0vEvv65bI/Pj/genJnsL7evI0/Xw42RvEGROS481MPiU80xzvwxEvhQiMQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.3.4.tgz",
+      "integrity": "sha512-YxoUJwkKmTHiRFQxMQOP0tz8Vy+ga5EXl+C+F/WubjDLwT1AJu5y8CNIjLvWyjPWckj/vZG4u/1js5bx6MLADA==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/difference": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-6.5.0.tgz",
-      "integrity": "sha512-l8iR5uJqvI+5Fs6leNbhPY5t/a3vipUF/3AeVLpwPQcgmedNXyheYuy07PcMGH5Jdpi5gItOiTqwiU/bUH4b3A==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-7.3.4.tgz",
+      "integrity": "sha512-kIxizNQrYLO2rtqUIeed0tPycicrXoipy/g9d4mjv91kzBEbwpyojz9zi8U9G1ISBfCEgA7wsViQD0r+8qzxXw==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "polygon-clipping": "^0.15.3"
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/distance": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
-      "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.4.tgz",
+      "integrity": "sha512-9drWgd46uHPPyzgrcRQLgSvdS/SjVlQ6ZIBoRQagS5P2kSjUbcOXHIMeOSPwfxwlKhEtobLyr+IiR2ns1TfF8w==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/ellipse": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-6.5.0.tgz",
-      "integrity": "sha512-kuXtwFviw/JqnyJXF1mrR/cb496zDTSbGKtSiolWMNImYzGGkbsAsFTjwJYgD7+4FixHjp0uQPzo70KDf3AIBw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-7.3.4.tgz",
+      "integrity": "sha512-SMgbERZl12j7H8YaIofmnf0NwAvdF5Wly4tjI/eUhj/sFOKrKXOS1lvCSBJ6uSV9tFijl3ecGOVOlTpURdZ30g==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "@turf/rhumb-destination": "^6.5.0",
-        "@turf/transform-rotate": "^6.5.0"
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/transform-rotate": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.3.4.tgz",
+      "integrity": "sha512-aDG/5mMCgKduqBwZ3XpLOdlE2hizV3fM+5dHCWyrBepCQLeM/QRvvpBDCdQKDWKpoIBmrGGYDNiOofnf3QmGhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/helpers": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
-      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.4.tgz",
+      "integrity": "sha512-U/S5qyqgx3WTvg4twaH0WxF3EixoTCfDsmk98g1E3/5e2YKp7JKYZdz0vivsS5/UZLJeZDEElOSFH4pUgp+l7g==",
       "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/intersect": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-6.5.0.tgz",
-      "integrity": "sha512-2legGJeKrfFkzntcd4GouPugoqPUjexPZnOvfez+3SfIMrHvulw8qV8u7pfVyn2Yqs53yoVCEjS5sEpvQ5YRQg==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-7.3.4.tgz",
+      "integrity": "sha512-VsqMEMeRWWs2mjwI7sTlUgH1cEfugTGhQ0nF8ncHG7YKd9HUUTzIKpn9FJeoguPWIYITcy1ar4yJEOU/hteBVw==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "polygon-clipping": "^0.15.3"
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/invariant": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
-      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.4.tgz",
+      "integrity": "sha512-88Eo4va4rce9sNZs6XiMJowWkikM3cS2TBhaCKlU+GFHdNf8PFEpiU42VDU8q5tOF6/fu21Rvlke5odgOGW4AQ==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/jsts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@turf/jsts/-/jsts-2.7.2.tgz",
+      "integrity": "sha512-zAezGlwWHPyU0zxwcX2wQY3RkRpwuoBmhhNE9HY9kWhFDkCxZ3aWK5URKwa/SWKJbj9aztO+8vtdiBA28KVJFg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "dependencies": {
+        "jsts": "2.7.1"
+      }
+    },
+    "node_modules/@turf/kinks": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-7.3.4.tgz",
+      "integrity": "sha512-LZTKELWxvXl0vc9ZxVgi0v07fO9+2FrZOam2B10fz/eGjy3oKNazU5gjggbnc499wEIcJS4hN+VyjQZrmsJAdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/line-intersect": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.5.0.tgz",
-      "integrity": "sha512-CS6R1tZvVQD390G9Ea4pmpM6mJGPWoL82jD46y0q1KSor9s6HupMIo1kY4Ny+AEYQl9jd21V3Scz20eldpbTVA==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.4.tgz",
+      "integrity": "sha512-XygbTvHa6A+v6l2ZKYtS8AAWxwmrPxKxfBbdH75uED1JvdytSLWYTKGlcU3soxd9sYb4x/g9sDvRIVyU6Lucrg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "@turf/line-segment": "^6.5.0",
-        "@turf/meta": "^6.5.0",
-        "geojson-rbush": "3.x"
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "sweepline-intersections": "^1.5.0",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/line-segment": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.5.0.tgz",
-      "integrity": "sha512-jI625Ho4jSuJESNq66Mmi290ZJ5pPZiQZruPVpmHkUw257Pew0alMmb6YrqYNnLUuiVVONxAAKXUVeeUGtycfw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.3.4.tgz",
+      "integrity": "sha512-UeISzf/JHoWEY5yeoyvKwA5epWcvJMCpCwbIMolvfTC5pp+IVozjHPVCRvRWuzmbmAvetcW0unL5bjqi0ADmuQ==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "@turf/meta": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.3.4.tgz",
+      "integrity": "sha512-l1zmCSUnGsiN4gf22Aw91a2VnYs5DZS67FdkYqKgr+wPEAL/gpQgIBBWSTmhwY8zb3NEqty+f/gMEe8EJAWYng==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.4",
+        "@turf/geojson-rbush": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/line-intersect": "7.3.4",
+        "@turf/line-segment": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@turf/truncate": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/meta": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
-      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.4.tgz",
+      "integrity": "sha512-tlmw9/Hs1p2n0uoHVm1w3ugw1I6L8jv9YZrcdQa4SH5FX5UY0ATrKeIvfA55FlL//PGuYppJp+eyg/0eb4goqw==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/midpoint": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-6.5.0.tgz",
-      "integrity": "sha512-MyTzV44IwmVI6ec9fB2OgZ53JGNlgOpaYl9ArKoF49rXpL84F9rNATndbe0+MQIhdkw8IlzA6xVP4lZzfMNVCw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-7.3.4.tgz",
+      "integrity": "sha512-/XAeGvsz8l5HaqcP7TUlexzGfibqXozQgBZ8rH7az6op2Dfm3pL/Z7bKLHoVavM0ccBg0Pt7g6j9NM54kZWdKA==",
       "license": "MIT",
       "dependencies": {
-        "@turf/bearing": "^6.5.0",
-        "@turf/destination": "^6.5.0",
-        "@turf/distance": "^6.5.0",
-        "@turf/helpers": "^6.5.0"
+        "@turf/bearing": "7.3.4",
+        "@turf/destination": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/nearest-point-on-line": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-6.5.0.tgz",
-      "integrity": "sha512-WthrvddddvmymnC+Vf7BrkHGbDOUu6Z3/6bFYUGv1kxw8tiZ6n83/VG6kHz4poHOfS0RaNflzXSkmCi64fLBlg==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.4.tgz",
+      "integrity": "sha512-DQrP3lRju83rIXFN68tUEpc7ki/eRwdwBkK2CTT4RAcyCxbcH2NGJPQv8dYiww/Ar77u1WLVn+aINXZH904dWw==",
       "license": "MIT",
       "dependencies": {
-        "@turf/bearing": "^6.5.0",
-        "@turf/destination": "^6.5.0",
-        "@turf/distance": "^6.5.0",
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "@turf/line-intersect": "^6.5.0",
-        "@turf/meta": "^6.5.0"
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/point-to-line-distance": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-6.5.0.tgz",
-      "integrity": "sha512-opHVQ4vjUhNBly1bob6RWy+F+hsZDH9SA0UW36pIRzfpu27qipU18xup0XXEePfY6+wvhF6yL/WgCO2IbrLqEA==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-7.3.4.tgz",
+      "integrity": "sha512-IdPAxlAQZj7FCZg+ObyVHlNdqwLL/oxYoQjpxMNJ511gNxokCtEv0aeRZQjYOYIxr9Ss97v3yo3ILJaF9V2kPw==",
       "license": "MIT",
       "dependencies": {
-        "@turf/bearing": "^6.5.0",
-        "@turf/distance": "^6.5.0",
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "@turf/meta": "^6.5.0",
-        "@turf/projection": "^6.5.0",
-        "@turf/rhumb-bearing": "^6.5.0",
-        "@turf/rhumb-distance": "^6.5.0"
+        "@turf/bearing": "7.3.4",
+        "@turf/distance": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/nearest-point-on-line": "7.3.4",
+        "@turf/projection": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/polygon-to-line": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-6.5.0.tgz",
-      "integrity": "sha512-5p4n/ij97EIttAq+ewSnKt0ruvuM+LIDzuczSzuHTpq4oS7Oq8yqg5TQ4nzMVuK41r/tALCk7nAoBuw3Su4Gcw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-7.3.4.tgz",
+      "integrity": "sha512-xhmOZ5rHZAKLUDLeYKWMsX84ip8CCGOcGLBHtPPYOjdIDHddMV6Sxt5kVgkmlZpK6NEWEmOD6lYR4obxHcHlGA==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/projection": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.5.0.tgz",
-      "integrity": "sha512-/Pgh9mDvQWWu8HRxqpM+tKz8OzgauV+DiOcr3FCjD6ubDnrrmMJlsf6fFJmggw93mtVPrZRL6yyi9aYCQBOIvg==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-7.3.4.tgz",
+      "integrity": "sha512-p91zOaLmzoBHzU/2H6Ot1tOhTmAom85n1P7I4Oo0V9xU8hmJXWfNnomLFf/6rnkKDIFZkncLQIBz4iIecZ61sA==",
       "license": "MIT",
       "dependencies": {
-        "@turf/clone": "^6.5.0",
-        "@turf/helpers": "^6.5.0",
-        "@turf/meta": "^6.5.0"
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/rewind": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-6.5.0.tgz",
-      "integrity": "sha512-IoUAMcHWotBWYwSYuYypw/LlqZmO+wcBpn8ysrBNbazkFNkLf3btSDZMkKJO/bvOzl55imr/Xj4fi3DdsLsbzQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-7.3.4.tgz",
+      "integrity": "sha512-4BZ8MHMujl4NAT7XnIs7JoOuDhpR96oDTB0RtqTeIP4onioIedVnw1ZA3Uq08sILGpR0qKLuDsvdz4x9jtbptg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/boolean-clockwise": "^6.5.0",
-        "@turf/clone": "^6.5.0",
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "@turf/meta": "^6.5.0"
+        "@turf/boolean-clockwise": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/rhumb-bearing": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.5.0.tgz",
-      "integrity": "sha512-jMyqiMRK4hzREjQmnLXmkJ+VTNTx1ii8vuqRwJPcTlKbNWfjDz/5JqJlb5NaFDcdMpftWovkW5GevfnuzHnOYA==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-7.3.4.tgz",
+      "integrity": "sha512-tvX1toSo80q0iL0cUMMXpSKsCCfOjRqDGCmOdR6B9shhk6xP1ZM2PLQDr+MFPBFeGyQuyY4CNFkV2+3DF49vYw==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/rhumb-destination": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-6.5.0.tgz",
-      "integrity": "sha512-RHNP1Oy+7xTTdRrTt375jOZeHceFbjwohPHlr9Hf68VdHHPMAWgAKqiX2YgSWDcvECVmiGaBKWus1Df+N7eE4Q==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-7.3.4.tgz",
+      "integrity": "sha512-6HikEb5nm2A18FQWk6vVLMQkc099I/7c69j47RYM27xQK8J8uBCNk1zLYyMPcZTh24xcNSbZ1iPHDsDOqw6wWQ==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/rhumb-distance": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.5.0.tgz",
-      "integrity": "sha512-oKp8KFE8E4huC2Z1a1KNcFwjVOqa99isxNOwfo4g3SUABQ6NezjKDDrnvC4yI5YZ3/huDjULLBvhed45xdCrzg==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-7.3.4.tgz",
+      "integrity": "sha512-phwskeijdgYMsR3qDQmytfsg2iZcp3uWK7UFc76wKTEpxozbDGFI4enX5gXvZPpyI1iD7gsktGqHsO33AjnFDA==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -9852,108 +9966,94 @@
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/simplify/node_modules/@turf/clone": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.1.0.tgz",
-      "integrity": "sha512-5R9qeWvL7FDdBIbEemd0eCzOStr09oburDvJ1hRiPCFX6rPgzcZBQ0gDmZzoF4AFcNLb5IwknbLZjVLaUGWtFA==",
-      "dependencies": {
-        "@turf/helpers": "^7.1.0",
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.6.2"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/simplify/node_modules/@turf/helpers": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
-      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
-      "dependencies": {
-        "@types/geojson": "^7946.0.10",
-        "tslib": "^2.6.2"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/simplify/node_modules/@turf/meta": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
-      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
-      "dependencies": {
-        "@turf/helpers": "^7.1.0",
-        "@types/geojson": "^7946.0.10"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
     "node_modules/@turf/transform-rotate": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-6.5.0.tgz",
-      "integrity": "sha512-A2Ip1v4246ZmpssxpcL0hhiVBEf4L8lGnSPWTgSv5bWBEoya2fa/0SnFX9xJgP40rMP+ZzRaCN37vLHbv1Guag==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-7.3.4.tgz",
+      "integrity": "sha512-pbUG6QLwyJvvitq4aAq4IQH79X8T0NmEPUGDUEEP69yW7t4+UZjDBAVbCKwpOc8gtsK0K5yvxlZ0e2CdtpNmEw==",
       "license": "MIT",
       "dependencies": {
-        "@turf/centroid": "^6.5.0",
-        "@turf/clone": "^6.5.0",
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "@turf/meta": "^6.5.0",
-        "@turf/rhumb-bearing": "^6.5.0",
-        "@turf/rhumb-destination": "^6.5.0",
-        "@turf/rhumb-distance": "^6.5.0"
+        "@turf/centroid": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/transform-scale": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-6.5.0.tgz",
-      "integrity": "sha512-VsATGXC9rYM8qTjbQJ/P7BswKWXHdnSJ35JlV4OsZyHBMxJQHftvmZJsFbOqVtQnIQIzf2OAly6rfzVV9QLr7g==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-7.3.4.tgz",
+      "integrity": "sha512-7gUIFFHaU3Ewj3rCzIu5Yo7Zjfv4R2ypjh6UWiMJnDavb7RQ8fn0AKKcNMA/vF/yxuncp2l3zoa2gygv4AKM8A==",
       "license": "MIT",
       "dependencies": {
-        "@turf/bbox": "^6.5.0",
-        "@turf/center": "^6.5.0",
-        "@turf/centroid": "^6.5.0",
-        "@turf/clone": "^6.5.0",
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "@turf/meta": "^6.5.0",
-        "@turf/rhumb-bearing": "^6.5.0",
-        "@turf/rhumb-destination": "^6.5.0",
-        "@turf/rhumb-distance": "^6.5.0"
+        "@turf/bbox": "7.3.4",
+        "@turf/center": "7.3.4",
+        "@turf/centroid": "7.3.4",
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/rhumb-bearing": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@turf/rhumb-distance": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/transform-translate": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-6.5.0.tgz",
-      "integrity": "sha512-NABLw5VdtJt/9vSstChp93pc6oel4qXEos56RBMsPlYB8hzNTEKYtC146XJvyF4twJeeYS8RVe1u7KhoFwEM5w==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-7.3.4.tgz",
+      "integrity": "sha512-qbSIEueOR8mNB7p4EB88vHvUAyuSBM8zxP68UiiTNV3Gh+OZF2VXTFiu3EFYMTaD9sE6Lxmzvv3fjW8N2q82pw==",
       "license": "MIT",
       "dependencies": {
-        "@turf/clone": "^6.5.0",
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "@turf/meta": "^6.5.0",
-        "@turf/rhumb-destination": "^6.5.0"
+        "@turf/clone": "7.3.4",
+        "@turf/helpers": "7.3.4",
+        "@turf/invariant": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@turf/rhumb-destination": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.4.tgz",
+      "integrity": "sha512-VPXdae9+RLLM19FMrJgt7QANBikm7DxPbfp/dXgzE4Ca7v+mJ4T1fYc7gCZDaqOrWMccHKbvv4iSuW7YZWdIIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/union": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/union/-/union-6.5.0.tgz",
-      "integrity": "sha512-igYWCwP/f0RFHIlC2c0SKDuM/ObBaqSljI3IdV/x71805QbIvY/BYGcJdyNcgEA6cylIGl/0VSlIbpJHZ9ldhw==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-7.3.4.tgz",
+      "integrity": "sha512-JJYyPMmGcrTa9sPv2ief2QU9Hb//cEAU1zgKu/OfoCMa9a8Imp5QVm9UTAkhGlc+4qm/N/X16iJ+cvVWaxPjkg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "polygon-clipping": "^0.15.3"
+        "@turf/helpers": "7.3.4",
+        "@turf/meta": "7.3.4",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -11603,16 +11703,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "node_modules/a5-js": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/a5-js/-/a5-js-0.1.4.tgz",
-      "integrity": "sha512-lpuXcoBHL4Sa5sKu+dbBaH/8L3TYIHpVBSWqBdwDVMKYNipaVpW6sZBv0x9Yu9y38iS72jWyoKLFiKynUpwvBw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "gl-matrix": "^3.4.3"
-      }
-    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -12690,6 +12780,15 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -13819,12 +13918,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
-    },
-    "node_modules/cubic-hermite-spline": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cubic-hermite-spline/-/cubic-hermite-spline-1.0.1.tgz",
-      "integrity": "sha512-OlfZfJqnCi44aYNg3YMn0IqYcvlUGv3SzRqNbm19cnZNTaMiWjFeA5l6rF/WLnmh1VBZs/kYc2QwAkD1t2Zhdg==",
       "license": "MIT"
     },
     "node_modules/cwd": {
@@ -17062,25 +17155,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/geojson-rbush": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-3.2.0.tgz",
-      "integrity": "sha512-oVltQTXolxvsz1sZnutlSuLDEcQAKYC/uXt9zDzJJ6bu0W+baTI8LZBaTup5afzibEH4N3jlq2p+a152wlBJ7w==",
-      "license": "MIT",
-      "dependencies": {
-        "@turf/bbox": "*",
-        "@turf/helpers": "6.x",
-        "@turf/meta": "6.x",
-        "@types/geojson": "7946.0.8",
-        "rbush": "^3.0.1"
-      }
-    },
-    "node_modules/geojson-rbush/node_modules/@types/geojson": {
-      "version": "7946.0.8",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
-      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==",
-      "license": "MIT"
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -21472,6 +21546,15 @@
         "verror": "1.10.0"
       }
     },
+    "node_modules/jsts": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
+      "integrity": "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
@@ -21862,10 +21945,9 @@
       "integrity": "sha512-NpSm8HRm1WkBBWHUveDukLF4Kfb5P5E3fjHc9Qre9A11nNubozLWD2wH3UBTZbu+KSuX8aSUvy9b+PUyEceJ8g=="
     },
     "node_modules/lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
-      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.18.0.tgz",
+      "integrity": "sha512-hZXIupXdHtocTnvIJ2aCd2vxKYtxex6gbiGuPvgBRnFQO9yu3AtmDAbVuCXcSsQx3INo/1g71OktlFFA/ES8Xg==",
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -24908,6 +24990,15 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/polished": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
@@ -24920,14 +25011,14 @@
         "node": ">=10"
       }
     },
-    "node_modules/polygon-clipping": {
-      "version": "0.15.7",
-      "resolved": "https://registry.npmjs.org/polygon-clipping/-/polygon-clipping-0.15.7.tgz",
-      "integrity": "sha512-nhfdr83ECBg6xtqOAJab1tbksbBAOMUltN60bU+llHVOL0e5Onm1WpAXXWXVB39L8AJFssoIhEVuy/S90MmotA==",
+    "node_modules/polyclip-ts": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
+      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
       "license": "MIT",
       "dependencies": {
-        "robust-predicates": "^3.0.2",
-        "splaytree": "^3.1.0"
+        "bignumber.js": "^9.1.0",
+        "splaytree-ts": "^1.0.2"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -25049,7 +25140,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
       "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -26627,14 +26717,11 @@
       "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
       "dev": true
     },
-    "node_modules/splaytree": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.2.3.tgz",
-      "integrity": "sha512-7OXrNWzy6CK+r7Ch9OLPBDTKfB6XlWHjX4P0RU5B3IgFuWPeYN0XtRtlexGRjgbQxpfaUve6jTAwBGWuGntz/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20 || >=20"
-      }
+    "node_modules/splaytree-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
+      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
+      "license": "BDS-3-Clause"
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -27054,6 +27141,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sweepline-intersections": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyqueue": "^2.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -27329,6 +27425,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
     },
     "node_modules/tinyrainbow": {
       "version": "1.2.0",
@@ -27634,12 +27736,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/turf-jsts": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
-      "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA==",
-      "license": "(EDL-1.0 OR EPL-1.0)"
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
@@ -28705,26 +28801,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/viewport-mercator-project": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/viewport-mercator-project/-/viewport-mercator-project-7.0.4.tgz",
-      "integrity": "sha512-0jzpL6pIMocCKWg1C3mqi/N4UPgZC3FzwghEm1H+XsUo8hNZAyJc3QR7YqC816ibOR8aWT5pCsV+gCu8/BMJgg==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "dependencies": {
-        "@math.gl/web-mercator": "^3.5.5"
-      }
-    },
-    "node_modules/viewport-mercator-project/node_modules/@math.gl/web-mercator": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
-      "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.0",
-        "gl-matrix": "^3.4.0"
-      }
-    },
     "node_modules/vue-style-loader": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.3.tgz",
@@ -29463,15 +29539,15 @@
       "version": "1.17.3",
       "license": "MPL-2.0",
       "dependencies": {
-        "@deck.gl-community/editable-layers": "~9.1.1",
-        "@deck.gl/aggregation-layers": "~9.2.7",
-        "@deck.gl/core": "~9.2.7",
-        "@deck.gl/extensions": "~9.2.7",
-        "@deck.gl/geo-layers": "~9.2.7",
-        "@deck.gl/json": "~9.2.7",
-        "@deck.gl/layers": "~9.2.7",
-        "@deck.gl/mesh-layers": "~9.2.7",
-        "@deck.gl/react": "~9.2.7",
+        "@deck.gl-community/editable-layers": "~9.2.8",
+        "@deck.gl/aggregation-layers": "~9.2.11",
+        "@deck.gl/core": "~9.2.11",
+        "@deck.gl/extensions": "~9.2.11",
+        "@deck.gl/geo-layers": "~9.2.11",
+        "@deck.gl/json": "~9.2.11",
+        "@deck.gl/layers": "~9.2.11",
+        "@deck.gl/mesh-layers": "~9.2.11",
+        "@deck.gl/react": "~9.2.11",
         "@emerson-eps/color-tables": "^1.0.2",
         "@equinor/eds-core-react": "^0.36.0",
         "@equinor/eds-icons": "^0.21.0",
@@ -29497,6 +29573,7 @@
         "react-redux": "^9.1.2"
       },
       "peerDependencies": {
+        "@deck.gl-community/layers": "~9.2.8",
         "@mui/icons-material": "^5.11 || ^6 || ^7.3",
         "@mui/material": "^5.11 || ^6 || ^7.3",
         "@mui/system": "^5.11 || ^6 || ^7.3",

--- a/typescript/packages/subsurface-viewer/package.json
+++ b/typescript/packages/subsurface-viewer/package.json
@@ -33,15 +33,15 @@
   "author": "Equinor <opensource@equinor.com>",
   "license": "MPL-2.0",
   "dependencies": {
-    "@deck.gl-community/editable-layers": "~9.1.1",
-    "@deck.gl/aggregation-layers": "~9.2.7",
-    "@deck.gl/core": "~9.2.7",
-    "@deck.gl/extensions": "~9.2.7",
-    "@deck.gl/geo-layers": "~9.2.7",
-    "@deck.gl/json": "~9.2.7",
-    "@deck.gl/layers": "~9.2.7",
-    "@deck.gl/mesh-layers": "~9.2.7",
-    "@deck.gl/react": "~9.2.7",
+    "@deck.gl-community/editable-layers": "~9.2.8",
+    "@deck.gl/aggregation-layers": "~9.2.11",
+    "@deck.gl/core": "~9.2.11",
+    "@deck.gl/extensions": "~9.2.11",
+    "@deck.gl/geo-layers": "~9.2.11",
+    "@deck.gl/json": "~9.2.11",
+    "@deck.gl/layers": "~9.2.11",
+    "@deck.gl/mesh-layers": "~9.2.11",
+    "@deck.gl/react": "~9.2.11",
     "@emerson-eps/color-tables": "^1.0.2",
     "@equinor/eds-core-react": "^0.36.0",
     "@equinor/eds-icons": "^0.21.0",
@@ -61,7 +61,11 @@
     "static-kdtree": "^1.0.2",
     "workerpool": "^9.2.0"
   },
+  "peerDependencies comments": {
+    "@deck.gl-community/layers": "@deck.gl-community/editable-layers peer deps is ^9.x until 9.3.2 where this peer dep can be removed"
+  },
   "peerDependencies": {
+    "@deck.gl-community/layers": "~9.2.8",
     "@mui/icons-material": "^5.11 || ^6 || ^7.3",
     "@mui/material": "^5.11 || ^6 || ^7.3",
     "@mui/system": "^5.11 || ^6 || ^7.3",

--- a/typescript/packages/subsurface-viewer/src/components/ColorLegend.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/ColorLegend.tsx
@@ -40,7 +40,7 @@ function isDiscrete(
 }
 
 function toDiscreteCodes(data: DiscreteLegendDataType): DiscreteCodes {
-    return data.metadata as DiscreteCodes;
+    return data.metadata as unknown as DiscreteCodes;
 }
 
 interface ColorLegendProps {

--- a/typescript/packages/subsurface-viewer/src/components/InfoCard.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/InfoCard.tsx
@@ -1,4 +1,7 @@
 import React from "react";
+
+import { rgb } from "d3-color";
+
 import {
     Collapse,
     Table,
@@ -7,16 +10,17 @@ import {
     TableContainer,
     TableRow,
 } from "@mui/material";
+import { styled } from "@mui/system";
+
 import { Button, Icon } from "@equinor/eds-core-react";
 import { arrow_drop_up, arrow_drop_down } from "@equinor/eds-icons";
-import { styled } from "@mui/system";
 
 import type {
     ExtendedLayerProps,
     LayerPickInfo,
     PropertyDataType,
 } from "../layers/utils/layerTools";
-import { rgb } from "d3-color";
+import { toNormalizedRGBAColor } from "../utils/Color";
 import { WellLabelLayer } from "../layers/wells/layers/wellLabelLayer";
 import { SectionViewport } from "../viewports/sectionViewport";
 
@@ -115,12 +119,9 @@ function Row(props: { layer_data: InfoCardDataType }) {
                                                 <span
                                                     style={{
                                                         color: rgb(
-                                                            ...(propertyRow.color as [
-                                                                number,
-                                                                number,
-                                                                number,
-                                                                number?,
-                                                            ])
+                                                            ...toNormalizedRGBAColor(
+                                                                propertyRow.color
+                                                            )
                                                         ).toString(),
                                                     }}
                                                 >

--- a/typescript/packages/subsurface-viewer/src/layers/axes2d/axes2DLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/axes2d/axes2DLayer.ts
@@ -19,6 +19,7 @@ import type { ShaderModule } from "@luma.gl/shadertools";
 import { vec4 } from "gl-matrix";
 
 import type { Point3D, RGBAColor } from "../../utils";
+import { toNormalizedColor } from "../../utils";
 import { SectionViewport } from "../../viewports/sectionViewport";
 import { precisionForTests } from "../shader_modules/test-precision/precisionForTests";
 import type { ExtendedLayerProps } from "../utils/layerTools";
@@ -237,11 +238,9 @@ export default class Axes2DLayer extends Layer<Axes2DLayerProps> {
         });
 
         const fontTexture = this.state["fontTexture"];
-        const {
-            labelModels,
-            lineModel: lineModel,
-            backgroundModel: backgroundModel,
-        } = this._getModels(fontTexture as UniformValue);
+        const { labelModels, lineModel, backgroundModel } = this._getModels(
+            fontTexture as UniformValue
+        );
 
         this.setState({
             ...this.state,
@@ -288,7 +287,7 @@ export default class Axes2DLayer extends Layer<Axes2DLayerProps> {
     makeLabel(n: number, ndecimals: number): string {
         let label = n.toFixed(ndecimals);
         if (this.props.formatLabelFunc) {
-            label = this.props.formatLabelFunc(n) as string;
+            label = this.props.formatLabelFunc(n);
             label = label.replace("e", "E"); // this font atlas does not have "e"
             label = label.replace("\u2212", "-"); // use standard minus sign
         }
@@ -356,9 +355,7 @@ export default class Axes2DLayer extends Layer<Axes2DLayerProps> {
                 ? -delta
                 : delta;
 
-        for (let i = 0; i < ticks.length; i++) {
-            const tick = ticks[i];
-
+        for (const tick of ticks) {
             const label = this.makeLabel(tick, ndecimals);
             tick_labels.push(label);
 
@@ -557,8 +554,6 @@ export default class Axes2DLayer extends Layer<Axes2DLayerProps> {
         for (let i = 0; i < n - 2; i++) {
             models[i].draw(opts.context.renderPass);
         }
-
-        return;
     }
 
     // Make models for background, lines (tick marks and axis) and labels.
@@ -677,14 +672,9 @@ export default class Axes2DLayer extends Layer<Axes2DLayerProps> {
 
         // Line models. (axis line and tick lines)
         // Color on axes and text.
-        let lineColor = [0.0, 0.0, 0.0, 1.0];
-        if (typeof this.props.axisColor !== "undefined") {
-            lineColor = this.props.axisColor as number[];
-            if (lineColor.length === 3) {
-                lineColor.push(255);
-            }
-            lineColor = lineColor.map((x) => (x ?? 0) / 255);
-        }
+        const lineColor = toNormalizedColor(this.props.axisColor) ?? [
+            0.0, 0.0, 0.0, 1.0,
+        ];
 
         const lineModel = new Model(device, {
             id: `${this.props.id}-lines`,
@@ -711,14 +701,9 @@ export default class Axes2DLayer extends Layer<Axes2DLayerProps> {
 
         //-- Background model --
         // Color on axes background.
-        let bColor = [0.5, 0.5, 0.5, 1];
-        if (typeof this.props.backgroundColor !== "undefined") {
-            bColor = this.props.backgroundColor as number[];
-            if (bColor.length === 3) {
-                bColor.push(255);
-            }
-            bColor = bColor.map((x) => (x ?? 0) / 255);
-        }
+        const bColor = toNormalizedColor(this.props.backgroundColor) ?? [
+            0.5, 0.5, 0.5, 1,
+        ];
 
         const backgroundModel = new Model(device, {
             id: `${this.props.id}-background`,
@@ -924,7 +909,6 @@ Axes2DLayer.defaultProps = defaultProps;
 //             >)
 //         )
 //     );
-
 //     return pos_v.slice(0, 3) as [number, number, number];
 // }
 

--- a/typescript/packages/subsurface-viewer/src/layers/drawing/drawingLayer.tsx
+++ b/typescript/packages/subsurface-viewer/src/layers/drawing/drawingLayer.tsx
@@ -1,8 +1,10 @@
+import type { GeoJsonProperties, Geometry } from "geojson";
+
 import type {
     EditAction,
     Feature,
     FeatureCollection,
-    GeoJsonEditMode,
+    SimpleFeatureCollection,
     ModeProps,
 } from "@deck.gl-community/editable-layers";
 import {
@@ -30,13 +32,24 @@ import type {
     LayerPickInfo,
 } from "../utils/layerTools";
 
+type SimpleFeatureCollectionWrapper = FeatureCollection<
+    Geometry,
+    GeoJsonProperties
+>;
+
 // Custom drawing mode that deletes the selected GeoJson feature when releasing the Delete key.
 class CustomModifyMode extends ModifyMode {
-    handleKeyUp(event: KeyboardEvent, props: ModeProps<FeatureCollection>) {
+    handleKeyUp(
+        event: KeyboardEvent,
+        props: ModeProps<SimpleFeatureCollectionWrapper>
+    ) {
         super.handleKeyUp(event, props);
 
         if (event.key === "Delete") {
-            const updatedData = new ImmutableFeatureCollection(props.data)
+            // Cast props.data to SimpleFeatureCollection for compatibility with ImmutableFeatureCollection
+            const updatedData = new ImmutableFeatureCollection(
+                props.data as SimpleFeatureCollection
+            )
                 .deleteFeatures(props.selectedIndexes)
                 .getObject();
 
@@ -54,9 +67,12 @@ class CustomModifyMode extends ModifyMode {
 }
 
 function deleteEscapeKeyHandler(
-    drawMode: GeoJsonEditMode,
+    drawMode: {
+        getClickSequence: () => unknown[];
+        resetClickSequence: () => void;
+    },
     event: KeyboardEvent,
-    props: ModeProps<FeatureCollection>
+    props: ModeProps<SimpleFeatureCollection>
 ) {
     if (event.key === "Escape") drawMode.getClickSequence().pop();
     else if (event.key === "Delete") drawMode.resetClickSequence();
@@ -76,14 +92,20 @@ function deleteEscapeKeyHandler(
 }
 
 class CustomDrawLineStringMode extends DrawLineStringMode {
-    handleKeyUp(event: KeyboardEvent, props: ModeProps<FeatureCollection>) {
+    handleKeyUp(
+        event: KeyboardEvent,
+        props: ModeProps<SimpleFeatureCollection>
+    ) {
         super.handleKeyUp(event, props);
         deleteEscapeKeyHandler(this, event, props);
     }
 }
 
 class CustomDrawPolygonMode extends DrawPolygonMode {
-    handleKeyUp(event: KeyboardEvent, props: ModeProps<FeatureCollection>) {
+    handleKeyUp(
+        event: KeyboardEvent,
+        props: ModeProps<SimpleFeatureCollection>
+    ) {
         super.handleKeyUp(event, props);
         deleteEscapeKeyHandler(this, event, props);
     }
@@ -171,7 +193,7 @@ export default class DrawingLayer extends CompositeLayer<DrawingLayerProps> {
 
     // Callback for various editing events. Most events will update this component
     // through patches sent to the map parent. See patchLayerPropsin layerTools.ts.
-    _onEdit(editAction: EditAction<FeatureCollection>): void {
+    _onEdit(editAction: EditAction<SimpleFeatureCollection>): void {
         switch (editAction.editType) {
             case "addFeature":
                 this.setState({
@@ -219,7 +241,7 @@ export default class DrawingLayer extends CompositeLayer<DrawingLayerProps> {
         const selectedFeatureIndexes = this.state[
             "selectedFeatureIndexes"
         ] as number[];
-        const data = this.state["data"] as FeatureCollection;
+        const data = this.state["data"] as SimpleFeatureCollection;
         const is_feature_selected = selectedFeatureIndexes.some(
             (i: number) => (data.features[i] as unknown as Feature) === feature
         );
@@ -242,7 +264,7 @@ export default class DrawingLayer extends CompositeLayer<DrawingLayerProps> {
             },
             selectedFeatureIndexes: this.state["selectedFeatureIndexes"],
             coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
-            onEdit: (editAction: EditAction<FeatureCollection>) =>
+            onEdit: (editAction: EditAction<SimpleFeatureCollection>) =>
                 this._onEdit(editAction),
             _subLayerProps: {
                 geojson: {

--- a/typescript/packages/subsurface-viewer/src/layers/gpglLayers/gpglValueMappedSurfaceLayer.tsx
+++ b/typescript/packages/subsurface-viewer/src/layers/gpglLayers/gpglValueMappedSurfaceLayer.tsx
@@ -593,11 +593,11 @@ export class GpglValueMappedSurfaceLayer extends Layer<GpglValueMappedSurfaceLay
                         defaultColormapSetup.undefinedValue,
                     undefinedColor: toNormalizedColor(
                         this.props.colormapSetup?.undefinedColor ??
-                            defaultColormapSetup.undefinedColor
+                            (defaultColormapSetup.undefinedColor as Color)
                     ),
                     // Normalize color to [0,1] range.
                     uColor: toNormalizedColor(
-                        this.props.color ?? defaultProps.color
+                        this.props.color ?? (defaultProps.color as Color)
                     ),
                     smoothShading:
                         this.props.smoothShading ?? defaultProps.smoothShading,

--- a/typescript/packages/subsurface-viewer/src/layers/grid3d/privateGrid3dLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/grid3d/privateGrid3dLayer.ts
@@ -28,6 +28,7 @@ import {
 } from "../utils/colormapTools";
 
 import type { Color, RGBAColor, RGBColor } from "../../utils/Color";
+import { toNormalizedRGBAColor, toNormalizedRGBColor } from "../../utils/Color";
 
 import linearFragmentShader from "./nodeProperty.fs.glsl";
 import linearVertexShader from "./nodeProperty.vs.glsl";
@@ -339,7 +340,7 @@ export default class PrivateLayer extends Layer<PrivateLayerProps> {
             // and this.props.propertyValueRange?.[1] should be N
             return {
                 discreteData: true,
-                colormapSize: (this.props.propertyValueRange?.[1] ?? 0.0) + 1,
+                colormapSize: (this.props.propertyValueRange?.[1] ?? 0) + 1,
             };
         }
         return {
@@ -349,8 +350,8 @@ export default class PrivateLayer extends Layer<PrivateLayerProps> {
     }
 
     private getUniforms(): IUniforms {
-        const valueRangeMin = this.props.propertyValueRange?.[0] ?? 0.0;
-        const valueRangeMax = this.props.propertyValueRange?.[1] ?? 1.0;
+        const valueRangeMin = this.props.propertyValueRange?.[0] ?? 0;
+        const valueRangeMax = this.props.propertyValueRange?.[1] ?? 1;
 
         // If specified color map will extend from colormapRangeMin to colormapRangeMax.
         // Otherwise it will extend from valueRangeMin to valueRangeMax.
@@ -363,37 +364,20 @@ export default class PrivateLayer extends Layer<PrivateLayerProps> {
             this.props.colormapClampColor !== undefined &&
             this.props.colormapClampColor !== true &&
             this.props.colormapClampColor !== false;
-        let colormapClampColor = (
-            hasClampColor ? this.props.colormapClampColor : [0, 0, 0, 255]
-        ) as Color;
-        if (isColormapClampColorTransparent) {
-            colormapClampColor = [0, 0, 0, 0];
-        }
-
-        if (colormapClampColor.length === 3) {
-            colormapClampColor = [...colormapClampColor, 255] as [
-                number,
-                number,
-                number,
-                number,
-            ];
-        }
-        const isClampColor = hasClampColor || isColormapClampColorTransparent;
 
         // Normalize to [0,1] range.
-        const colormapClampColorUniform = colormapClampColor.map(
-            (x) => (x ?? 0) / 255
-        );
+        const colormapClampColorUniform: RGBAColor = hasClampColor
+            ? toNormalizedRGBAColor(this.props.colormapClampColor as Color)
+            : [0, 0, 0, 1];
         if (isColormapClampColorTransparent) {
-            colormapClampColor[3] = 0;
+            colormapClampColorUniform[3] = 0;
         }
 
-        const undefinedPropertyColorUniform =
-            this.props.undefinedPropertyColor.map((x) => (x ?? 0) / 255) as [
-                number,
-                number,
-                number,
-            ];
+        const isClampColor = hasClampColor || isColormapClampColorTransparent;
+
+        const undefinedPropertyColorUniform = toNormalizedRGBColor(
+            this.props.undefinedPropertyColor
+        ) as [number, number, number];
 
         const coloringHints = this.getColoringHints();
 
@@ -403,7 +387,7 @@ export default class PrivateLayer extends Layer<PrivateLayerProps> {
             valueRangeMax,
             colormapRangeMin: colormapRangeMin,
             colormapRangeMax: colormapRangeMax,
-            colormapClampColor: Array.from(colormapClampColorUniform),
+            colormapClampColor: colormapClampColorUniform,
             isClampColor,
             coloringMode: this.props.coloringMode,
             undefinedPropertyColor: undefinedPropertyColorUniform,

--- a/typescript/packages/subsurface-viewer/src/layers/piechart/pieChartLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/piechart/pieChartLayer.ts
@@ -19,6 +19,7 @@ import type {
     PropertyDataType,
 } from "../utils/layerTools";
 import { createPropertyData } from "../utils/layerTools";
+import { toNormalizedColor } from "../../utils";
 
 import { precisionForTests } from "../shader_modules/test-precision/precisionForTests";
 
@@ -108,12 +109,9 @@ export default class PieChartLayer extends Layer<PieChartLayerProps<PiesData>> {
                 const end_a = start_a + frac * 360.0;
 
                 const prop = pieData.properties[pie.fractions[i].idx];
-                let col: number[] = (prop?.color as number[]) ?? [
-                    255, 0, 255, 255,
+                const col: number[] = toNormalizedColor(prop?.color) ?? [
+                    1, 0, 1, 1,
                 ]; // magenta
-                col = col.map(
-                    (x) => (x ?? 0) / 255 // Normalize to [0,1] range.
-                );
 
                 const name = prop?.label ?? "no label";
                 const frac_string = (frac * 100).toFixed(1) + "%";

--- a/typescript/packages/subsurface-viewer/src/layers/utils/layerTools.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/utils/layerTools.ts
@@ -7,21 +7,20 @@ import type {
     ChangeFlags,
     Color,
     CompositeLayerProps,
-    Layer,
     LayerContext,
-    LayerManager,
     LayersList,
     PickingInfo,
 } from "@deck.gl/core";
+import { Layer, LayerManager } from "@deck.gl/core";
 
 import type {
     ContinuousLegendDataType,
     DiscreteLegendDataType,
 } from "../../components/ColorLegend";
-import type DrawingLayer from "../drawing/drawingLayer";
+import DrawingLayer from "../drawing/drawingLayer";
 
 import type { BoundingBox3D } from "../../utils";
-import { computeBoundingBox as buidBoundingBox } from "../../utils/BoundingBox3D";
+import { computeBoundingBox as buildBoundingBox } from "../../utils/BoundingBox3D";
 
 export interface TypeAndNameLayerProps {
     "@@type"?: string;
@@ -190,7 +189,7 @@ export function computeBoundingBox(
     dataArray: Float32Array,
     zIncreasingDownwards: boolean = false
 ): BoundingBox3D {
-    const bbox = buidBoundingBox(dataArray);
+    const bbox = buildBoundingBox(dataArray);
     if (zIncreasingDownwards) {
         // invert Z coordinates
         bbox[2] = -bbox[2];

--- a/typescript/packages/subsurface-viewer/src/layers/wells/layers/flatWellMarkersLayer.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/wells/layers/flatWellMarkersLayer.ts
@@ -20,6 +20,7 @@ import { GL } from "@luma.gl/constants";
 import type { Position } from "geojson";
 import _ from "lodash";
 
+import type { RGBAColor, RGBColor } from "../../../utils/Color";
 import { blendColors } from "../../../utils/Color";
 import type { LayerPickInfo } from "../../utils/layerTools";
 import {
@@ -177,7 +178,7 @@ export class FlatWellMarkersLayer<TData = unknown> extends CompositeLayer<
                         itemContext
                         // The typing is a little misleading here; the *default* accessor could
                         // potentially return undefined, so we need to include a fallback here
-                    ) ?? getCumulativeDistance(trajectoryPath)!;
+                    ) ?? getCumulativeDistance(trajectoryPath);
 
                 cumulativePathDistanceCache.set(index, cumulativeDistance);
             }
@@ -306,18 +307,14 @@ export class FlatWellMarkersLayer<TData = unknown> extends CompositeLayer<
         let baseColor: Color;
 
         if (this.props.getMarkerColor) {
-            baseColor = getFromAccessor(
-                this.props.getMarkerColor,
-                d,
-                ctx
-            ) as Color;
+            baseColor = getFromAccessor(this.props.getMarkerColor, d, ctx);
         } else if (this.props.getLineColor) {
             baseColor = getFromAccessor(
                 this.props.getLineColor,
                 // @ts-expect-error -- accessors are hard :O
                 d.sourceObject,
                 ctx
-            ) as Color;
+            );
         } else {
             baseColor = [0, 0, 0, 255];
         }
@@ -327,7 +324,7 @@ export class FlatWellMarkersLayer<TData = unknown> extends CompositeLayer<
         }
 
         // Mimic auto-highlight behavior
-        let highlightColor: Color;
+        let highlightColor: RGBAColor | RGBColor;
 
         if (typeof this.props.highlightColor === "function") {
             console.warn(
@@ -335,7 +332,7 @@ export class FlatWellMarkersLayer<TData = unknown> extends CompositeLayer<
             );
             highlightColor = [0, 0, 128, 128];
         } else {
-            highlightColor = this.props.highlightColor as Color;
+            highlightColor = this.props.highlightColor as RGBAColor | RGBColor;
         }
 
         return blendColors(baseColor, highlightColor);

--- a/typescript/packages/subsurface-viewer/src/layers/wells/utils/trajectory.test.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/wells/utils/trajectory.test.ts
@@ -1,10 +1,11 @@
 import "jest";
+import { describe, expect, it, jest } from "@jest/globals";
 
 import type { Color } from "@deck.gl/core";
 import type { Position } from "geojson";
 import { cloneDeep, reverse, set } from "lodash";
 
-import type { WellFeature } from "../types";
+import type { ColorAccessor, WellFeature } from "../types";
 import {
     getColor,
     getCumulativeDistance,
@@ -32,6 +33,7 @@ describe("trajectory utils", () => {
     };
 
     const mockFeature: WellFeature = {
+        type: "Feature",
         geometry: {
             type: "GeometryCollection",
             geometries: [
@@ -40,6 +42,7 @@ describe("trajectory utils", () => {
             ],
         },
         properties: {
+            name: "Depth",
             md: [[0, 100, 200, 300]],
             color: [100, 100, 100, 255],
         },
@@ -55,7 +58,7 @@ describe("trajectory utils", () => {
         it("Should return a wrapped accessor function if accessor is a function", () => {
             const mockAccessor = jest.fn().mockReturnValue([0, 255, 0, 255]);
 
-            const colorFunc = getColor(mockAccessor);
+            const colorFunc = getColor(mockAccessor as ColorAccessor);
             const result =
                 typeof colorFunc === "function"
                     ? colorFunc(mockFeature)
@@ -67,7 +70,7 @@ describe("trajectory utils", () => {
         it("should return the feature's color property if accessor function returns a falsy value", () => {
             const mockAccessor = jest.fn().mockReturnValue(undefined);
 
-            const colorFunc = getColor(mockAccessor);
+            const colorFunc = getColor(mockAccessor as ColorAccessor);
             const result =
                 typeof colorFunc === "function"
                     ? colorFunc(mockFeature)

--- a/typescript/packages/subsurface-viewer/src/storybook/layers/WellsLayer.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/layers/WellsLayer.stories.tsx
@@ -1333,7 +1333,7 @@ function PerforationsAndScreensComponent(
                     ...perforationAndScreensByWellIndex.get(i),
                 },
             })),
-        } as WellFeatureCollection;
+        } as unknown as WellFeatureCollection;
     }, [perforationAndScreensByWellIndex]);
 
     const sharedLayerProps: Partial<WellsLayerProps> = {
@@ -1547,7 +1547,7 @@ const VOLVE_WELLS_WITH_FORMATIONS = {
                     : undefined,
         },
     })),
-} as WellFeatureCollection;
+} as unknown as WellFeatureCollection;
 
 export const TrajectoryFilter: StoryObj<TrajectoryFilterArgs> = {
     args: {

--- a/typescript/packages/subsurface-viewer/src/storybook/sub_layers/WellsLayerSubs.stories.tsx
+++ b/typescript/packages/subsurface-viewer/src/storybook/sub_layers/WellsLayerSubs.stories.tsx
@@ -186,7 +186,8 @@ export const TrajectoryMarkers: Story = {
                     lineWidthUnits: "pixels",
                     getWidth: 2,
                     getColor: [115, 115, 115],
-                    getPath: (d) => getTrajectoryCoordinates(d) as GlPosition[],
+                    getPath: (d) =>
+                        getTrajectoryCoordinates(d) as unknown as GlPosition[],
                     updateTriggers: { getPath: [args["use3dView"]] },
                 }),
                 new FlatWellMarkersLayer({

--- a/typescript/packages/subsurface-viewer/src/utils/Color.test.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/Color.test.ts
@@ -1,7 +1,13 @@
 import "jest";
 
 import type { RGBAColor, RGBColor } from "../utils/Color";
-import { blendColors, toNormalizedColor } from "./Color";
+import {
+    blendColors,
+    toArrayColor,
+    toNormalizedColor,
+    toNormalizedRGBAColor,
+    toNormalizedRGBColor,
+} from "./Color";
 
 describe("Color utilities", () => {
     describe("toNormalizedColor", () => {
@@ -41,6 +47,70 @@ describe("Color utilities", () => {
         });
     });
 
+    describe("toNormalizedRGBAColor", () => {
+        it("should normalize an RGB color array", () => {
+            const input: RGBColor = [255, 128, 0];
+            const result = toNormalizedRGBAColor(input);
+            expect(result).toEqual([1, 128 / 255, 0, 1]);
+        });
+
+        it("should normalize an RGBA color array", () => {
+            const input: RGBAColor = [64, 128, 192, 128];
+            const result = toNormalizedRGBAColor(input);
+            expect(result).toEqual([64 / 255, 128 / 255, 192 / 255, 128 / 255]);
+        });
+
+        it("should handle black RGB color", () => {
+            const input: RGBColor = [0, 0, 0];
+            const result = toNormalizedRGBAColor(input);
+            expect(result).toEqual([0, 0, 0, 1]);
+        });
+
+        it("should handle white RGBA color", () => {
+            const input: RGBAColor = [255, 255, 255, 255];
+            const result = toNormalizedRGBAColor(input);
+            expect(result).toEqual([1, 1, 1, 1]);
+        });
+
+        it("should handle alpha channel of 0 in RGBA", () => {
+            const input: RGBAColor = [10, 20, 30, 0];
+            const result = toNormalizedRGBAColor(input);
+            expect(result).toEqual([10 / 255, 20 / 255, 30 / 255, 0]);
+        });
+    });
+
+    describe("toNormalizedRGBColor", () => {
+        it("should normalize an RGB color array", () => {
+            const input: RGBColor = [255, 128, 0];
+            const result = toNormalizedRGBColor(input);
+            expect(result).toEqual([1, 128 / 255, 0]);
+        });
+
+        it("should normalize an RGBA color array", () => {
+            const input: RGBAColor = [64, 128, 192, 128];
+            const result = toNormalizedRGBColor(input);
+            expect(result).toEqual([64 / 255, 128 / 255, 192 / 255]);
+        });
+
+        it("should handle black RGB color", () => {
+            const input: RGBColor = [0, 0, 0];
+            const result = toNormalizedRGBColor(input);
+            expect(result).toEqual([0, 0, 0]);
+        });
+
+        it("should handle white RGBA color", () => {
+            const input: RGBAColor = [255, 255, 255, 255];
+            const result = toNormalizedRGBColor(input);
+            expect(result).toEqual([1, 1, 1]);
+        });
+
+        it("should handle alpha channel of 0 in RGBA", () => {
+            const input: RGBAColor = [10, 20, 30, 0];
+            const result = toNormalizedRGBColor(input);
+            expect(result).toEqual([10 / 255, 20 / 255, 30 / 255]);
+        });
+    });
+
     describe("blendColors", () => {
         it("should blend two colors equally", () => {
             const color1: RGBAColor = [255, 0, 0, 255];
@@ -77,6 +147,35 @@ describe("Color utilities", () => {
 
             const result = blendColors(color1, color2);
             expect(result).toEqual([0, 0, 0, 0]);
+        });
+    });
+
+    describe("toArrayColor", () => {
+        it("should convert an RGBColor to an array", () => {
+            const input: RGBColor = [10, 20, 30];
+            const result = toArrayColor(input);
+            expect(Array.isArray(result)).toBe(true);
+            expect(result).toEqual(input);
+        });
+
+        it("should convert an RGBAColor to an array", () => {
+            const input: RGBAColor = [100, 150, 200, 50];
+            const result = toArrayColor(input);
+            expect(Array.isArray(result)).toBe(true);
+            expect(result).toEqual(input);
+        });
+
+        it("should handle a TypedArray input", () => {
+            const inputArray = [1, 2, 3, 4];
+            const input = new Uint8Array(inputArray);
+            const result = toArrayColor(input as unknown as RGBAColor);
+            expect(result).toEqual(inputArray);
+        });
+
+        it("should handle an array-like object", () => {
+            const input = { 0: 5, 1: 10, 2: 15, 3: 20, length: 4 };
+            const result = toArrayColor(input as unknown as RGBAColor);
+            expect(result).toEqual([5, 10, 15, 20]);
         });
     });
 });

--- a/typescript/packages/subsurface-viewer/src/utils/Color.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/Color.ts
@@ -5,7 +5,7 @@
  */
 import type { Color } from "@deck.gl/core";
 
-export type { Color };
+export type { Color } from "@deck.gl/core";
 
 /**
  * RGB color represented as a tuple of three numbers: [red, green, blue].
@@ -24,11 +24,10 @@ export type RGBAColor = [number, number, number, number];
  * @param color - The input color as an array of numbers. It can be either:
  *   - [r, g, b]: An RGB color, where each channel is a number between 0 and 255.
  *   - [r, g, b, a]: An RGBA color, where each channel is a number between 0 and 255.
- * @returns A tuple [r, g, b, a] where each value is normalized to the range [0, 1].
+ *   - undefined
+ * @returns A tuple [r, g, b, a] where each value is normalized to the range [0, 1] or undefined.
  */
-export function toNormalizedColor(
-    color: Color | undefined
-): RGBAColor | undefined {
+export function toNormalizedColor(color?: Color): RGBAColor | undefined {
     return color
         ? [
               color[0] / 255,
@@ -40,7 +39,38 @@ export function toNormalizedColor(
 }
 
 /**
- * Blends to color arrays together, following an additive blending pattern.
+ * Converts a color represented as an array of numbers (either RGB or RGBA) with 8-bit channel values (0-255)
+ * into a normalized RGBA tuple with values in the range [0, 1].
+ *
+ * @param color - The input color as an array of numbers. It can be either:
+ *   - [r, g, b]: An RGB color, where each channel is a number between 0 and 255.
+ *   - [r, g, b, a]: An RGBA color, where each channel is a number between 0 and 255.
+ * @returns A tuple [r, g, b, a] where each value is normalized to the range [0, 1].
+ */
+export function toNormalizedRGBAColor(color: Color): RGBAColor {
+    return [
+        color[0] / 255,
+        color[1] / 255,
+        color[2] / 255,
+        color.length === 3 ? 1 : (color as RGBAColor)[3] / 255,
+    ];
+}
+
+/**
+ * Converts a color represented as an array of numbers (either RGB or RGBA) with 8-bit channel values (0-255)
+ * into a normalized RGB tuple with values in the range [0, 1].
+ *
+ * @param color - The input color as an array of numbers. It can be either:
+ *   - [r, g, b]: An RGB color, where each channel is a number between 0 and 255.
+ *   - [r, g, b, a]: An RGBA color, where each channel is a number between 0 and 255.
+ * @returns A tuple [r, g, b] where each value is normalized to the range [0, 1].
+ */
+export function toNormalizedRGBColor(color: Color): RGBColor {
+    return [color[0] / 255, color[1] / 255, color[2] / 255];
+}
+
+/**
+ * Blends two color arrays together, following an additive blending pattern.
  * @param baseColor The underlying color.
  * @param addedColor The color to add on top. If this color has no opacity, the base color is fully overwritten
  * @returns The blended color as an RGBA array
@@ -62,4 +92,14 @@ export function blendColors(baseColor: Color, addedColor: Color) {
     };
 
     return [mixChannel(0), mixChannel(1), mixChannel(2), mixedAlpha * 255];
+}
+
+/**
+ * Converts a `Color` object to an array representation.
+ *
+ * @param color - The color value to convert, expected to be an iterable (e.g., TypedArray or array-like) representing a color.
+ * @returns The color as an array of numbers, typed as either `RGBColor` or `RGBAColor`.
+ */
+export function toArrayColor(color: Color): RGBColor | RGBAColor {
+    return Array.from(color) as RGBColor | RGBAColor;
 }

--- a/typescript/packages/subsurface-viewer/src/utils/index.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/index.ts
@@ -4,7 +4,11 @@ export type { Point3D } from "./Point3D";
 export { add as addPoints3D } from "./Point3D";
 
 export type { Color, RGBColor, RGBAColor } from "./Color";
-export { toNormalizedColor } from "./Color";
+export {
+    toArrayColor,
+    toNormalizedColor,
+    toNormalizedRGBAColor,
+} from "./Color";
 
 export type { TypedArray, TypedFloatArray, TypedIntArray } from "./typedArray";
 export { isNumberArray, isTypedArray, toTypedArray } from "./typedArray";

--- a/typescript/packages/subsurface-viewer/src/utils/measurement.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/measurement.ts
@@ -2,7 +2,7 @@
 
 import { subtract, dot } from "mathjs";
 import type {
-    FeatureOf,
+    Feature,
     LineString,
     Polygon,
 } from "@deck.gl-community/editable-layers";
@@ -10,14 +10,14 @@ import type { Position } from "geojson";
 
 import { geomReduce, segmentReduce } from "@turf/meta";
 
-export function length(geojson: FeatureOf<LineString>): number {
+export function length(geojson: Feature<LineString>): number {
     // Calculate distance from 2-vertex line segments
     return segmentReduce(
         // @ts-ignore
         geojson,
-        function (previousValue?: number, segment?: FeatureOf<LineString>) {
+        function (previousValue?: number, segment?: Feature<LineString>) {
             if (segment === undefined || previousValue === undefined) return 0;
-            const coords = segment.geometry.coordinates as Position[];
+            const coords = segment.geometry.coordinates;
             return previousValue + distance(coords[0], coords[1]);
         },
         0
@@ -27,7 +27,7 @@ export function length(geojson: FeatureOf<LineString>): number {
 /**
  * Takes one or more features and returns their area in square meters.
  */
-export function area(geojson: FeatureOf<Polygon>): number {
+export function area(geojson: Feature<Polygon>): number {
     return geomReduce(
         // @ts-ignore
         geojson,
@@ -107,7 +107,7 @@ export function isPointAwayFromLineEnd(
     const ab = subtract(line[1] as number[], line[0] as number[]);
     const cb = subtract(line[1] as number[], point as number[]);
 
-    const dotProduct = dot(ab as number[], cb as number[]);
+    const dotProduct = dot(ab, cb);
 
     // If the dot product is negative, the point has moved past the end of the line
     return dotProduct < 0;


### PR DESCRIPTION
Bump:
- @deck.gl-community/editable-layers from 9.1.1 to ~9.2.8
- @deck.gl/aggregation-layers from 9.2.7 to ~9.2.11
- @deck.gl/core from ~9.2.7 to ~9.2.11
- @deck.gl/extensions from ~9.2.7 to ~9.2.11
- @deck.gl/geo-layers from ~9.2.7 to ~9.2.11
- @deck.gl/json from ~9.2.7 to ~9.2.11
- @deck.gl/layers from ~9.2.7 to ~9.2.11
- @deck.gl/mesh-layers from ~9.2.7 to ~9.2.11
- @deck.gl/react from ~9.2.7 to ~9.2.11

Add deck.gl-community/layers@~9.2.8 as peer dependency to ensure not slipping to 9.3 line.

Fix compilation errors.