### PR TITLE
chore: fix WLV stories

### DIFF
--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.stories.tsx
@@ -128,7 +128,7 @@ function fillInfo(controller: WellLogController | undefined): string {
  * The function getWellLogCollections() returns the well log collections based on the name.
  * The storybook args.wellLogCollections is a string name, which is used to get the well log collections.
  *
- * Note: it does not make really sense to pack some huge data structure into a storybook argument; user will never be able to
+ * Note: it does not really make sense to pack some huge data structure into a storybook argument; user will never be able to
  * read/edit it.
  */
 function getWellLogCollections(

--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.stories.tsx
@@ -48,8 +48,15 @@ const L898MUD = L898MUDJson as WellLogSet[];
 const L916MUD = L916MUDJson as WellLogSet[];
 const List1 = List1Json as WellLogSet[];
 const facies3Wells = facies3WellsJson as unknown as SyncLogViewerProps;
-const { welllogs: facies3WellsLogs, ...facies3WellsArgs } = facies3Wells;
-const facies3WellsCollections: WellLogSet[][] = [facies3WellsLogs];
+const {
+    welllogs: facies3WellsLogs,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    wellLogCollections: discarded,
+    ...facies3WellsArgs
+} = facies3Wells;
+const facies3WellsCollections: WellLogSet[][] | undefined = facies3WellsLogs
+    ? ([facies3WellsLogs] as WellLogSet[][])
+    : undefined;
 
 const ComponentCode =
     "<SyncLogViewer id='SyncLogViewer' \r\n" +
@@ -124,7 +131,12 @@ function fillInfo(controller: WellLogController | undefined): string {
  * Note: it does not make really sense to pack some huge data structure into a storybook argument; user will never be able to
  * read/edit it.
  */
-function getWellLogCollections(name: string): WellLogSet[][] {
+function getWellLogCollections(
+    name: string | undefined
+): WellLogSet[][] | undefined {
+    if (name === undefined) {
+        return undefined;
+    }
     switch (name) {
         case "Default":
             return defaultLogCollections;
@@ -141,7 +153,7 @@ type SyncLogViewerPropsWrapper = Omit<
     SyncLogViewerProps,
     "wellLogCollections"
 > & {
-    wellLogCollections?: string[];
+    wellLogCollections?: string;
 };
 
 const Template = (args: SyncLogViewerPropsWrapper) => {
@@ -257,9 +269,7 @@ const exampleWellPicks: WellPickProps[] = [
 ];
 
 const defaultLogCollections: WellLogSet[][] = [
-    L898MUD[0],
-    L916MUD[0],
-    List1[0],
+    [L898MUD[0], L916MUD[0], List1[0]],
 ];
 
 export const Default: StoryObj<typeof Template> = {
@@ -320,7 +330,7 @@ type TemplateWithSelectionProps = Omit<
 const TemplateWithSelection = (args: TemplateWithSelectionProps) => {
     const { wellLogCollections: collectionName = "", ...restOfArgs } = args;
     const allCollections: WellLogSet[][] =
-        getWellLogCollections(collectionName);
+        getWellLogCollections(collectionName) ?? [];
 
     const [showWell1, setShowWell1] = React.useState(true);
     const [showWell2, setShowWell2] = React.useState(true);

--- a/typescript/packages/well-log-viewer/src/SyncLogViewer.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/SyncLogViewer.stories.tsx
@@ -48,6 +48,8 @@ const L898MUD = L898MUDJson as WellLogSet[];
 const L916MUD = L916MUDJson as WellLogSet[];
 const List1 = List1Json as WellLogSet[];
 const facies3Wells = facies3WellsJson as unknown as SyncLogViewerProps;
+const { welllogs: facies3WellsLogs, ...facies3WellsArgs } = facies3Wells;
+const facies3WellsCollections: WellLogSet[][] = [facies3WellsLogs];
 
 const ComponentCode =
     "<SyncLogViewer id='SyncLogViewer' \r\n" +
@@ -113,7 +115,36 @@ function fillInfo(controller: WellLogController | undefined): string {
     );
 }
 
-const Template = (args: SyncLogViewerProps) => {
+/**
+ * Storybook 9 is very slow to parse huge JSON args.
+ * Thus the approach to use a string name to select the well log collections to be used in the story.
+ * The function getWellLogCollections() returns the well log collections based on the name.
+ * The storybook args.wellLogCollections is a string name, which is used to get the well log collections.
+ *
+ * Note: it does not make really sense to pack some huge data structure into a storybook argument; user will never be able to
+ * read/edit it.
+ */
+function getWellLogCollections(name: string): WellLogSet[][] {
+    switch (name) {
+        case "Default":
+            return defaultLogCollections;
+        case "DiscreteLogs":
+        case "DiscreteLogsWithIndividualDomains":
+            return facies3WellsCollections;
+        case "LogsWithDifferentSets":
+            return logsWithDifferentSetsCollections;
+    }
+    return [];
+}
+
+type SyncLogViewerPropsWrapper = Omit<
+    SyncLogViewerProps,
+    "wellLogCollections"
+> & {
+    wellLogCollections?: string[];
+};
+
+const Template = (args: SyncLogViewerPropsWrapper) => {
     const infoRef = React.useRef<HTMLDivElement | null>(null);
     const setInfo = function (info: string): void {
         if (infoRef.current) infoRef.current.innerHTML = info;
@@ -174,6 +205,9 @@ const Template = (args: SyncLogViewerProps) => {
                 <SyncLogViewer
                     id="SyncLogViewer"
                     {...args}
+                    wellLogCollections={getWellLogCollections(
+                        args.wellLogCollections
+                    )}
                     onCreateController={onCreateController}
                     onDeleteController={onDeleteController}
                     onContentRescale={onContentRescale}
@@ -222,6 +256,12 @@ const exampleWellPicks: WellPickProps[] = [
     },
 ];
 
+const defaultLogCollections: WellLogSet[][] = [
+    L898MUD[0],
+    L916MUD[0],
+    List1[0],
+];
+
 export const Default: StoryObj<typeof Template> = {
     args: {
         syncTrackPos: true,
@@ -230,7 +270,6 @@ export const Default: StoryObj<typeof Template> = {
         syncTemplate: true,
         horizontal: false,
 
-        welllogs: [L898MUD[0], L916MUD[0], List1[0]],
         templates: [syncTemplate, syncTemplate],
         colorMapFunctions: exampleColormapFunctions,
         wellpicks: exampleWellPicks,
@@ -265,13 +304,23 @@ export const Default: StoryObj<typeof Template> = {
             wellpickPatternFill: true,
         },
     },
-    render: (args) => <Template {...args} />,
+    // wellLogCollections is used to retrieve the well log sets from the getWellLogCollections() function
+    render: (args) => <Template {...args} wellLogCollections="Default" />,
 };
 
 Default.tags = ["no-screenshot-test"];
 
-const TemplateWithSelection = (args: SyncLogViewerProps) => {
-    const { welllogs = [], ...restOfArgs } = args;
+type TemplateWithSelectionProps = Omit<
+    SyncLogViewerProps,
+    "wellLogCollections"
+> & {
+    wellLogCollections: string;
+};
+
+const TemplateWithSelection = (args: TemplateWithSelectionProps) => {
+    const { wellLogCollections: collectionName = "", ...restOfArgs } = args;
+    const allCollections: WellLogSet[][] =
+        getWellLogCollections(collectionName);
 
     const [showWell1, setShowWell1] = React.useState(true);
     const [showWell2, setShowWell2] = React.useState(true);
@@ -294,11 +343,14 @@ const TemplateWithSelection = (args: SyncLogViewerProps) => {
         []
     );
 
-    const filtered: (WellLogSet[] | WellLogSet)[] = [];
+    const wellLogCollections: WellLogSet[][] = [];
 
-    if (showWell1 && welllogs[0]) filtered.push(welllogs[0]);
-    if (showWell2 && welllogs[1]) filtered.push(welllogs[1]);
-    if (showWell3 && welllogs[2]) filtered.push(welllogs[2]);
+    if (showWell1 && allCollections[0])
+        wellLogCollections.push(allCollections[0]);
+    if (showWell2 && allCollections[1])
+        wellLogCollections.push(allCollections[1]);
+    if (showWell3 && allCollections[2])
+        wellLogCollections.push(allCollections[2]);
 
     const handleClick = function (): void {
         for (const ctrl of controllers) {
@@ -308,7 +360,7 @@ const TemplateWithSelection = (args: SyncLogViewerProps) => {
 
     const argsWithSelection: SyncLogViewerProps = {
         ...restOfArgs,
-        welllogs: filtered,
+        wellLogCollections,
     };
 
     return (
@@ -318,9 +370,10 @@ const TemplateWithSelection = (args: SyncLogViewerProps) => {
             <div style={{ flexDirection: "row" }}>
                 <ToggleButton
                     value="check"
-                    selected={showWell1 && !!welllogs[0]}
+                    selected={showWell1 && !!allCollections[0]}
                     onChange={(): void => {
-                        if (!welllogs[1]) alert("No args.welllogs[0]");
+                        if (!allCollections[0])
+                            alert("No args.wellLogCollections[0]");
                         setShowWell1(!showWell1);
                     }}
                 >
@@ -328,9 +381,10 @@ const TemplateWithSelection = (args: SyncLogViewerProps) => {
                 </ToggleButton>
                 <ToggleButton
                     value="check"
-                    selected={showWell2 && !!welllogs[1]}
+                    selected={showWell2 && !!allCollections[1]}
                     onChange={(): void => {
-                        if (!welllogs[1]) alert("No args.welllogs[1]");
+                        if (!allCollections[1])
+                            alert("No args.wellLogCollections[1]");
                         setShowWell2(!showWell2);
                     }}
                 >
@@ -338,9 +392,10 @@ const TemplateWithSelection = (args: SyncLogViewerProps) => {
                 </ToggleButton>
                 <ToggleButton
                     value="check"
-                    selected={showWell3 && !!welllogs[2]}
+                    selected={showWell3 && !!allCollections[2]}
                     onChange={(): void => {
-                        if (!welllogs[2]) alert("No args.welllogs[2]");
+                        if (!allCollections[2])
+                            alert("No args.wellLogCollections[2]");
                         setShowWell3(!showWell3);
                     }}
                 >
@@ -362,15 +417,19 @@ const TemplateWithSelection = (args: SyncLogViewerProps) => {
 };
 
 export const DiscreteLogs: StoryObj<typeof TemplateWithSelection> = {
-    args: facies3Wells,
-    render: (args) => <TemplateWithSelection {...args} />,
+    args: { ...facies3WellsArgs },
+    // wellLogCollections is used to retrieve the well log sets from the getWellLogCollections() function
+    render: (args) => (
+        <TemplateWithSelection {...args} wellLogCollections="DiscreteLogs" />
+    ),
 };
 
 export const DiscreteLogsWithIndividualDomains: StoryObj<
     typeof TemplateWithSelection
 > = {
     args: {
-        ...facies3Wells,
+        ...facies3WellsArgs,
+
         domain: [
             [3000, 5500],
             [2500, 4000],
@@ -385,7 +444,14 @@ export const DiscreteLogsWithIndividualDomains: StoryObj<
         syncContentSelection: false,
         syncTrackPos: false,
     },
-    render: (args) => <TemplateWithSelection {...args} />,
+
+    render: (args) => (
+        <TemplateWithSelection
+            {...args}
+            // wellLogCollections is used to retrieve the well log sets from the getWellLogCollections() function
+            wellLogCollections="DiscreteLogsWithIndividualDomains"
+        />
+    ),
 };
 
 const verySimpleTemplate: TemplateType = {
@@ -421,8 +487,95 @@ const verySimpleTemplate: TemplateType = {
     ],
 };
 
+const logsWithDifferentSetsCollections: WellLogSet[][] = [
+    [
+        ...L916MUD,
+        {
+            header: L916MUD[0].header,
+            curves: [
+                {
+                    name: "DEPT",
+                    description: null,
+                    quantity: null,
+                    unit: "M",
+                    valueType: "float",
+                    dimensions: 1,
+                },
+                {
+                    name: "DVER",
+                    description: "continuous",
+                    quantity: "m",
+                    unit: "m",
+                    valueType: "float",
+                    dimensions: 1,
+                },
+
+                {
+                    name: "FLAG_EXAMPLE",
+                    description: "discrete with different sampling",
+                    quantity: "DISC",
+                    unit: "DISC",
+                    valueType: "integer",
+                    dimensions: 1,
+                },
+            ],
+            data: [
+                [2966, 2254.3, null],
+                [3297, 2533.72, 0],
+                [4123, 3251.07, 1],
+            ],
+            metadata_discrete: {
+                FLAG_EXAMPLE: {
+                    attributes: ["color", "code"],
+                    objects: {
+                        no: [[244, 237, 255, 255], 0],
+                        yes: [[255, 171, 178, 255], 1],
+                    },
+                },
+            },
+        },
+    ],
+    [
+        ...L898MUD,
+        {
+            header: L898MUD[0].header,
+            curves: [
+                {
+                    name: "DEPT",
+                    description: null,
+                    quantity: null,
+                    unit: "M",
+                    valueType: "float",
+                    dimensions: 1,
+                },
+                {
+                    name: "DVER",
+                    description: "continuous",
+                    quantity: "m",
+                    unit: "m",
+                    valueType: "float",
+                    dimensions: 1,
+                },
+
+                {
+                    name: "BAD_CONT",
+                    description: "continuous with different sampling",
+                    quantity: "m",
+                    unit: "m",
+                    valueType: "integer",
+                    dimensions: 1,
+                },
+            ],
+            data: [
+                [2977, 2263.39, 0.1],
+                [3606, 2792.98, 4],
+                [4129, 3256.31, 2],
+            ],
+        },
+    ],
+];
+
 export const LogsWithDifferentSets: StoryObj<typeof Template> = {
-    render: (args) => <Template {...args} />,
     parameters: {
         docs: {
             description: {
@@ -446,92 +599,9 @@ export const LogsWithDifferentSets: StoryObj<typeof Template> = {
         },
         colorMapFunctions: exampleColormapFunctions,
         templates: [verySimpleTemplate, verySimpleTemplate],
-        wellLogCollections: [
-            [
-                ...L916MUDJson,
-                {
-                    header: L916MUDJson[0].header,
-                    curves: [
-                        {
-                            name: "DEPT",
-                            description: null,
-                            quantity: null,
-                            unit: "M",
-                            valueType: "float",
-                            dimensions: 1,
-                        },
-                        {
-                            name: "DVER",
-                            description: "continuous",
-                            quantity: "m",
-                            unit: "m",
-                            valueType: "float",
-                            dimensions: 1,
-                        },
-
-                        {
-                            name: "FLAG_EXAMPLE",
-                            description: "discrete with different sampling",
-                            quantity: "DISC",
-                            unit: "DISC",
-                            valueType: "integer",
-                            dimensions: 1,
-                        },
-                    ],
-                    data: [
-                        [2966, 2254.3, null],
-                        [3297, 2533.72, 0],
-                        [4123, 3251.07, 1],
-                    ],
-                    metadata_discrete: {
-                        FLAG_EXAMPLE: {
-                            attributes: ["color", "code"],
-                            objects: {
-                                no: [[244, 237, 255, 255], 0],
-                                yes: [[255, 171, 178, 255], 1],
-                            },
-                        },
-                    },
-                },
-            ],
-            [
-                ...L898MUDJson,
-                {
-                    header: L898MUDJson[0].header,
-                    curves: [
-                        {
-                            name: "DEPT",
-                            description: null,
-                            quantity: null,
-                            unit: "M",
-                            valueType: "float",
-                            dimensions: 1,
-                        },
-                        {
-                            name: "DVER",
-                            description: "continuous",
-                            quantity: "m",
-                            unit: "m",
-                            valueType: "float",
-                            dimensions: 1,
-                        },
-
-                        {
-                            name: "BAD_CONT",
-                            description: "continuous with different sampling",
-                            quantity: "m",
-                            unit: "m",
-                            valueType: "integer",
-                            dimensions: 1,
-                        },
-                    ],
-                    data: [
-                        [2977, 2263.39, 0.1],
-                        [3606, 2792.98, 4],
-                        [4129, 3256.31, 2],
-                    ],
-                },
-            ],
-        ],
     },
+    // wellLogCollections is used to retrieve the well log sets from the getWellLogCollections() function
+    render: (args) => (
+        <Template {...args} wellLogCollections="LogsWithDifferentSets" />
+    ),
 };

--- a/typescript/packages/well-log-viewer/src/WellLogViewer.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/WellLogViewer.stories.tsx
@@ -37,6 +37,7 @@ const exampleColorTables = colorTablesJson as ColorTable[];
 
 const wellLogs = wellLogsJson as unknown as WellLogSet[];
 const wellLogl898MUD = wellLogl898MUDJson as WellLogSet[];
+const wellLogMWD3 = wellLogMWD3Json as WellLogSet[];
 const template1 = templateJson1 as unknown as Template;
 const template2 = templateJson2 as unknown as Template;
 
@@ -119,7 +120,41 @@ function fillInfo(controller: WellLogController | undefined): string {
     );
 }
 
-const StoryTemplate = (args: WellLogViewerProps) => {
+/**
+ * Storybook 9 is very slow to parse huge JSON args.
+ * Thus the approach to use a string name to select the well log sets to be used in the story.
+ * The function getWellLogSets() returns the well log sets based on the name.
+ * The storybook args.wellLogSets is a string name, which is used to get the well log sets.
+ *
+ * Note: it does not make really sense to pack some huge data structure into a storybook argument; user will never be able to
+ * read/edit it.
+ */
+function getWellLogSets(name: string): WellLogSet[] {
+    switch (name) {
+        case "Default":
+        case "ColorByFunction":
+            return wellLogl898MUD;
+        case "TrackTitleTooltip":
+            return trackTitleTooltipLogSets;
+        case "Horizontal":
+        case "OnInfoFilledEvent":
+            return wellLogMWD3;
+        case "Discrete":
+            return discreteLogSet;
+        case "LogsWithDifferentSets":
+            return logsWithDifferentSetsLogSet;
+    }
+    return [];
+}
+
+/**
+ * Update wellLogSets property by a name to retrieve the well log sets from the getWellLogSets() function.
+ */
+type StoryTemplateProps = Omit<WellLogViewerProps, "wellLogSets"> & {
+    wellLogSets: string;
+};
+
+const StoryTemplate = (args: StoryTemplateProps) => {
     const infoRef = React.useRef<HTMLDivElement | null>(null);
     const setInfo = function (info: string): void {
         if (infoRef.current) infoRef.current.innerHTML = info;
@@ -163,6 +198,7 @@ const StoryTemplate = (args: WellLogViewerProps) => {
                 <WellLogViewer
                     id="WellLogViewer"
                     {...args}
+                    wellLogSets={getWellLogSets(args.wellLogSets)}
                     onCreateController={onCreateController}
                     onContentRescale={onContentRescale}
                     onContentSelection={onContentSelection}
@@ -199,7 +235,6 @@ export const Default: StoryObj<typeof StoryTemplate> = {
     args: {
         //id: "Well-Log-Viewer",
         horizontal: false,
-        wellLogSets: wellLogl898MUD,
         template: template1,
         colorMapFunctions: exampleColormapFunctions,
         wellpick: wellpick,
@@ -215,14 +250,14 @@ export const Default: StoryObj<typeof StoryTemplate> = {
             hideSelectionInterval: false,
         },
     },
-    render: (args) => <StoryTemplate {...args} />,
+    // wellLogSets is used to retrieve the well log sets from the getWellLogSets() function
+    render: (args) => <StoryTemplate {...args} wellLogSets="Default" />,
 };
 
 export const ColorByFunction: StoryObj<typeof StoryTemplate> = {
     args: {
         //id: "Well-Log-Viewer",
         horizontal: false,
-        wellLogSets: wellLogl898MUD,
         template: {
             name: "Template 1",
             scale: {
@@ -264,50 +299,52 @@ export const ColorByFunction: StoryObj<typeof StoryTemplate> = {
             hideSelectionInterval: false,
         },
     },
-    render: (args) => <StoryTemplate {...args} />,
+    // wellLogSets is used to retrieve the well log sets from the getWellLogSets() function
+    render: (args) => <StoryTemplate {...args} wellLogSets="ColorByFunction" />,
 };
+
+const trackTitleTooltipLogSets: WellLogSet[] = [
+    {
+        header: {
+            name: "continuous and discrete logs",
+        },
+        curves: [
+            {
+                name: "MD",
+                description: "continuous",
+                quantity: "m",
+                unit: "m",
+                valueType: "float",
+                dimensions: 1,
+            },
+            {
+                name: "continuous",
+                description: "A continuous curve",
+            },
+            {
+                name: "discrete",
+                description: "A discrete curve",
+            },
+        ],
+        data: [
+            [0, 0, 1],
+            [1, 1, 1],
+            [2, 2, 1],
+            [3, 3, 2],
+            [4, 2, 2],
+            [5, 1, 2],
+            [6, 0, 3],
+            [7, 1, 3],
+            [8, 2, 3],
+            [9, 3, null],
+            [10, 2, null],
+        ],
+    },
+];
 
 export const TrackTitleTooltip: StoryObj<typeof StoryTemplate> = {
     args: {
         horizontal: false,
-        wellLogSets: [
-            {
-                header: {
-                    name: "continuous and discrete logs",
-                },
-                curves: [
-                    {
-                        name: "MD",
-                        description: "continuous",
-                        quantity: "m",
-                        unit: "m",
-                        valueType: "float",
-                        dimensions: 1,
-                    },
-                    {
-                        name: "continuous",
-                        description: "A continuous curve",
-                    },
-                    {
-                        name: "discrete",
-                        description: "A discrete curve",
-                    },
-                ],
-                data: [
-                    [0, 0, 1],
-                    [1, 1, 1],
-                    [2, 2, 1],
-                    [3, 3, 2],
-                    [4, 2, 2],
-                    [5, 1, 2],
-                    [6, 0, 3],
-                    [7, 1, 3],
-                    [8, 2, 3],
-                    [9, 3, null],
-                    [10, 2, null],
-                ],
-            },
-        ],
         template: {
             name: "template",
             scale: {
@@ -366,13 +403,15 @@ export const TrackTitleTooltip: StoryObj<typeof StoryTemplate> = {
             });
         }
     },
-    render: (args) => <StoryTemplate {...args} />,
+    render: (args) => (
+        // wellLogSets is used to retrieve the well log sets from the getWellLogSets() function
+        <StoryTemplate {...args} wellLogSets="TrackTitleTooltip" />
+    ),
 };
 
 export const Horizontal: StoryObj<typeof StoryTemplate> = {
     args: {
         horizontal: true,
-        wellLogSets: wellLogMWD3Json,
         template: template2,
         colorMapFunctions: exampleColormapFunctions,
         wellpick: wellpick,
@@ -387,13 +426,14 @@ export const Horizontal: StoryObj<typeof StoryTemplate> = {
             },
         },
     },
-    render: (args) => <StoryTemplate {...args} />,
+    // wellLogSets is used to retrieve the well log sets from the getWellLogSets() function
+    render: (args) => <StoryTemplate {...args} wellLogSets="Horizontal" />,
 };
 
 export const OnInfoFilledEvent: StoryObj<typeof StoryTemplate> = {
     args: {
         horizontal: true,
-        wellLogSets: wellLogMWD3Json,
+
         template: template2,
         colorMapFunctions: exampleColormapFunctions,
         wellpick: wellpick,
@@ -409,7 +449,13 @@ export const OnInfoFilledEvent: StoryObj<typeof StoryTemplate> = {
             },
         },
     },
-    render: (args) => <StoryTemplateWithCustomPanel {...args} />,
+    render: (args) => (
+        <StoryTemplateWithCustomPanel
+            {...args}
+            // wellLogSets is used to retrieve the well log sets from the getWellLogSets() function
+            wellLogSets="OnInfoFilledEvent"
+        />
+    ),
 };
 
 function StoryTemplateWithCustomPanel(props: WellLogViewerProps): JSX.Element {
@@ -480,30 +526,31 @@ function CustomInfoPanel(props: { infos: Info[] }): JSX.Element {
     );
 }
 
+const discreteLogSet: WellLogSet[] = [
+    {
+        ...wellLogs[0],
+        curves: [
+            ...wellLogs[0].curves,
+            {
+                name: "STRING_CURVE",
+                description: "A discrete curve with a string value type",
+                quantity: "DISC",
+                unit: "DISC",
+                valueType: "string",
+                dimensions: 1,
+            },
+        ],
+        data: wellLogs[0].data.map((d) => {
+            if ((d[0] as number) <= 3900) return [...d, "FOO"];
+            else return [...d, "BAR"];
+        }),
+    },
+];
+
 export const Discrete: StoryObj<typeof StoryTemplate> = {
     args: {
         horizontal: false,
-        wellLogSets: [
-            {
-                ...wellLogs[0],
-                curves: [
-                    ...wellLogs[0].curves,
-                    {
-                        name: "STRING_CURVE",
-                        description:
-                            "A discrete curve with a string value type",
-                        quantity: "DISC",
-                        unit: "DISC",
-                        valueType: "string",
-                        dimensions: 1,
-                    },
-                ],
-                data: wellLogs[0].data.map((d) => {
-                    if ((d[0] as number) <= 3900) return [...d, "FOO"];
-                    else return [...d, "BAR"];
-                }),
-            },
-        ],
+
         template: {
             ...template2,
             tracks: [
@@ -527,107 +574,109 @@ export const Discrete: StoryObj<typeof StoryTemplate> = {
             },
         },
     },
-    render: (args) => <StoryTemplate {...args} />,
+    // wellLogSets is used to retrieve the well log sets from the getWellLogSets() function
+    render: (args) => <StoryTemplate {...args} wellLogSets="Discrete" />,
 };
+
+const logsWithDifferentSetsLogSet: WellLogSet[] = [
+    {
+        header: wellLogs[0].header,
+        curves: [
+            {
+                name: "MD",
+                description: "continuous",
+                quantity: "m",
+                unit: "m",
+                valueType: "float",
+                dimensions: 1,
+            },
+            {
+                name: "PORO",
+                description: "continuous",
+                quantity: "",
+                unit: "",
+                valueType: "float",
+                dimensions: 1,
+            },
+        ],
+
+        data: [
+            [3700, 45],
+            [3725, 78],
+            [3750, 12],
+            [3775, 34],
+            [3800, 89],
+            [3825, 67],
+            [3850, 90],
+            [3875, 11],
+            [3900, 78],
+            [3925, 34],
+            [3950, 56],
+            [3975, 89],
+            [4000, 67],
+            [4025, 11],
+            [4050, 45],
+            [4075, 78],
+            [4100, 34],
+            [4125, 89],
+        ],
+    },
+
+    {
+        // Sharing the discrete config across all logs for simplicity
+        metadata_discrete: {
+            FLAG_EXAMPLE: {
+                attributes: ["color", "code"],
+                objects: {
+                    no: [[244, 237, 255, 255], 0],
+                    yes: [[255, 171, 178, 255], 1],
+                },
+            },
+        },
+        header: {
+            name: "The second log",
+            well: wellLogs[0].header.well,
+        },
+        curves: [
+            {
+                name: "MD",
+                description: "continuous",
+                quantity: "m",
+                unit: "m",
+                valueType: "float",
+                dimensions: 1,
+            },
+
+            {
+                name: "FLAG_EXAMPLE",
+                description: "discrete with different sampling",
+                quantity: "DISC",
+                unit: "DISC",
+                valueType: "integer",
+                dimensions: 1,
+            },
+
+            {
+                name: "BAD_CONT",
+                description:
+                    "A continuous curve with a really bad sampling rate",
+                quantity: "m",
+                unit: "m",
+                valueType: "integer",
+                dimensions: 1,
+            },
+        ],
+        data: [
+            [3800, null, 2],
+            [3870, 0, 2.4],
+            [4000, 1, 0.4],
+        ],
+    },
+];
 
 export const LogWithDifferentSets: StoryObj<typeof StoryTemplate> = {
     args: {
         colorMapFunctions: [],
-        wellLogSets: [
-            {
-                header: wellLogs[0].header,
-                curves: [
-                    {
-                        name: "MD",
-                        description: "continuous",
-                        quantity: "m",
-                        unit: "m",
-                        valueType: "float",
-                        dimensions: 1,
-                    },
-                    {
-                        name: "PORO",
-                        description: "continuous",
-                        quantity: "",
-                        unit: "",
-                        valueType: "float",
-                        dimensions: 1,
-                    },
-                ],
-
-                data: [
-                    [3700, 45],
-                    [3725, 78],
-                    [3750, 12],
-                    [3775, 34],
-                    [3800, 89],
-                    [3825, 67],
-                    [3850, 90],
-                    [3875, 11],
-                    [3900, 78],
-                    [3925, 34],
-                    [3950, 56],
-                    [3975, 89],
-                    [4000, 67],
-                    [4025, 11],
-                    [4050, 45],
-                    [4075, 78],
-                    [4100, 34],
-                    [4125, 89],
-                ],
-            },
-
-            {
-                // Sharing the discrete config across all logs for simplicity
-                metadata_discrete: {
-                    FLAG_EXAMPLE: {
-                        attributes: ["color", "code"],
-                        objects: {
-                            no: [[244, 237, 255, 255], 0],
-                            yes: [[255, 171, 178, 255], 1],
-                        },
-                    },
-                },
-                header: {
-                    name: "The second log",
-                    well: wellLogs[0].header.well,
-                },
-                curves: [
-                    {
-                        name: "MD",
-                        description: "continuous",
-                        quantity: "m",
-                        unit: "m",
-                        valueType: "float",
-                        dimensions: 1,
-                    },
-
-                    {
-                        name: "FLAG_EXAMPLE",
-                        description: "discrete with different sampling",
-                        quantity: "DISC",
-                        unit: "DISC",
-                        valueType: "integer",
-                        dimensions: 1,
-                    },
-
-                    {
-                        name: "BAD_CONT",
-                        description:
-                            "A continuous curve with a really bad sampling rate",
-                        quantity: "m",
-                        unit: "m",
-                        valueType: "integer",
-                        dimensions: 1,
-                    },
-                ],
-                data: [
-                    [3800, null, 2],
-                    [3870, 0, 2.4],
-                    [4000, 1, 0.4],
-                ],
-            },
-        ],
 
         template: {
             name: "aaa",
@@ -669,7 +718,10 @@ export const LogWithDifferentSets: StoryObj<typeof StoryTemplate> = {
             },
         },
     },
-    render: (args) => <StoryTemplate {...args} />,
+    render: (args) => (
+        // wellLogSets is used to retrieve the well log sets from the getWellLogSets() function
+        <StoryTemplate {...args} wellLogSets="LogsWithDifferentSets" />
+    ),
 };
 
 const MapAndWellLogViewerStoryComp = (

--- a/typescript/packages/well-log-viewer/src/WellLogViewer.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/WellLogViewer.stories.tsx
@@ -458,7 +458,16 @@ export const OnInfoFilledEvent: StoryObj<typeof StoryTemplate> = {
     ),
 };
 
-function StoryTemplateWithCustomPanel(props: WellLogViewerProps): JSX.Element {
+type StoryTemplateWithCustomPanelProps = Omit<
+    WellLogViewerProps,
+    "wellLogSets"
+> & {
+    wellLogSets: string;
+};
+
+function StoryTemplateWithCustomPanel(
+    props: StoryTemplateWithCustomPanelProps
+): JSX.Element {
     const [infos, setInfos] = React.useState<Info[]>([]);
     const [showPanel, setShowPanel] = React.useState<boolean>(false);
 

--- a/typescript/packages/well-log-viewer/src/WellLogViewer.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/WellLogViewer.stories.tsx
@@ -126,7 +126,7 @@ function fillInfo(controller: WellLogController | undefined): string {
  * The function getWellLogSets() returns the well log sets based on the name.
  * The storybook args.wellLogSets is a string name, which is used to get the well log sets.
  *
- * Note: it does not make really sense to pack some huge data structure into a storybook argument; user will never be able to
+ * Note: it does not really make sense to pack some huge data structure into a storybook argument; user will never be able to
  * read/edit it.
  */
 function getWellLogSets(name: string): WellLogSet[] {

--- a/typescript/packages/well-log-viewer/src/components/WellLogView.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogView.stories.tsx
@@ -45,7 +45,7 @@ export default stories;
  * The function getWellLogSets() returns the well log sets based on the name.
  * The storybook args.wellLogSets is a string name, which is used to get the well log sets.
  *
- * Note: it does not make really sense to pack some huge data structure into a storybook argument; user will never be able to
+ * Note: it does not really make sense to pack some huge data structure into a storybook argument; user will never be able to
  * read/edit it.
  */
 function getWellLogSets(name: string): WellLogSet[] {

--- a/typescript/packages/well-log-viewer/src/components/WellLogView.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogView.stories.tsx
@@ -2,11 +2,11 @@ import type { Meta, StoryObj } from "@storybook/react-webpack5";
 import { colorTables } from "@emerson-eps/color-tables";
 import React from "react";
 
-import WellLogView from "./WellLogView";
+import type { WellLogViewProps } from "./WellLogView";
+import WellLogView, { argTypesWellLogViewProp } from "./WellLogView";
+
 import type { WellLogSet } from "./WellLogTypes";
 import type { Template } from "./WellLogTemplateTypes";
-import type { WellLogViewProps } from "./WellLogView";
-import { argTypesWellLogViewProp } from "./WellLogView";
 import { axisTitles, axisMnemos } from "../utils/axes";
 import type { ColormapFunction } from "../utils/color-function";
 
@@ -39,10 +39,38 @@ const stories: Meta<WellLogViewProps> = {
 };
 export default stories;
 
-const WrappedWellLogView = (args: WellLogViewProps) => {
+/**
+ * Storybook 9 is very slow to parse huge JSON args.
+ * Thus the approach to use a string name to select the well log sets to be used in the story.
+ * The function getWellLogSets() returns the well log sets based on the name.
+ * The storybook args.wellLogSets is a string name, which is used to get the well log sets.
+ *
+ * Note: it does not make really sense to pack some huge data structure into a storybook argument; user will never be able to
+ * read/edit it.
+ */
+function getWellLogSets(name: string): WellLogSet[] {
+    switch (name) {
+        case "Default":
+            return [wellLogDefault];
+        case "Discrete":
+            return [wellLogDiscrete];
+    }
+    return [];
+}
+
+/**
+ * Update wellLogSets property by a name to retrieve the well log sets from the getWellLogSets() function.
+ */
+type WrappedWellLogProps = Omit<WellLogViewerProps, "wellLogSets"> & {
+    wellLogSets: string;
+};
+const WrappedWellLogView = (args: WrappedWellLogProps) => {
     return (
         <div style={{ height: "92vh" }}>
-            <WellLogView {...args} />
+            <WellLogView
+                {...args}
+                wellLogSets={getWellLogSets(args.wellLogSets)}
+            />
         </div>
     );
 };
@@ -50,7 +78,6 @@ const WrappedWellLogView = (args: WellLogViewProps) => {
 export const Default: StoryObj<typeof WrappedWellLogView> = {
     args: {
         horizontal: false,
-        wellLogSets: [wellLogDefault],
         template: viewerTemplate1,
         viewTitle: (
             <div>
@@ -61,13 +88,13 @@ export const Default: StoryObj<typeof WrappedWellLogView> = {
         axisTitles: axisTitles,
         axisMnemos: axisMnemos,
     },
-    render: (args) => <WrappedWellLogView {...args} />,
+    // wellLogSets is used to retrieve the well log sets from the getWellLogSets() function
+    render: (args) => <WrappedWellLogView {...args} wellLogSets="Default" />,
 };
 
 export const Discrete: StoryObj<typeof WrappedWellLogView> = {
     args: {
         horizontal: false,
-        wellLogSets: [wellLogDiscrete] as WellLogSet[],
         template: viewerTemplate2,
         viewTitle: "Well '" + wellLogDiscrete.header.well + "'",
         colorMapFunctions: exampleColormapFunctions,
@@ -77,5 +104,6 @@ export const Discrete: StoryObj<typeof WrappedWellLogView> = {
             checkDatafileSchema: true,
         },
     },
-    render: (args) => <WrappedWellLogView {...args} />,
+    // wellLogSets is used to retrieve the well log sets from the getWellLogSets() function
+    render: (args) => <WrappedWellLogView {...args} wellLogSets="Discrete" />,
 };

--- a/typescript/packages/well-log-viewer/src/components/WellLogView.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogView.stories.tsx
@@ -61,7 +61,7 @@ function getWellLogSets(name: string): WellLogSet[] {
 /**
  * Update wellLogSets property by a name to retrieve the well log sets from the getWellLogSets() function.
  */
-type WrappedWellLogProps = Omit<WellLogViewerProps, "wellLogSets"> & {
+type WrappedWellLogProps = Omit<WellLogViewProps, "wellLogSets"> & {
     wellLogSets: string;
 };
 const WrappedWellLogView = (args: WrappedWellLogProps) => {

--- a/typescript/packages/well-log-viewer/src/components/WellLogViewWithScroller.stories.tsx
+++ b/typescript/packages/well-log-viewer/src/components/WellLogViewWithScroller.stories.tsx
@@ -39,7 +39,7 @@ const stories: Meta<WellLogViewWithScrollerProps> = {
         },
     },
     args: {
-        // must be explicitely set starting storybook V 8
+        // must be explicitly set starting storybook V 8
         onCreateController: fn(),
         onInfo: fn(),
         onTrackScroll: fn(),
@@ -60,6 +60,10 @@ const Template = (args: WellLogViewWithScrollerProps) => {
                 <WellLogViewWithScroller
                     id="WellLogViewWithScroller"
                     {...args}
+                    // Storybook 9 is very slow to parse huge JSON args.
+                    // Move the wellLogSets from the arguments to inline to speed up storybook.
+                    // See SyncLogViewer.stories.tsx as an example to handle multiple stories.
+                    wellLogSets={wellLog898MudJson}
                 />
             </div>
         </div>
@@ -69,7 +73,6 @@ const Template = (args: WellLogViewWithScrollerProps) => {
 export const Default: StoryObj<typeof Template> = {
     args: {
         horizontal: false,
-        wellLogSets: wellLog898MudJson,
         template: templateJson1 as TemplateType,
         viewTitle: "Well '" + wellLog898MudJson[0].header.well + "'",
         colorMapFunctions: exampleColormapFunctions,


### PR DESCRIPTION
After bump to storybook 9, most WellLogViewer stories became slow and froze. This was caused by well log sets/collections to be given as story arguments. With storybook 9, parsing huge arguments leads to freeze.

Note: it does not make really sense to pack some huge data structure into a storybook argument; user will never be able to read/edit it.

This has been fixed by removing the huge data from arguments and passed directly to the components, outside of the storybook arguments or rendering function.