### PR TITLE
feat: add support of an array of domains and selections for the Well Log Viewer

### DIFF
--- a/typescript/packages/well-log-viewer/src/Storybook/examples/MapAndWellLogViewer.tsx
+++ b/typescript/packages/well-log-viewer/src/Storybook/examples/MapAndWellLogViewer.tsx
@@ -24,6 +24,7 @@ import type { WellsLayer } from "@webviz/subsurface-viewer/dist/layers";
 
 import type { MapMouseEvent } from "@webviz/subsurface-viewer/dist/components/Map";
 
+import type { OpenRange } from "../../utils/arrayTypes";
 import { axisMnemos, axisTitles } from "../../utils/axes";
 import { deepCopy } from "../../utils/deepcopy";
 
@@ -101,7 +102,7 @@ interface State {
     layers?: TLayerDefinition[];
 
     wellName?: string;
-    selection?: [number | undefined, number | undefined];
+    selection?: OpenRange;
     selPersistent?: boolean;
     wellColor?: Color; // well color
 }
@@ -260,9 +261,7 @@ export class MapAndWellLogViewer extends React.Component<
             if (event.type === "click") {
                 const iWell = findWellLogIndex(wellLogs, event.wellname);
                 this.setState((state: Readonly<State>) => {
-                    let selection:
-                        | [number | undefined, number | undefined]
-                        | undefined = undefined;
+                    let selection: OpenRange | undefined = undefined;
                     let selPersistent: boolean | undefined = undefined;
                     if (
                         state.wellIndex !== iWell ||

--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.stories.tsx
@@ -366,6 +366,28 @@ export const DiscreteLogs: StoryObj<typeof TemplateWithSelection> = {
     render: (args) => <TemplateWithSelection {...args} />,
 };
 
+export const DiscreteLogsWithIndividualDomains: StoryObj<
+    typeof TemplateWithSelection
+> = {
+    args: {
+        ...facies3Wells,
+        domain: [
+            [3000, 5500],
+            [2500, 4000],
+            [1000, 4000],
+        ],
+        selection: [
+            [3500, 3600],
+            [2700, 2900],
+            [3300, 3400],
+        ],
+        syncContentDomain: false,
+        syncContentSelection: false,
+        syncTrackPos: false,
+    },
+    render: (args) => <TemplateWithSelection {...args} />,
+};
+
 const verySimpleTemplate: TemplateType = {
     name: "Something simple",
     scale: syncTemplateJson.scale,

--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
@@ -1350,12 +1350,18 @@ SyncLogViewer.propTypes = {
     /**
      * Initial visible interval of the log data
      */
-    domain: PropTypes.arrayOf(PropTypes.number),
+    domain: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.number),
+        PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
+    ]),
 
     /**
      * Initial selected interval of the log data
      */
-    selection: PropTypes.arrayOf(PropTypes.number),
+    selection: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.number),
+        PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
+    ]),
 
     /**
      * Set to true for default titles or to array of individual well log titles

--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
@@ -43,6 +43,7 @@ import { onTrackMouseEventDefault } from "./utils/edit-track";
 import { fillInfos } from "./utils/fill-info";
 import type { Info, InfoOptions } from "./components/InfoTypes";
 
+import type { OpenRange, Range } from "./utils/arrayTypes";
 import {
     isEqDomains,
     isEqualArrays,
@@ -151,15 +152,13 @@ export interface SyncLogViewerProps {
      * Initial visible range. A single domain applies to all the tracks,
      * an array of domains applies to the tracks in corresponding views.
      */
-    domain?: [number, number] | [number, number][];
+    domain?: Range | Range[];
 
     /**
      * Initial selected range. A single selection applies to all the tracks,
      * an array of selections applies to the tracks in corresponding views.
      */
-    selection?:
-        | [number | undefined, number | undefined]
-        | [number | undefined, number | undefined][];
+    selection?: OpenRange | OpenRange[];
 
     /**
      * Options for well log views
@@ -655,8 +654,8 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
         }
     }
 
-    getCommonContentBaseDomain(): [number, number] {
-        const commonBaseDomain: [number, number] = [
+    getCommonContentBaseDomain(): Range {
+        const commonBaseDomain: Range = [
             Number.POSITIVE_INFINITY,
             Number.NEGATIVE_INFINITY,
         ];
@@ -674,8 +673,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
             !(this.props.wellpickFlatting && this.props.wellpicks) &&
             this.props.syncContentDomain
         ) {
-            const commonBaseDomain: [number, number] =
-                this.getCommonContentBaseDomain();
+            const commonBaseDomain: Range = this.getCommonContentBaseDomain();
             for (const callbackManager of this.callbackManagers) {
                 const controller = callbackManager?.controller;
                 if (!controller) continue;
@@ -692,7 +690,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
     makeFlattingCoeffs(): {
         A: number[][];
         B: number[][];
-        newBaseDomain: [number, number][]; // not used
+        newBaseDomain: Range[]; // not used
     } {
         const wellpickFlatting = this.props.wellpickFlatting;
         if (!wellpickFlatting) return { A: [], B: [], newBaseDomain: [] };
@@ -701,7 +699,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
         const flattingB: number[][] = [];
 
         const nView = this.callbackManagers.length;
-        const newBaseDomain: [number, number][] = [];
+        const newBaseDomain: Range[] = [];
         for (let i = 0; i < nView; i++) {
             newBaseDomain.push([
                 Number.POSITIVE_INFINITY,
@@ -777,7 +775,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
                     _flattingB.push(b);
 
                     const baseDomain = controller.getContentBaseDomain();
-                    const baseDomainNew: [number, number] = [
+                    const baseDomainNew: Range = [
                         a * baseDomain[0] + b,
                         a * baseDomain[1] + b,
                     ];
@@ -812,7 +810,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
         let coeff: {
             A: number[][];
             B: number[][];
-            newBaseDomain: [number, number][];
+            newBaseDomain: Range[];
         } | null = null;
         if (this.props.wellpicks && wellpickFlatting)
             coeff = this.makeFlattingCoeffs();
@@ -837,7 +835,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
                     const a = coeff.A[iWellLog][j];
                     const b = coeff.B[iWellLog][j];
 
-                    const domainNew: [number, number] = [
+                    const domainNew: Range = [
                         a * domain[0] + b,
                         a * domain[1] + b,
                     ];
@@ -856,7 +854,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
                         // sync scroll bar: not work yet
                         const baseDomain = _controller.getContentBaseDomain();
                         //const newBaseDomain = coeff.newBaseDomain[j];
-                        const newBaseDomain: [number, number] = [
+                        const newBaseDomain: Range = [
                             domainNew[0],
                             domainNew[1],
                         ];
@@ -1123,12 +1121,12 @@ function getWellLogCollectionsFromProps(props: SyncLogViewerProps) {
 function getDomain(
     domain: SyncLogViewerProps["domain"],
     index: number
-): [number, number] | undefined {
+): Range | undefined {
     if (Array.isArray(domain)) {
         if (Array.isArray(domain[0])) {
-            return domain[index] as [number, number] | undefined;
+            return domain[index] as Range | undefined;
         } else {
-            return domain as [number, number];
+            return domain as Range;
         }
     }
     return undefined;
@@ -1153,16 +1151,10 @@ function isEqualDomains(
     if (!domain1 || !domain2) return false;
     if (typeof domain1 !== typeof domain2) return false;
     if (typeof domain1[0] === "number") {
-        return isEqualRanges(
-            domain1 as [number, number],
-            domain2 as [number, number]
-        );
+        return isEqualRanges(domain1 as Range, domain2 as Range);
     }
     return domain1.every((range, index) =>
-        isEqualRanges(
-            range as [number, number],
-            domain2[index] as [number, number]
-        )
+        isEqualRanges(range as Range, domain2[index] as Range)
     );
 }
 
@@ -1177,14 +1169,12 @@ function isEqualDomains(
 function getSelection(
     selection: SyncLogViewerProps["selection"],
     index: number
-): [number | undefined, number | undefined] | undefined {
+): OpenRange | undefined {
     if (Array.isArray(selection)) {
         if (Array.isArray(selection[0])) {
-            return selection[index] as
-                | [number | undefined, number | undefined]
-                | undefined;
+            return selection[index] as OpenRange | undefined;
         } else {
-            return selection as [number | undefined, number | undefined];
+            return selection as OpenRange;
         }
     }
     return undefined;
@@ -1209,16 +1199,10 @@ function isEqualSelections(
     if (!selection1 || !selection2) return false;
     if (typeof selection1 !== typeof selection2) return false;
     if (typeof selection1[0] === "number" || selection1[0] === undefined) {
-        return isEqualRanges(
-            selection1 as [number | undefined, number | undefined],
-            selection2 as [number | undefined, number | undefined]
-        );
+        return isEqualRanges(selection1 as OpenRange, selection2 as OpenRange);
     }
     return selection1.every((range, index) =>
-        isEqualRanges(
-            range as [number | undefined, number | undefined],
-            selection2[index] as [number | undefined, number | undefined]
-        )
+        isEqualRanges(range as OpenRange, selection2[index] as OpenRange)
     );
 }
 

--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
@@ -3,7 +3,10 @@ import React, { Component } from "react";
 
 import PropTypes from "prop-types";
 
+import type { LogViewer } from "@equinor/videx-wellog";
+
 import WellLogSpacer from "./components/WellLogSpacer";
+import type { WellLogSpacerOptions } from "./components/WellLogSpacer";
 import WellLogViewWithScroller from "./components/WellLogViewWithScroller";
 
 import { CallbackManager } from "./components/CallbackManager";
@@ -14,38 +17,38 @@ import defaultLayout from "./components/DefaultSyncLogViewerLayout";
 
 import type { WellLogSet } from "./components/WellLogTypes";
 import type { Template } from "./components/WellLogTemplateTypes";
-import type { ColormapFunction } from "./utils/color-function";
-import { ColorFunctionType } from "./components/CommonPropTypes";
-import type { PatternsTable, Pattern } from "./utils/pattern";
-import { PatternsTableType, PatternsType } from "./components/CommonPropTypes";
-import type {
-    WellLogController,
-    WellPickProps,
-} from "./components/WellLogView";
-import { WellPickPropsType } from "./components/WellLogView";
+import {
+    ColorFunctionType,
+    PatternsTableType,
+    PatternsType,
+} from "./components/CommonPropTypes";
 
 import type WellLogView from "./components/WellLogView";
 import type {
+    WellLogController,
+    WellPickProps,
     WellLogViewOptions,
     TrackMouseEvent,
 } from "./components/WellLogView";
-import type { WellLogSpacerOptions } from "./components/WellLogSpacer";
-import { getWellPicks } from "./components/WellLogView";
+import { WellPickPropsType, getWellPicks } from "./components/WellLogView";
 
-import { toggleId } from "./utils/arrays";
+import type { ColormapFunction } from "./utils/color-function";
+import type { PatternsTable, Pattern } from "./utils/pattern";
 import { getAvailableAxes } from "./utils/well-log";
 
 import { checkMinMax } from "./utils/minmax";
 
 import { onTrackMouseEventDefault } from "./utils/edit-track";
 
+import { fillInfos } from "./utils/fill-info";
 import type { Info, InfoOptions } from "./components/InfoTypes";
 
-import { isEqDomains } from "./utils/arrays";
-import { isEqualRanges } from "./utils/arrays";
-import type { LogViewer } from "@equinor/videx-wellog";
-import { fillInfos } from "./utils/fill-info";
-import { isEqualArrays } from "./utils/arrays";
+import {
+    isEqDomains,
+    isEqualArrays,
+    isEqualRanges,
+    toggleId,
+} from "./utils/arrays";
 
 export type WellDistances = {
     units: string;
@@ -487,7 +490,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
         this.callbackManagers.length = nViews;
 
         for (let iView = nViews; iView < this.controllers.length; iView++) {
-            console.assert(this.controllers[iView]);
+            console.assert(!!this.controllers[iView]);
             this.onDeleteController(iView, this.controllers[iView]);
         }
         this.controllers.length = nViews;

--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.tsx
@@ -110,7 +110,7 @@ export interface SyncLogViewerProps {
      */
     spacers?: boolean | number | number[];
     /**
-     * Distanses between wells to show on the spacers
+     * Distances between wells to show on the spacers
      */
     wellDistances?: WellDistances;
 
@@ -119,7 +119,13 @@ export interface SyncLogViewerProps {
      */
     horizontal?: boolean;
     syncTrackPos?: boolean;
+    /**
+     * Synchronize visible content domain (pan and zoom) across all the tracks in the views.
+     */
     syncContentDomain?: boolean;
+    /**
+     * Synchronize selected content across all the tracks in the views.
+     */
     syncContentSelection?: boolean;
     syncTemplate?: boolean;
 
@@ -139,14 +145,18 @@ export interface SyncLogViewerProps {
     axisMnemos: Record<string, string[]>;
 
     /**
-     * Initial visible range
+     * Initial visible range. A single domain applies to all the tracks,
+     * an array of domains applies to the tracks in corresponding views.
      */
-    domain?: [number, number];
+    domain?: [number, number] | [number, number][];
 
     /**
-     * Initial selected range
+     * Initial selected range. A single selection applies to all the tracks,
+     * an array of selections applies to the tracks in corresponding views.
      */
-    selection?: [number | undefined, number | undefined];
+    selection?:
+        | [number | undefined, number | undefined]
+        | [number | undefined, number | undefined][];
 
     /**
      * Options for well log views
@@ -195,7 +205,7 @@ export interface SyncLogViewerProps {
 export const argTypesSyncLogViewerProp = {
     welllogs: {
         description:
-            "Array of JSON objects describing well log data.\n<i>Depreacted — Use <b>wellLogCollections</b> instead.</i>",
+            "Array of JSON objects describing well log data.\n<i>Deprecated — Use <b>wellLogCollections</b> instead.</i>",
     },
     wellLogCollections: {
         description:
@@ -222,7 +232,7 @@ export const argTypesSyncLogViewerProp = {
             "Set to true or to spacers width or to array of spacer widths if WellLogSpacers should be used",
     },
     wellDistances: {
-        description: "Distanses between wells to show on the spacers",
+        description: "Distances between wells to show on the spacers",
     },
 
     horizontal: {
@@ -309,7 +319,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
     }[];
 
     collapsedTrackIds: (string | number)[][];
-    controllers: WellLogController[]; // for onDeletecontroller implementation
+    controllers: WellLogController[]; // for onDeleteController implementation
 
     _isMounted: boolean;
     _inInfoGroupClick: number;
@@ -402,7 +412,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
 
         if (
             this.props.syncContentDomain !== prevProps.syncContentDomain ||
-            !isEqualRanges(this.props.domain, prevProps.domain)
+            !isEqualDomains(this.props.domain, prevProps.domain)
         ) {
             this.setControllersZoom();
         }
@@ -420,7 +430,7 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
                 this.syncContentScrollPos(0); // force to redraw visible domain
         }
 
-        if (!isEqualRanges(this.props.selection, prevProps.selection)) {
+        if (!isEqualSelections(this.props.selection, prevProps.selection)) {
             this.setControllersSelection();
         }
 
@@ -922,22 +932,32 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
     }
 
     setControllersZoom(): void {
-        for (const callbackManager of this.callbackManagers) {
+        for (const [
+            index,
+            callbackManager,
+        ] of this.callbackManagers.entries()) {
             const controller = callbackManager?.controller;
             if (!controller) continue;
-            if (this.props.domain) {
-                controller.zoomContentTo(this.props.domain);
+            const domain = getDomain(this.props.domain, index);
+            if (domain) {
+                controller.zoomContentTo(domain);
                 //this.forceUpdate();
-                if (this.props.syncContentDomain) break; // Set the domain only to the first controllers. Another controllers should be set by syncContentDomain or wellpickFlatting options
+                if (this.props.syncContentDomain) break; // Set the domain only to the first controllers. Other controllers should be set by syncContentDomain or wellpickFlatting options
             }
         }
     }
     setControllersSelection(): void {
         if (!this.props.selection) return;
-        for (const callbackManager of this.callbackManagers) {
+        for (const [
+            index,
+            callbackManager,
+        ] of this.callbackManagers.entries()) {
             const controller = callbackManager?.controller;
             if (!controller) continue;
-            controller.selectContent(this.props.selection);
+            const selection = getSelection(this.props.selection, index);
+            if (selection) {
+                controller.selectContent(selection);
+            }
         }
         for (const spacer of this.spacers) {
             if (!spacer) continue;
@@ -972,8 +992,8 @@ class SyncLogViewer extends Component<SyncLogViewerProps, State> {
                 horizontal={this.props.horizontal}
                 axisTitles={this.props.axisTitles}
                 axisMnemos={this.props.axisMnemos}
-                domain={this.props.domain}
-                selection={this.props.selection}
+                domain={getDomain(this.props.domain, index)}
+                selection={getSelection(this.props.selection, index)}
                 primaryAxis={this.state.primaryAxis}
                 options={options}
                 // callbacks
@@ -1086,6 +1106,117 @@ function getWellLogCollectionsFromProps(props: SyncLogViewerProps) {
         if (Array.isArray(setOrCollection)) return setOrCollection;
         else return [setOrCollection];
     });
+}
+
+/**
+ * Retrieves the domain range for a specific index from the provided domain configuration.
+ *
+ * @param domain - The domain configuration, which can be either a single [min, max] tuple
+ *                 applicable to all indices, or an array of [min, max] tuples, one for each index.
+ * @param index - The index to retrieve the domain for. Only used if domain is an array of tuples.
+ * @returns A [min, max] tuple representing the domain range, or undefined if the domain
+ *          configuration is invalid or the index is out of bounds.
+ */
+function getDomain(
+    domain: SyncLogViewerProps["domain"],
+    index: number
+): [number, number] | undefined {
+    if (Array.isArray(domain)) {
+        if (Array.isArray(domain[0])) {
+            return domain[index] as [number, number] | undefined;
+        } else {
+            return domain as [number, number];
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Compares two domain props for structural and value equality.
+ *
+ * Supports both accepted domain shapes:
+ * - A single [min, max] tuple used by all views.
+ * - An array of [min, max] tuples used per view.
+ *
+ * @param domain1 - First domain value to compare.
+ * @param domain2 - Second domain value to compare.
+ * @returns True when both domains represent the same ranges, otherwise false.
+ */
+function isEqualDomains(
+    domain1: SyncLogViewerProps["domain"],
+    domain2: SyncLogViewerProps["domain"]
+): boolean {
+    if (domain1 === domain2) return true;
+    if (!domain1 || !domain2) return false;
+    if (typeof domain1 !== typeof domain2) return false;
+    if (typeof domain1[0] === "number") {
+        return isEqualRanges(
+            domain1 as [number, number],
+            domain2 as [number, number]
+        );
+    }
+    return domain1.every((range, index) =>
+        isEqualRanges(
+            range as [number, number],
+            domain2[index] as [number, number]
+        )
+    );
+}
+
+/**
+ * Retrieves the selection range for a specific index from the provided selection configuration.
+ *
+ * @param selection - The selection configuration, either a single [from, to] tuple
+ *                    for all indices or an array of [from, to] tuples per index.
+ * @param index - The index to retrieve the selection for when selection is per-index.
+ * @returns A [from, to] tuple for the requested index, or undefined when unavailable.
+ */
+function getSelection(
+    selection: SyncLogViewerProps["selection"],
+    index: number
+): [number | undefined, number | undefined] | undefined {
+    if (Array.isArray(selection)) {
+        if (Array.isArray(selection[0])) {
+            return selection[index] as
+                | [number | undefined, number | undefined]
+                | undefined;
+        } else {
+            return selection as [number | undefined, number | undefined];
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Compares two selection props for structural and value equality.
+ *
+ * Supports both accepted selection shapes:
+ * - A single [from, to] tuple used by all indices.
+ * - An array of [from, to] tuples used per index.
+ *
+ * @param selection1 - First selection value to compare.
+ * @param selection2 - Second selection value to compare.
+ * @returns True when both selections represent the same ranges, otherwise false.
+ */
+function isEqualSelections(
+    selection1: SyncLogViewerProps["selection"],
+    selection2: SyncLogViewerProps["selection"]
+): boolean {
+    if (selection1 === selection2) return true;
+    if (!selection1 || !selection2) return false;
+    if (typeof selection1 !== typeof selection2) return false;
+    if (typeof selection1[0] === "number" || selection1[0] === undefined) {
+        return isEqualRanges(
+            selection1 as [number | undefined, number | undefined],
+            selection2 as [number | undefined, number | undefined]
+        );
+    }
+    return selection1.every((range, index) =>
+        isEqualRanges(
+            range as [number | undefined, number | undefined],
+            selection2[index] as [number | undefined, number | undefined]
+        )
+    );
 }
 
 ///

--- a/typescript/packages/well-log-viewer/src/components/WellLogTemplateTypes.ts
+++ b/typescript/packages/well-log-viewer/src/components/WellLogTemplateTypes.ts
@@ -1,3 +1,5 @@
+import type { Range } from "../utils/arrayTypes";
+
 export type TemplatePlotScale = "linear" | "log";
 
 export type TemplatePlotType =
@@ -17,7 +19,7 @@ export type CSSColor = string;
 export type TemplatePlotProps = {
     type?: TemplatePlotType; // should be given or got from a style!
     scale?: TemplatePlotScale; // 'linear' or 'log', default 'linear'
-    domain?: [number, number]; // min, max values
+    domain?: Range; // min, max values
 
     color?: CSSColor; // color or colorMapFunction should be given or got from a style!
     inverseColor?: CSSColor;
@@ -58,7 +60,7 @@ export type TemplateTrack = {
     width?: number;
     plots: TemplatePlot[];
     scale?: TemplatePlotScale; // 'linear' or 'log', default first plot scale
-    domain?: [number, number]; // min, max values, default all plots domain
+    domain?: Range; // min, max values, default all plots domain
 }; // Part of JSON
 
 export interface TemplateStyle extends TemplatePlotProps {

--- a/typescript/packages/well-log-viewer/src/components/WellLogView.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogView.tsx
@@ -42,6 +42,7 @@ import {
     editViewTrack,
     removeViewTrack,
 } from "../utils/log-viewer";
+import type { OpenRange, Range } from "../utils/arrayTypes";
 import { isEqualRanges } from "../utils/arrays";
 import type { Pattern, PatternsTable } from "../utils/pattern";
 import type { ExtPlotOptions } from "../utils/plots";
@@ -888,15 +889,15 @@ export interface TrackMouseEvent {
 }
 
 export interface WellLogController {
-    zoomContentTo(domain: [number, number]): boolean;
+    zoomContentTo(domain: Range): boolean;
     scrollContentTo(f: number): boolean; // fraction of content
     zoomContent(zoom: number): void;
-    selectContent(selection: [number | undefined, number | undefined]): void;
-    setContentBaseDomain(domain: [number, number]): boolean;
-    getContentBaseDomain(): [number, number]; // full scale range
-    getContentDomain(): [number, number]; // visible range
+    selectContent(selection: OpenRange): void;
+    setContentBaseDomain(domain: Range): boolean;
+    getContentBaseDomain(): Range; // full scale range
+    getContentDomain(): Range; // visible range
     getContentZoom(): number;
-    getContentSelection(): [number | undefined, number | undefined]; // [current, pinned]
+    getContentSelection(): OpenRange; // [current, pinned]
     setContentScale(value: number): void;
     getContentScale(): number;
     setControllerDefaultZoom(): void;
@@ -1059,12 +1060,12 @@ export interface WellLogViewProps {
     /**
      * Initial visible range
      */
-    domain?: [number, number];
+    domain?: Range;
 
     /**
      * Initial selected range
      */
-    selection?: [number | undefined, number | undefined];
+    selection?: OpenRange;
 
     /**
      * Additional options
@@ -1348,8 +1349,7 @@ class WellLogView
         }
 
         let selectedTrackIndices: number[] = []; // Indices to restore
-        let selection: [number | undefined, number | undefined] | undefined =
-            undefined; // content selection to restore
+        let selection: OpenRange | undefined = undefined; // content selection to restore
         let shouldSetTracks = false;
         let checkSchema = false;
         if (
@@ -1605,7 +1605,7 @@ class WellLogView
     }
 
     // content
-    zoomContentTo(domain: [number, number]): boolean {
+    zoomContentTo(domain: Range): boolean {
         if (!this.logController) return false;
         return zoomContentTo(this.logController, domain);
     }
@@ -1679,7 +1679,7 @@ class WellLogView
             posWellPickTitles(this.logController, this);
         }
     }
-    selectContent(selection: [number | undefined, number | undefined]): void {
+    selectContent(selection: OpenRange): void {
         const selPinned = selection[1];
         if (this.selCurrent === selection[0] && this.selPinned === selPinned)
             return;
@@ -1691,15 +1691,15 @@ class WellLogView
         this.updateInfo(); // reflect new value in this.selCurrent
     }
 
-    setContentBaseDomain(domain: [number, number]): boolean {
+    setContentBaseDomain(domain: Range): boolean {
         if (!this.logController) return false;
         return setContentBaseDomain(this.logController, domain);
     }
-    getContentBaseDomain(): [number, number] {
+    getContentBaseDomain(): Range {
         if (!this.logController) return [0.0, 0.0];
         return getContentBaseDomain(this.logController);
     }
-    getContentDomain(): [number, number] {
+    getContentDomain(): Range {
         if (!this.logController) return [0.0, 0.0];
         return getContentDomain(this.logController);
     }
@@ -1707,7 +1707,7 @@ class WellLogView
         if (!this.logController) return 1.0;
         return getContentZoom(this.logController);
     }
-    getContentSelection(): [number | undefined, number | undefined] {
+    getContentSelection(): OpenRange {
         if (!this.logController) return [undefined, undefined];
         return [this.selCurrent, this.selPinned];
     }

--- a/typescript/packages/well-log-viewer/src/components/index.ts
+++ b/typescript/packages/well-log-viewer/src/components/index.ts
@@ -1,11 +1,10 @@
-export { default as WellLogView } from "./WellLogView";
+export { default as WellLogView, WellPickPropsType } from "./WellLogView";
 export type {
     TrackMouseEvent,
     WellLogController,
     WellLogViewOptions,
     WellLogViewProps,
     WellPickProps,
-    WellPickPropsType,
 } from "./WellLogView";
 
 export { default as WellLogViewWithScroller } from "./WellLogViewWithScroller";

--- a/typescript/packages/well-log-viewer/src/utils/arrayTypes.ts
+++ b/typescript/packages/well-log-viewer/src/utils/arrayTypes.ts
@@ -1,0 +1,30 @@
+/**
+ * Represents a range defined by two numeric boundaries.
+ * @typeParam 0 - The start value of the range
+ * @typeParam 1 - The end value of the range
+ */
+export type Range = [number, number];
+
+/**
+ * Represents an open-ended range where either or both bounds can be undefined.
+ * @typeParam 0 - The start value of the range, or undefined if no lower limit
+ * @typeParam 1 - The end value of the range, or undefined if no upper limit
+
+ * 
+ * @example
+ * // A range from 10 to 20
+ * const range: OpenRange = [10, 20];
+ * 
+ * @example
+ * // An open range starting from 5 with no upper limit
+ * const range: OpenRange = [5, undefined];
+ * 
+ * @example
+ * // An open range with no lower limit, ending at 100
+ * const range: OpenRange = [undefined, 100];
+ * 
+ * @example
+ * // A completely open range
+ * const range: OpenRange = [undefined, undefined];
+ */
+export type OpenRange = [number | undefined, number | undefined];

--- a/typescript/packages/well-log-viewer/src/utils/arrays.ts
+++ b/typescript/packages/well-log-viewer/src/utils/arrays.ts
@@ -1,5 +1,7 @@
 import type { Domain } from "@equinor/videx-wellog/dist/common/interfaces";
 
+import type { OpenRange, Range } from "./arrayTypes";
+
 /**
  * Utility type for various well-log things that are "named", such as tracks, plots and curves, and so on.
  */
@@ -84,8 +86,8 @@ export function toggleId(
  * @returns True if the ranges are equal, false otherwise.
  */
 export function isEqualRanges(
-    d1: undefined | [number | undefined, number | undefined],
-    d2: undefined | [number | undefined, number | undefined]
+    d1: undefined | OpenRange,
+    d2: undefined | OpenRange
 ): boolean {
     if (!d1) return !d2;
     if (!d2) return !d1;
@@ -102,10 +104,7 @@ export function isEqualRanges(
  * @returns `true` if the domains are equivalent, `false` otherwise.
  */
 // ? Conceptually very similar to isEqualRanges, should they be combined? (@anders2303)
-export function isEqDomains(
-    d1: Domain | [number, number],
-    d2: Domain | [number, number]
-): boolean {
+export function isEqDomains(d1: Domain | Range, d2: Domain | Range): boolean {
     // ! We consider all invalid domains as equivalent
     if (d1.some(Number.isNaN) && d2.some(Number.isNaN)) return true;
 

--- a/typescript/packages/well-log-viewer/src/utils/index.ts
+++ b/typescript/packages/well-log-viewer/src/utils/index.ts
@@ -1,6 +1,7 @@
 export type { AxesInfo } from "./axes";
 export { axisTitles, axisMnemos, getAxisTitle } from "./axes";
 
+export type { Range, OpenRange } from "./arrayTypes";
 export { isEqDomains, isEqualArrays, isEqualRanges } from "./arrays";
 
 export type {

--- a/typescript/packages/well-log-viewer/src/utils/index.ts
+++ b/typescript/packages/well-log-viewer/src/utils/index.ts
@@ -1,6 +1,8 @@
 export type { AxesInfo } from "./axes";
 export { axisTitles, axisMnemos, getAxisTitle } from "./axes";
 
+export { isEqDomains, isEqualArrays, isEqualRanges } from "./arrays";
+
 export type {
     ColorFunction,
     ColorTable,

--- a/typescript/packages/well-log-viewer/src/utils/log-viewer.ts
+++ b/typescript/packages/well-log-viewer/src/utils/log-viewer.ts
@@ -10,13 +10,15 @@ import type {
 import { InterpolatedScaleHandler } from "@equinor/videx-wellog";
 import type { TrackOptions } from "@equinor/videx-wellog/dist/tracks/interfaces";
 
+import type { TemplateTrack } from "../components/WellLogTemplateTypes";
+import type { WellLogSet } from "../components/WellLogTypes";
+
 import type { AxesInfo } from "./axes";
 import type { ColormapFunction } from "./color-function";
 import { getAxisIndices } from "./well-log";
 import { checkMinMax } from "./minmax";
 import { createTrack, isScaleTrack, editTrack } from "../utils/tracks";
-import type { TemplateTrack } from "../components/WellLogTemplateTypes";
-import type { WellLogSet } from "../components/WellLogTypes";
+import type { Range } from "../utils/arrayTypes";
 import { isEqDomains } from "./arrays";
 
 /**
@@ -27,7 +29,7 @@ import { isEqDomains } from "./arrays";
  */
 export function setContentBaseDomain(
     logViewer: VidexLogViewer,
-    domain: [number, number]
+    domain: Range
 ): boolean {
     const [b1, b2] = logViewer.scaleHandler.baseDomain();
     if (b1 !== domain[0] || b2 !== domain[1]) {
@@ -47,10 +49,10 @@ export function setContentBaseDomain(
  */
 export function expandDomainToFitRange(
     logViewer: VidexLogViewer,
-    range: [number, number]
+    range: Range
 ) {
     const baseDomain = logViewer.scaleHandler.baseDomain();
-    checkMinMax(baseDomain as [number, number], range);
+    checkMinMax(baseDomain as Range, range);
 
     logViewer.rescale();
 }
@@ -188,7 +190,7 @@ export function zoomContent(logViewer: VidexLogViewer, zoom: number): boolean {
         // check if new domain is in the base domain
         if (c + d > b2) c = b2 - d;
         if (c - d < b1) c = b1 + d;
-        const domain: [number, number] = [c - d, c + d];
+        const domain: Range = [c - d, c + d];
         return zoomContentTo(logViewer, domain);
     }
     return false;
@@ -210,7 +212,7 @@ export function scrollContentTo(
     const w = b2 - b1 - d; // width of not visible part of content
 
     const c = b1 + fraction * w;
-    const domain: [number, number] = [c, c + d];
+    const domain: Range = [c, c + d];
     return zoomContentTo(logViewer, domain);
 }
 
@@ -222,7 +224,7 @@ export function scrollContentTo(
  */
 export function zoomContentTo(
     logViewer: VidexLogViewer,
-    domain: [number, number]
+    domain: Range
 ): boolean {
     // ? Why do we need to retry multiple times here? (@anders2303)
     if (!isEqDomains(logViewer.domain, domain)) {
@@ -254,9 +256,7 @@ export function zoomContentTo(
  * @param logViewer A videx log view controller
  * @returns The base domain as a two-element tuple.
  */
-export function getContentBaseDomain(
-    logViewer: VidexLogViewer
-): [number, number] {
+export function getContentBaseDomain(logViewer: VidexLogViewer): Range {
     const [b1, b2] = logViewer.scaleHandler.baseDomain();
     return [b1, b2];
 }
@@ -266,7 +266,7 @@ export function getContentBaseDomain(
  * @param logViewer A videx log view controller
  * @returns The domain as a two-element tuple.
  */
-export function getContentDomain(logViewer: VidexLogViewer): [number, number] {
+export function getContentDomain(logViewer: VidexLogViewer): Range {
     const [d1, d2] = logViewer.domain; // same as logViewer.scale.domain()
     return [d1, d2];
 }

--- a/typescript/packages/well-log-viewer/src/utils/minmax.ts
+++ b/typescript/packages/well-log-viewer/src/utils/minmax.ts
@@ -1,7 +1,6 @@
-export function checkMinMaxValue(
-    minmax: [number, number],
-    value: number
-): void {
+import type { Range } from "./arrayTypes";
+
+export function checkMinMaxValue(minmax: Range, value: number): void {
     if (value !== null) {
         if (minmax[0] === Number.POSITIVE_INFINITY)
             minmax[0] = minmax[1] = value;
@@ -10,10 +9,7 @@ export function checkMinMaxValue(
     }
 }
 
-export function checkMinMax(
-    minmax: [number, number],
-    minmaxSrc: [number, number]
-): void {
+export function checkMinMax(minmax: Range, minmaxSrc: Range): void {
     if (minmax[0] === Number.POSITIVE_INFINITY) {
         minmax[0] = minmaxSrc[0];
         minmax[1] = minmaxSrc[1];
@@ -23,7 +19,7 @@ export function checkMinMax(
     }
 }
 
-export function roundMinMax(minmax: [number, number]): [number, number] {
+export function roundMinMax(minmax: Range): Range {
     const kmin = 6; // a minimal number of intervals
     const kmax = 9; // a maximal number of intervals
 
@@ -108,7 +104,7 @@ export function roundMinMax(minmax: [number, number]): [number, number] {
     return [parseFloat(a.toPrecision(5)), parseFloat(b.toPrecision(5))];
 }
 
-export function roundLogMinMax(minmax: [number, number]): [number, number] {
+export function roundLogMinMax(minmax: Range): Range {
     const r = roundMinMax(minmax);
     /* TODO: make Log version
       const ret = roundMinMax([Math.log10(minmax[0]), Math.log10(minmax[1])]);

--- a/typescript/packages/well-log-viewer/src/utils/plots.ts
+++ b/typescript/packages/well-log-viewer/src/utils/plots.ts
@@ -25,6 +25,7 @@ import type {
     WellLogSet,
 } from "../components/WellLogTypes";
 
+import type { Range } from "./arrayTypes";
 import { type AxesInfo } from "./axes";
 import type { ColormapFunction } from "./color-function";
 import { getColormapFunction } from "./color-function";
@@ -60,7 +61,7 @@ export type PlotSetup = {
     sourceLogSet: WellLogSet;
     curve: WellLogCurve;
     plotData: PlotData;
-    minmax: [number, number];
+    minmax: Range;
     templatePlot: TemplatePlot;
     isSecondary: boolean;
 };
@@ -69,8 +70,8 @@ export type PlotSetup = {
  * Data-class used when translating JSON well-log data to videx-data
  */
 export class PlotData {
-    minmax: [number, number];
-    minmaxPrimaryAxis: [number, number];
+    minmax: Range;
+    minmaxPrimaryAxis: Range;
     data: [number | null, number | string | null][];
 
     constructor() {
@@ -134,8 +135,8 @@ export function getPlotType(plot: Plot): TemplatePlotType {
 function getScaledDomain(
     templatePlot: TemplatePlot,
     scale: string,
-    minmax: [number, number]
-): [number, number] {
+    minmax: Range
+): Range {
     if (templatePlot.domain) return templatePlot.domain;
     if (scale === "log") return roundLogMinMax(minmax);
     if (
@@ -433,7 +434,7 @@ export function setupPlot(
 
     const axisIndices = getAxisIndices(sourceLogSet.curves, axesInfo);
     const plotData = preparePlotData(data, iCurve, axisIndices.primary);
-    const minmax: [number, number] = [plotData.minmax[0], plotData.minmax[1]];
+    const minmax: Range = [plotData.minmax[0], plotData.minmax[1]];
 
     return {
         iCurve,

--- a/typescript/packages/well-log-viewer/src/utils/trackFactory.ts
+++ b/typescript/packages/well-log-viewer/src/utils/trackFactory.ts
@@ -29,7 +29,7 @@ import { scaleLegendConfig } from "./stack/scale-legend";
 export function newGraphTrack(
     /* should contain:
         title: string,
-        data: [number, number][][],
+        data: Range[][],
         plots: PlotConfig[]
     */
     // ? Should we enforce this with an extended type? (@anders2303)

--- a/typescript/packages/well-log-viewer/src/utils/tracks.ts
+++ b/typescript/packages/well-log-viewer/src/utils/tracks.ts
@@ -32,6 +32,7 @@ import { createScale } from "./graph/factory";
 import { stackLegendConfig } from "./stack/stack-legend";
 import { type AxesInfo, getAxisTitle } from "./axes";
 
+import type { Range } from "./arrayTypes";
 import { checkMinMax } from "./minmax";
 import { getAxisIndices, getDiscreteMeta } from "./well-log";
 import {
@@ -49,24 +50,23 @@ import {
     newDualScaleTrack,
     newScaleTrack,
 } from "./trackFactory";
-import { isStackedTrackTemplate } from "./template";
-import { makeTrackHeader } from "./template";
+import { isStackedTrackTemplate, makeTrackHeader } from "./template";
 
 // Extended track options interface that includes template and index range properties. Used interally in other
 interface ExtTrackOptions extends TrackOptions {
-    __indexMinMax: [number, number];
+    __indexMinMax: Range;
     __template: TemplateTrack;
 }
 
 // Data class utility for createTracks return object
 class TracksInfo {
     tracks: Track[] = [];
-    minmaxPrimaryAxis: [number, number] = [
+    minmaxPrimaryAxis: Range = [
         Number.POSITIVE_INFINITY,
         Number.NEGATIVE_INFINITY,
     ];
     // ? Doesn't seem to be used anywhere? (@anders2303)
-    minmaxSecondaryAxis: [number, number] = [
+    minmaxSecondaryAxis: Range = [
         Number.POSITIVE_INFINITY,
         Number.NEGATIVE_INFINITY,
     ];
@@ -247,7 +247,7 @@ function setupTrackPlots(
 function applySetupMinMax(
     setup1: PlotSetup,
     setup2: PlotSetup | null,
-    primaryAxisMinMax: [number, number]
+    primaryAxisMinMax: Range
 ) {
     checkMinMax(primaryAxisMinMax, setup1.plotData.minmaxPrimaryAxis);
 
@@ -289,7 +289,7 @@ function makeGraphTrackOptions(
     const curvesUsed: WellLogCurve[] = [];
 
     // Store tracks index range
-    const indexMinMax: [number, number] = [
+    const indexMinMax: Range = [
         Number.POSITIVE_INFINITY,
         Number.NEGATIVE_INFINITY,
     ];
@@ -630,7 +630,7 @@ export function removeTrackPlot(track: Track, plot: Plot) {
  * @param track A videx track
  * @returns A number tuple, with the lower and upper axis values
  */
-export function getTrackIndexRange(track: Track): [number, number] {
+export function getTrackIndexRange(track: Track): Range {
     const options = track.options as ExtTrackOptions;
     if (options.__indexMinMax) {
         return options.__indexMinMax;


### PR DESCRIPTION
Accept an array of domains and selections, one for each log view.

Enhance the API to accept an array of domains or of selections to apply individually on each log view
(the current API accepts only one single domain or selection, which are applied to all the log views).

Add a SyncLogViewer story demonstrating it.
Update definition of domain and selection for the SyncLogViewer.
Export some helper functions (isEqDomains, isEqualArrays, isEqualRanges)

