### PR TITLE
chore: update tests to fix VS code false positive errors

### DIFF
--- a/typescript/packages/subsurface-viewer/src/SubsurfaceViewer.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/SubsurfaceViewer.test.tsx
@@ -1,9 +1,16 @@
-import { colorTables } from "@emerson-eps/color-tables";
-import "@testing-library/jest-dom";
-import { render } from "@testing-library/react";
-import type { Unit } from "convert-units";
-import "jest-styled-components";
 import React from "react";
+
+import "jest";
+import { describe, expect, xit } from "@jest/globals";
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import "jest-styled-components";
+
+import type { Unit } from "convert-units";
+
+import { colorTables } from "@emerson-eps/color-tables";
+
 import mapData from "../../../../example-data/deckgl-map.json";
 import SubsurfaceViewer from "./SubsurfaceViewer";
 

--- a/typescript/packages/subsurface-viewer/src/components/ColorLegend.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/ColorLegend.test.tsx
@@ -1,13 +1,20 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { render } from "@testing-library/react";
-import "jest-styled-components";
-import "@testing-library/jest-dom";
 import React from "react";
-import ColorLegend from "./ColorLegend";
-import type { ExtendedLegendLayer } from "../layers/utils/layerTools";
+
+import "jest";
+import { describe, expect, xit } from "@jest/globals";
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
+import "jest-styled-components";
+
 import { colorTables } from "@emerson-eps/color-tables";
 
-describe("Test Color Legend component", () => {
+import ColorLegend from "./ColorLegend";
+
+import type { ExtendedLegendLayer } from "../layers/utils/layerTools";
+
+describe("Test ColorLegend component", () => {
     xit("snapshot test", () => {
         const { container } = render(
             <ColorLegend

--- a/typescript/packages/subsurface-viewer/src/components/ColorLegends.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/ColorLegends.test.tsx
@@ -1,17 +1,19 @@
-/**
- * @jest-environment jsdom
- */
-
 /* eslint-disable @typescript-eslint/no-var-requires */
-import type { Layer } from "@deck.gl/core";
-import "@testing-library/jest-dom";
-import { render } from "@testing-library/react";
-import "jest-styled-components";
 import React from "react";
-import { getLayersInViewport } from "../layers/utils/layerTools";
-import ColorLegends from "./ColorLegends";
+
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
+import "jest-styled-components";
+
+import type { Layer } from "@deck.gl/core";
 
 import { colorTables } from "@emerson-eps/color-tables";
+
+import { getLayersInViewport } from "../layers/utils/layerTools";
+import ColorLegends from "./ColorLegends";
 
 const colormapLayer = {
     "@@type": "ColormapLayer",
@@ -24,7 +26,7 @@ const colormapLayer = {
     valueDecoder: {
         rgbScaler: [1, 1, 1],
         // By default, scale the [0, 256*256*256-1] decoded values to [0, 1]
-        floatScaler: 1.0 / (256.0 * 256.0 * 256.0 - 1.0),
+        floatScaler: 1 / (256 * 256 * 256 - 1),
         offset: 0,
         step: 0,
     },
@@ -56,7 +58,7 @@ const wellsLayer = {
 
 const layers = [colormapLayer, wellsLayer];
 
-describe("Test Color Legend", () => {
+describe("Test ColorLegends", () => {
     it("snapshot test", () => {
         const { container } = render(
             <ColorLegends

--- a/typescript/packages/subsurface-viewer/src/components/DistanceScale.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/DistanceScale.test.tsx
@@ -1,10 +1,15 @@
-import { render } from "@testing-library/react";
-import "jest-styled-components";
-import "@testing-library/jest-dom";
 import React from "react";
+
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
+import "jest-styled-components";
+
 import { DistanceScale } from "./DistanceScale";
 
-describe("Test Color Legend", () => {
+describe("Test DistanceScale", () => {
     it("snapshot test with default props", () => {
         const { container } = render(<DistanceScale />);
         expect(container.firstChild).toMatchSnapshot();

--- a/typescript/packages/subsurface-viewer/src/components/InfoCard.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/InfoCard.test.tsx
@@ -1,17 +1,19 @@
-/**
- * @jest-environment jsdom
- */
+import React from "react";
 
-import type { Layer } from "@deck.gl/core";
-import "@testing-library/jest-dom";
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/jest-globals";
 import "jest-styled-components";
-import React from "react";
+
+import type { Layer } from "@deck.gl/core";
+
 import type { LayerPickInfo } from "../layers/utils/layerTools";
 import InfoCard from "./InfoCard";
 
-describe("Test Info Card", () => {
+describe("Test InfoCard", () => {
     it("snapshot test with no props", () => {
         const { container } = render(
             <InfoCard

--- a/typescript/packages/subsurface-viewer/src/components/Map.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/Map.test.tsx
@@ -1,13 +1,16 @@
-/**
- * @jest-environment jsdom
- */
+import React from "react";
+
+import "jest";
+import { describe, expect, xit } from "@jest/globals";
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
+import "jest-styled-components";
 
 import type { LayersList } from "@deck.gl/core";
+
 import { colorTables } from "@emerson-eps/color-tables";
-import "@testing-library/jest-dom";
-import { render } from "@testing-library/react";
-import "jest-styled-components";
-import React from "react";
+
 import {
     ColormapLayer,
     DrawingLayer,

--- a/typescript/packages/subsurface-viewer/src/components/StatusIndicator.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/StatusIndicator.test.tsx
@@ -1,7 +1,12 @@
-import { render } from "@testing-library/react";
-import "jest-styled-components";
-import "@testing-library/jest-dom";
 import React from "react";
+
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
+import "jest-styled-components";
+
 import StatusIndicator from "./StatusIndicator";
 
 describe("Test Status Indicator", () => {

--- a/typescript/packages/subsurface-viewer/src/components/ViewFooter.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/ViewFooter.test.tsx
@@ -1,7 +1,12 @@
-import { render } from "@testing-library/react";
-import "jest-styled-components";
-import "@testing-library/jest-dom";
 import React from "react";
+
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
+import "jest-styled-components";
+
 import { ViewFooter } from "./ViewFooter";
 
 describe("Test View Footer", () => {

--- a/typescript/packages/subsurface-viewer/src/components/__snapshots__/ColorLegends.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/__snapshots__/ColorLegends.test.tsx.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Test Color Legend snapshot test 1`] = `
+exports[`Test ColorLegends snapshot test 1`] = `
 <div
   style="position: absolute; display: flex; z-index: 999;"
 />
 `;
 
-exports[`Test Color Legend snapshot test if layers=0 1`] = `null`;
+exports[`Test ColorLegends snapshot test if layers=0 1`] = `null`;
 
-exports[`Test Color Legend snapshot test with props 1`] = `
+exports[`Test ColorLegends snapshot test with props 1`] = `
 <div
   style="position: absolute; display: flex; z-index: 999;"
 />

--- a/typescript/packages/subsurface-viewer/src/components/__snapshots__/DistanceScale.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/__snapshots__/DistanceScale.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Test Color Legend snapshot test with default props 1`] = `
+exports[`Test DistanceScale snapshot test with default props 1`] = `
 <div
   style="position: absolute;"
 >
@@ -14,7 +14,7 @@ exports[`Test Color Legend snapshot test with default props 1`] = `
 </div>
 `;
 
-exports[`Test Color Legend snapshot test with higher zoom 1`] = `
+exports[`Test DistanceScale snapshot test with higher zoom 1`] = `
 <div
   style="position: absolute; top: 10px; left: 10px;"
 >
@@ -30,4 +30,4 @@ exports[`Test Color Legend snapshot test with higher zoom 1`] = `
 </div>
 `;
 
-exports[`Test Color Legend snapshot test with invalid props 1`] = `null`;
+exports[`Test DistanceScale snapshot test with invalid props 1`] = `null`;

--- a/typescript/packages/subsurface-viewer/src/components/__snapshots__/InfoCard.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/__snapshots__/InfoCard.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Test Info Card snapshot test when property value provided 1`] = `
+exports[`Test InfoCard snapshot test when property value provided 1`] = `
 .c1 {
   display: grid;
   grid-gap: var(--eds_button__gap,8px);
@@ -359,7 +359,7 @@ exports[`Test Info Card snapshot test when property value provided 1`] = `
 </div>
 `;
 
-exports[`Test Info Card snapshot test with no props 1`] = `
+exports[`Test InfoCard snapshot test with no props 1`] = `
 .c1 {
   display: grid;
   grid-gap: var(--eds_button__gap,8px);
@@ -595,4 +595,4 @@ exports[`Test Info Card snapshot test with no props 1`] = `
 </div>
 `;
 
-exports[`Test Info Card undefined coordinates 1`] = `null`;
+exports[`Test InfoCard undefined coordinates 1`] = `null`;

--- a/typescript/packages/subsurface-viewer/src/components/settings/DrawModeSelector.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/settings/DrawModeSelector.test.tsx
@@ -1,12 +1,17 @@
-import { render, screen } from "@testing-library/react";
-import "jest-styled-components";
-import "@testing-library/jest-dom";
 import React from "react";
+
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/jest-globals";
+import "jest-styled-components";
+
 import { EmptyWrapper } from "../../test/TestWrapper";
 import DrawModeSelector from "./DrawModeSelector";
 
-describe("Test draw-mode menu", () => {
+describe("Test DrawModeSelector", () => {
     it("snapshot test", () => {
         const { container } = render(
             EmptyWrapper({

--- a/typescript/packages/subsurface-viewer/src/components/settings/DrawModeSelector_performance.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/settings/DrawModeSelector_performance.test.tsx
@@ -1,13 +1,19 @@
-import { render } from "@testing-library/react";
-import "jest-styled-components";
-import "@testing-library/jest-dom";
 import React, { Profiler } from "react";
+
+import "jest";
+import { describe, it } from "@jest/globals";
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
+import "jest-styled-components";
+
+import * as core from "@actions/core";
+
 import { EmptyWrapper } from "../../test/TestWrapper";
 import DrawModeSelector from "./DrawModeSelector";
-import * as core from "@actions/core";
 import logTimes, { obj } from "../../test/performanceMetrics";
 
-describe("Test draw-mode menu", () => {
+describe("Test DrawModeSelector", () => {
     it("performance test", () => {
         render(
             EmptyWrapper({

--- a/typescript/packages/subsurface-viewer/src/components/settings/LayerProperty.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/settings/LayerProperty.test.tsx
@@ -1,7 +1,12 @@
-import { render } from "@testing-library/react";
-import "jest-styled-components";
-import "@testing-library/jest-dom";
 import React from "react";
+
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
+import "jest-styled-components";
+
 import { EmptyWrapper } from "../../test/TestWrapper";
 import LayerProperty from "./LayerProperty";
 
@@ -21,7 +26,7 @@ const drawingLayer = {
     },
 };
 
-describe("Test Layer Property", () => {
+describe("Test LayerProperty", () => {
     it("snapshot test", () => {
         const { container } = drawingLayer
             ? render(

--- a/typescript/packages/subsurface-viewer/src/components/settings/LayerProperty_performance.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/settings/LayerProperty_performance.test.tsx
@@ -1,17 +1,23 @@
-import { render } from "@testing-library/react";
-import "jest-styled-components";
-import "@testing-library/jest-dom";
 import React, { Profiler } from "react";
+
+import "jest";
+import { describe, it } from "@jest/globals";
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
+import "jest-styled-components";
+
+import * as core from "@actions/core";
+
 import { EmptyWrapper } from "../../test/TestWrapper";
 import LayerProperty from "./LayerProperty";
-import * as core from "@actions/core";
 import logTimes, { obj } from "../../test/performanceMetrics";
 
 import exampleData from "../../../../../../example-data/deckgl-map.json";
 
 const layers: Record<string, unknown>[] = exampleData[0].layers;
 
-describe("Test Layer Property", () => {
+describe("Test LayerProperty", () => {
     it("performance test", () => {
         const drawing_layer = layers.find(
             (item) => item["@@type"] === "DrawingLayer"

--- a/typescript/packages/subsurface-viewer/src/components/settings/LayerSettingsButton.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/settings/LayerSettingsButton.test.tsx
@@ -1,8 +1,13 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import "jest-styled-components";
 import React from "react";
+
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/jest-globals";
+import "jest-styled-components";
+
 import { EmptyWrapper } from "../../test/TestWrapper";
 import LayerSettingsButton from "./LayerSettingsButton";
 
@@ -46,7 +51,7 @@ const wellsLayer = {
 
 const layers = [drawingLayer, wellsLayer];
 
-describe("test layers settings button", () => {
+describe("test LayerSettingsButton", () => {
     it("snapshot test", () => {
         const { container } = drawingLayer
             ? render(

--- a/typescript/packages/subsurface-viewer/src/components/settings/LayersButton.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/settings/LayersButton.test.tsx
@@ -1,10 +1,16 @@
+import React from "react";
+
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/jest-globals";
+import "jest-styled-components";
+
 import { layers } from "@equinor/eds-icons";
 import { Icon } from "@equinor/eds-core-react";
-import { render, screen, waitFor } from "@testing-library/react";
-import "jest-styled-components";
-import "@testing-library/jest-dom";
-import React from "react";
-import userEvent from "@testing-library/user-event";
+
 import { EmptyWrapper } from "../../test/TestWrapper";
 import LayersButton from "./LayersButton";
 
@@ -22,7 +28,7 @@ const testLayers: Record<string, unknown>[] = exampleData[0].layers.map(
     }
 );
 
-describe("test 'layers' button", () => {
+describe("test LayersButton", () => {
     it("snapshot test", () => {
         Icon.add({ layers });
         const { container } = render(

--- a/typescript/packages/subsurface-viewer/src/components/settings/NumericInput.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/settings/NumericInput.test.tsx
@@ -1,12 +1,16 @@
+import React, { type ChangeEvent } from "react";
+
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
 import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
 import "jest-styled-components";
-import "@testing-library/jest-dom";
-import type { ChangeEvent } from "react";
-import React from "react";
+
 import { EmptyWrapper } from "../../test/TestWrapper";
 import NumericInput from "./NumericInput";
 
-describe("Test Numeric Input", () => {
+describe("Test NumericInput", () => {
     it("snapshot test", () => {
         const { container } = render(
             EmptyWrapper({

--- a/typescript/packages/subsurface-viewer/src/components/settings/NumericInput.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/settings/NumericInput.tsx
@@ -23,7 +23,7 @@ interface Props {
 }
 
 const NumericInput: React.FC<Props> = React.memo(
-    ({ label, value, min, max, step, onChange }: Props) => {
+    ({ label, value, min = 0, max, step = 1, onChange }: Props) => {
         return (
             <div
                 style={{
@@ -58,11 +58,6 @@ const NumericInput: React.FC<Props> = React.memo(
         );
     }
 );
-
-NumericInput.defaultProps = {
-    min: 0,
-    step: 1,
-};
 
 NumericInput.displayName = "NumericInput";
 export default NumericInput;

--- a/typescript/packages/subsurface-viewer/src/components/settings/SliderInput.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/settings/SliderInput.test.tsx
@@ -1,12 +1,16 @@
+import React, { type FormEvent } from "react";
+
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
 import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
 import "jest-styled-components";
-import "@testing-library/jest-dom";
-import type { FormEvent } from "react";
-import React from "react";
+
 import { EmptyWrapper } from "../../test/TestWrapper";
 import SliderInput from "./SliderInput";
 
-describe("Test Slider Input", () => {
+describe("Test SliderInput", () => {
     it("snapshot test", () => {
         const { container } = render(
             EmptyWrapper({

--- a/typescript/packages/subsurface-viewer/src/components/settings/ToggleButton.test.tsx
+++ b/typescript/packages/subsurface-viewer/src/components/settings/ToggleButton.test.tsx
@@ -1,12 +1,16 @@
+import React, { type ChangeEvent } from "react";
+
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
 import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/jest-globals";
 import "jest-styled-components";
-import "@testing-library/jest-dom";
-import type { ChangeEvent } from "react";
-import React from "react";
+
 import { EmptyWrapper } from "../../test/TestWrapper";
 import ToggleButton from "./ToggleButton";
 
-describe("Test Toggle Input", () => {
+describe("Test ToggleButton", () => {
     it("snapshot test", () => {
         const { container } = render(
             EmptyWrapper({

--- a/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/DrawModeSelector.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/DrawModeSelector.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Test draw-mode menu snapshot test 1`] = `
+exports[`Test DrawModeSelector snapshot test 1`] = `
 .c1 {
   display: flex;
   justify-content: space-between;

--- a/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/LayerProperty.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/LayerProperty.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Test Layer Property snapshot test 1`] = `
+exports[`Test LayerProperty snapshot test 1`] = `
 .c1 {
   display: flex;
   justify-content: space-between;

--- a/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/LayerSettingsButton.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/LayerSettingsButton.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`test layers settings button snapshot test 1`] = `
+exports[`test LayerSettingsButton snapshot test 1`] = `
 .c0 {
   transform: none;
 }

--- a/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/LayersButton.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/LayersButton.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`test 'layers' button snapshot test 1`] = `
+exports[`test LayersButton snapshot test 1`] = `
 .c0 {
   transform: none;
 }
@@ -36,7 +36,7 @@ exports[`test 'layers' button snapshot test 1`] = `
 </div>
 `;
 
-exports[`test 'layers' button test empty MapState/specbase 1`] = `
+exports[`test LayersButton test empty MapState/specbase 1`] = `
 .c0 {
   transform: none;
 }
@@ -72,4 +72,4 @@ exports[`test 'layers' button test empty MapState/specbase 1`] = `
 </div>
 `;
 
-exports[`test 'layers' button test with no layers present 1`] = `null`;
+exports[`test LayersButton test with no layers present 1`] = `null`;

--- a/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/NumericInput.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/NumericInput.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Test Numeric Input snapshot test 1`] = `
+exports[`Test NumericInput snapshot test 1`] = `
 .c0 {
   display: flex;
   justify-content: space-between;

--- a/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/SliderInput.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/SliderInput.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Test Slider Input snapshot test 1`] = `
+exports[`Test SliderInput snapshot test 1`] = `
 .c0 {
   display: flex;
   justify-content: space-between;

--- a/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/ToggleButton.test.tsx.snap
+++ b/typescript/packages/subsurface-viewer/src/components/settings/__snapshots__/ToggleButton.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Test Toggle Input snapshot test 1`] = `
+exports[`Test ToggleButton snapshot test 1`] = `
 .c0 {
   display: flex;
   justify-content: space-between;

--- a/typescript/packages/subsurface-viewer/src/layers/shader_modules/test-precision/precisionForTests-shaders-glsl.test.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/shader_modules/test-precision/precisionForTests-shaders-glsl.test.ts
@@ -1,5 +1,4 @@
 import "jest";
-
 import { describe, expect, it, afterEach } from "@jest/globals";
 
 import { computePrecision } from "./precisionForTests-shaders-glsl";

--- a/typescript/packages/subsurface-viewer/src/layers/utils/layerTools.test.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/utils/layerTools.test.ts
@@ -1,4 +1,6 @@
 import "jest";
+import { describe, expect, it, jest } from "@jest/globals";
+
 import type { AccessorContext, ChangeFlags } from "@deck.gl/core";
 
 import { getFromAccessor, hasUpdateTriggerChanged } from "./layerTools";
@@ -21,12 +23,15 @@ describe("layerTools", () => {
         });
 
         it("should call accessor function with data and objectInfo", () => {
-            const accessorFn = jest.fn((data: typeof mockData) => {
-                return data.value * 2;
-            });
+            const accessorFn = jest.fn(
+                (data: typeof mockData, objectInfo: unknown) => {
+                    expect(objectInfo).toBe(mockContext);
+                    return data.value * 2;
+                }
+            );
 
             const result = getFromAccessor(accessorFn, mockData, mockContext);
-
+            expect(accessorFn).toHaveBeenCalledTimes(1);
             expect(accessorFn).toHaveBeenCalledWith(mockData, mockContext);
             expect(result).toBe(200);
         });

--- a/typescript/packages/subsurface-viewer/src/layers/utils/simplify.test.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/utils/simplify.test.ts
@@ -1,3 +1,6 @@
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
 import type { Point3D } from "../../utils";
 import { simplify } from "./simplify";
 

--- a/typescript/packages/subsurface-viewer/src/layers/wells/utils/abscissaTransform.test.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/wells/utils/abscissaTransform.test.ts
@@ -1,6 +1,9 @@
+import "jest";
 import { describe, expect, it } from "@jest/globals";
+
 import type { LineString, Point } from "geojson";
 import _ from "lodash";
+
 import type { WellFeature, WellFeatureCollection } from "../types";
 import {
     abscissaTransform,

--- a/typescript/packages/subsurface-viewer/src/layers/wells/utils/features.test.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/wells/utils/features.test.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-function-type */
 import "jest";
+import { describe, expect, it, jest } from "@jest/globals";
+
 import type { Feature } from "geojson";
 
-import type { WellFeature } from "../types";
+import type { SizeAccessor, WellFeature } from "../types";
 import {
     getSize,
     getWellHeadPosition,
@@ -11,6 +13,9 @@ import {
     DEFAULT_LINE_WIDTH,
     DEFAULT_POINT_SIZE,
 } from "./features";
+
+// disable console.warn to avoid warning messages in the test output
+jest.spyOn(console, "warn").mockImplementation(() => {});
 
 describe("features", () => {
     describe("getSize", () => {
@@ -23,8 +28,8 @@ describe("features", () => {
         });
 
         it("should return function that wraps provided accessor function", () => {
-            const mockAccessor1 = jest.fn().mockReturnValue(20);
-            const mockAccessor2 = jest.fn().mockReturnValue(16);
+            const mockAccessor1 = jest.fn().mockReturnValue(20) as SizeAccessor;
+            const mockAccessor2 = jest.fn().mockReturnValue(16) as SizeAccessor;
 
             const mockObject = {} as Feature;
             const mockObjectInfo = { index: 0 };
@@ -45,7 +50,7 @@ describe("features", () => {
         it("should use apply offset value in generated accessors", () => {
             const mockObject = {} as Feature;
             const mockObjectInfo = { index: 0 };
-            const mockAccessor1 = jest.fn().mockReturnValue(12);
+            const mockAccessor1 = jest.fn().mockReturnValue(12) as SizeAccessor;
             const mockAccessor2 = 16;
 
             const result1 = getSize(LINE, mockAccessor1, 6);

--- a/typescript/packages/subsurface-viewer/src/layers/wells/utils/log.test.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/wells/utils/log.test.ts
@@ -1,4 +1,5 @@
 import "jest";
+import { describe, expect, it } from "@jest/globals";
 
 import type { LogCurveDataType } from "../types";
 import {

--- a/typescript/packages/subsurface-viewer/src/layers/wells/utils/markers.test.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/wells/utils/markers.test.ts
@@ -1,5 +1,9 @@
-import { buildMarkerPath2D } from "./markers";
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
 import type { Position } from "geojson";
+
+import { buildMarkerPath2D } from "./markers";
 
 describe("Marker utilities", () => {
     const anchorPoint: Position = [100, 200, 50];

--- a/typescript/packages/subsurface-viewer/src/layers/wells/utils/readout.test.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/wells/utils/readout.test.ts
@@ -1,4 +1,6 @@
 import "jest";
+import { describe, expect, it } from "@jest/globals";
+
 import type {
     PerforationProperties,
     ScreenProperties,

--- a/typescript/packages/subsurface-viewer/src/layers/wells/utils/spline.test.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/wells/utils/spline.test.ts
@@ -1,3 +1,6 @@
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
 import { removeConsecutiveDuplicates, splineRefine } from "./spline";
 import type { Point3D } from "../../../utils";
 import type {

--- a/typescript/packages/subsurface-viewer/src/layers/wells/utils/wells.test.ts
+++ b/typescript/packages/subsurface-viewer/src/layers/wells/utils/wells.test.ts
@@ -1,6 +1,8 @@
 import "jest";
+import { describe, expect, it } from "@jest/globals";
 
 import type { Position } from "geojson";
+
 import type { WellFeature } from "../types";
 import {
     getWellObjectByName,

--- a/typescript/packages/subsurface-viewer/src/utils/BoundingBox2D.test.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/BoundingBox2D.test.ts
@@ -1,4 +1,5 @@
 import "jest";
+import { describe, expect, it } from "@jest/globals";
 
 import type { BoundingBox2D } from "./BoundingBox2D";
 import { boxCenter, boxUnion, isEmpty } from "./BoundingBox2D";

--- a/typescript/packages/subsurface-viewer/src/utils/BoundingBox3D.test.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/BoundingBox3D.test.ts
@@ -1,4 +1,5 @@
 import "jest";
+import { describe, expect, it } from "@jest/globals";
 
 import type { BoundingBox3D } from "./BoundingBox3D";
 import {

--- a/typescript/packages/subsurface-viewer/src/utils/Color.test.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/Color.test.ts
@@ -1,4 +1,5 @@
 import "jest";
+import { describe, expect, it } from "@jest/globals";
 
 import type { RGBAColor, RGBColor } from "../utils/Color";
 import {
@@ -24,7 +25,7 @@ describe("Color utilities", () => {
         });
 
         it("should return undefined for undefined input", () => {
-            const result = toNormalizedColor(undefined);
+            const result = toNormalizedColor();
             expect(result).toBeUndefined();
         });
 

--- a/typescript/packages/subsurface-viewer/src/utils/Point3D.test.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/Point3D.test.ts
@@ -1,4 +1,5 @@
 import "jest";
+import { describe, expect, it } from "@jest/globals";
 
 import type { Point3D } from "./Point3D";
 import { add } from "./Point3D";

--- a/typescript/packages/subsurface-viewer/src/utils/arrays.test.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/arrays.test.ts
@@ -1,4 +1,5 @@
 import "jest";
+import { describe, expect, it } from "@jest/globals";
 
 import { scaleArray } from "./arrays";
 

--- a/typescript/packages/subsurface-viewer/src/utils/camera.test.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/camera.test.ts
@@ -1,6 +1,8 @@
 import "jest";
+import { describe, expect, it } from "@jest/globals";
 
 import { renderHook } from "@testing-library/react";
+
 import type { ViewStateType } from "../components/Map";
 import type { ViewportType } from "../views/viewport";
 import { getZoom, useLateralZoom } from "./camera";

--- a/typescript/packages/subsurface-viewer/src/utils/configTools.test.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/configTools.test.ts
@@ -1,4 +1,5 @@
 import "jest";
+import { describe, expect, it } from "@jest/globals";
 
 import type { Config } from "./configTools";
 import { findConfig } from "./configTools";

--- a/typescript/packages/subsurface-viewer/src/utils/measurement.test.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/measurement.test.ts
@@ -1,4 +1,5 @@
 import "jest";
+import { describe, expect, it } from "@jest/globals";
 
 import {
     distToSegmentSquared,

--- a/typescript/packages/subsurface-viewer/src/utils/serialize.test.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/serialize.test.ts
@@ -1,8 +1,5 @@
-/**
- * @jest-environment jsdom
- */
-
 import "jest";
+import { describe, expect, it, jest } from "@jest/globals";
 
 import fs from "node:fs";
 import path from "node:path";

--- a/typescript/packages/subsurface-viewer/src/utils/typedArray.test.ts
+++ b/typescript/packages/subsurface-viewer/src/utils/typedArray.test.ts
@@ -1,4 +1,5 @@
 import "jest";
+import { describe, expect, it } from "@jest/globals";
 
 import { isNumberArray, isTypedArray, toTypedArray } from "./typedArray";
 

--- a/typescript/packages/well-completions-plot/src/private-utils/stringUtil.test.ts
+++ b/typescript/packages/well-completions-plot/src/private-utils/stringUtil.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { capitalizeFirstLetter } from "./stringUtils";
 
 describe("capitalize the first letter", () => {

--- a/typescript/packages/well-completions-plot/src/utility-lib/dataTypeUtils.test.ts
+++ b/typescript/packages/well-completions-plot/src/utility-lib/dataTypeUtils.test.ts
@@ -1,3 +1,6 @@
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
 import {
     areCompletionsPlotDataValuesEqual,
     extractSubzones,

--- a/typescript/packages/well-completions-plot/src/utility-lib/stringUtils.test.ts
+++ b/typescript/packages/well-completions-plot/src/utility-lib/stringUtils.test.ts
@@ -1,3 +1,6 @@
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
 import { createWellNameRegexMatcher } from "./stringUtils";
 
 describe("createWellNameRegexMatcher", () => {

--- a/typescript/packages/well-completions-plot/src/utility-lib/wellSortUtils.test.ts
+++ b/typescript/packages/well-completions-plot/src/utility-lib/wellSortUtils.test.ts
@@ -1,3 +1,6 @@
+import "jest";
+import { describe, expect, it } from "@jest/globals";
+
 import {
     createGetWellPlotDataCompareValueFunction,
     compareWellPlotDataValues,


### PR DESCRIPTION
Unify imports in test files.
Disable console warnings or logs during the tests. Update snapshots