### PR TITLE
fix: crash in seismic display with null clampRange

### DIFF
--- a/typescript/packages/subsurface-viewer/src/layers/gpglLayers/gpglValueMappedSurfaceLayer.tsx
+++ b/typescript/packages/subsurface-viewer/src/layers/gpglLayers/gpglValueMappedSurfaceLayer.tsx
@@ -573,7 +573,7 @@ export class GpglValueMappedSurfaceLayer extends Layer<GpglValueMappedSurfaceLay
 
         const clampRange =
             this.props.colormapSetup?.clampRange === null
-                ? null
+                ? [0, 1]
                 : (this.props.colormapSetup?.clampRange ?? colormapRange);
 
         // render all the triangle surfaces


### PR DESCRIPTION
The shader expects 2 values for the clamp range, even if not used.
The fix is to set a dummy [0, 1] clamp range for the shader.