### PR TITLE
test(storybook): stabilize flaky GroupTreePlot smoke tests

### DIFF
--- a/typescript/.storybook/preview.tsx
+++ b/typescript/.storybook/preview.tsx
@@ -1,4 +1,35 @@
-import type { Preview } from "@storybook/react-webpack5";
+import type { Decorator, Preview } from "@storybook/react-webpack5";
+import { MotionGlobalConfig } from "motion/react";
+
+declare global {
+    interface Window {
+        /**
+         * Test-only flag set by the Storybook test-runner (see
+         * `.storybook/test-runner.ts`, `preVisit`) before each story is
+         * visited. When set, Framer Motion animations are skipped so that
+         * screenshot and DOM snapshot assertions run against a settled
+         * frame instead of racing an in-flight spring animation (this is
+         * what made the `GroupTreePlot` stories intermittently fail with
+         * `Page.captureScreenshot` protocol errors).
+         *
+         * Deliberately *not* driven by `prefers-reduced-motion`: gating on
+         * that media query would also disable animations for anyone
+         * manually browsing Storybook with that OS setting enabled, which
+         * would misrepresent the real, motion-enabled component behaviour.
+         * This flag is only ever set by Playwright, so manual Storybook use
+         * is unaffected.
+         */
+        __WEBVIZ_SKIP_MOTION__?: boolean;
+    }
+}
+
+const withMotionTestOverride: Decorator = (Story) => {
+    MotionGlobalConfig.skipAnimations = Boolean(
+        typeof window !== "undefined" && window.__WEBVIZ_SKIP_MOTION__
+    );
+
+    return Story();
+};
 
 const preview: Preview = {
     parameters: {
@@ -18,6 +49,8 @@ const preview: Preview = {
     },
 
     tags: ["autodocs"],
+
+    decorators: [withMotionTestOverride],
 };
 
 export default preview;

--- a/typescript/.storybook/test-runner.ts
+++ b/typescript/.storybook/test-runner.ts
@@ -10,27 +10,72 @@ import {
 // https://github.com/mapbox/pixelmatch#pixelmatchimg1-img2-output-width-height-options
 const customDiffConfig = {};
 
-const screenshotTest = async (page: Page, context: TestContext) => {
-    let previousScreenshot: Buffer = Buffer.from("");
+/**
+ * Polls `sample()` until two consecutive samples are equal (by `isEqual`), or
+ * until `maxAttempts` is reached, whichever comes first. Returns the last
+ * sample taken.
+ *
+ * Used to wait out stories whose rendering settles asynchronously (debounced
+ * `ResizeObserver` layout, animations, etc.) before asserting a screenshot or
+ * DOM snapshot against them. Bounded so that a story which never settles
+ * fails fast with a diff to inspect, instead of silently consuming the whole
+ * Jest `testTimeout`.
+ */
+async function waitUntilStable<T>(
+    sample: () => Promise<T>,
+    isEqual: (a: T, b: T) => boolean,
+    { maxAttempts, poll }: { maxAttempts: number; poll: number }
+): Promise<T> {
+    let previous: T = await sample();
 
-    let stable = false;
+    for (let attempt = 1; attempt < maxAttempts; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, poll));
 
-    const poll = 10000;
-
-    while (!stable) {
-        const currentScreenshot = await page.screenshot();
-        if (currentScreenshot.equals(previousScreenshot)) {
-            stable = true;
-        } else {
-            previousScreenshot = currentScreenshot;
+        const current = await sample();
+        if (isEqual(current, previous)) {
+            return current;
         }
+        previous = current;
+    }
 
-        if (!stable) {
-            await page.waitForTimeout(poll);
+    return previous;
+}
+
+/**
+ * `page.screenshot()` can intermittently throw
+ * `Protocol error (Page.captureScreenshot): Unable to capture screenshot`
+ * when Chromium's compositor is captured mid-frame (observed almost
+ * exclusively on stories with continuously-running animations). This is a
+ * transient CDP failure, not a rendering problem, so a couple of retries
+ * clear it without masking genuine screenshot failures, which still throw
+ * after exhausting the attempts.
+ */
+async function screenshotWithRetry(page: Page, attempts = 3): Promise<Buffer> {
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+        try {
+            return await page.screenshot({
+                animations: "disabled",
+                caret: "hide",
+                timeout: 15000,
+            });
+        } catch (error) {
+            lastError = error;
         }
     }
 
-    expect(previousScreenshot).toMatchImageSnapshot({
+    throw lastError;
+}
+
+const screenshotTest = async (page: Page, context: TestContext) => {
+    const screenshot = await waitUntilStable(
+        () => screenshotWithRetry(page),
+        (a, b) => a.equals(b),
+        { maxAttempts: 20, poll: 500 }
+    );
+
+    expect(screenshot).toMatchImageSnapshot({
         customSnapshotIdentifier: context.id,
         // https://www.npmjs.com/package/jest-image-snapshot/v/4.0.2#-api
         failureThreshold: 0.01,
@@ -45,26 +90,16 @@ const domSnapshotTest = async (page: Page) => {
     // ResizeObserver-driven layout for axis ticks), so poll until the
     // markup stops changing before asserting - mirroring the stability
     // loop used by screenshotTest above.
-    let previousHTML = "";
-    let stable = false;
-    const maxAttempts = 20;
-    const poll = 500;
+    const html = await waitUntilStable(
+        async () => {
+            const elementHandler = await page.$("#storybook-root");
+            return elementHandler ? await elementHandler.innerHTML() : "";
+        },
+        (a, b) => a === b,
+        { maxAttempts: 20, poll: 500 }
+    );
 
-    for (let attempt = 0; attempt < maxAttempts && !stable; attempt++) {
-        const elementHandler = await page.$("#storybook-root");
-        const currentHTML = elementHandler
-            ? await elementHandler.innerHTML()
-            : "";
-
-        if (currentHTML === previousHTML) {
-            stable = true;
-        } else {
-            previousHTML = currentHTML;
-            await page.waitForTimeout(poll);
-        }
-    }
-
-    expect(previousHTML).toMatchSnapshot();
+    expect(html).toMatchSnapshot();
 };
 
 const config: TestRunnerConfig = {
@@ -72,6 +107,18 @@ const config: TestRunnerConfig = {
         jest.retryTimes(3);
 
         expect.extend({ toMatchImageSnapshot });
+    },
+
+    async preVisit(page) {
+        // Tell preview.tsx's motion decorator to skip Framer Motion
+        // animations for this story. Set here (rather than read once at
+        // module load) because the test-runner navigates to iframe.html a
+        // single time in its `prepare` step and reuses that page for every
+        // story - preview.tsx's module body runs before any preVisit hook,
+        // so a flag read at import time would always be stale.
+        await page.evaluate(() => {
+            window.__WEBVIZ_SKIP_MOTION__ = true;
+        });
     },
 
     async postVisit(page, context) {

--- a/typescript/.storybook/test-runner.ts
+++ b/typescript/.storybook/test-runner.ts
@@ -50,7 +50,11 @@ async function waitUntilStable<T>(
  * clear it without masking genuine screenshot failures, which still throw
  * after exhausting the attempts.
  */
-async function screenshotWithRetry(page: Page, attempts = 3): Promise<Buffer> {
+async function screenshotWithRetry(
+    page: Page,
+    attempts = 4,
+    retryDelay = 250
+): Promise<Buffer> {
     let lastError: unknown;
 
     for (let attempt = 1; attempt <= attempts; attempt++) {
@@ -62,6 +66,14 @@ async function screenshotWithRetry(page: Page, attempts = 3): Promise<Buffer> {
             });
         } catch (error) {
             lastError = error;
+
+            // Give the CDP session a brief moment to recover before
+            // retrying - retrying instantly back-to-back doesn't reliably
+            // clear the transient error, since the compositor may still be
+            // mid-frame from the previous attempt.
+            if (attempt < attempts) {
+                await new Promise((resolve) => setTimeout(resolve, retryDelay));
+            }
         }
     }
 

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -75,6 +75,7 @@
         "jest-image-snapshot": "^6.5.2",
         "jest-styled-components": "^7.4.0",
         "json-schema": "^0.4.0",
+        "motion": "^11.18.0",
         "nx": "^22.0.1",
         "postcss": "^8.5.23",
         "prettier": "^3.5.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -107,6 +107,7 @@
     "jest-image-snapshot": "^6.5.2",
     "jest-styled-components": "^7.4.0",
     "json-schema": "^0.4.0",
+    "motion": "^11.18.0",
     "nx": "^22.0.1",
     "postcss": "^8.5.23",
     "prettier": "^3.5.3",


### PR DESCRIPTION
## Summary

The `Storybook Smoke Tests` CI job is intermittently flaky. Fixes #2828, which documents the
evidence: across the 20 most recent failing `typescript.yml` runs, **24 of 28** individual test
failures were

```
page.screenshot: Protocol error (Page.captureScreenshot): Unable to capture screenshot
```

thrown from the screenshot-stability loop in `typescript/.storybook/test-runner.ts`, and **all 24**
were one of the three `GroupTreePlot` stories (`Default`, `Resizable`,
`InteractiveWithTreeTypeSwitch`) — the only stories driven by continuously-running `motion` (Framer
Motion) spring animations on SVG geometry. The animation keeps the Chromium compositor busy while the
harness polls `page.screenshot()` for a settled frame, which intermittently trips a transient CDP
capture error.

## Changes

- **`.storybook/preview.tsx`**: add a decorator that sets `MotionGlobalConfig.skipAnimations` from a
  `window.__WEBVIZ_SKIP_MOTION__` flag. That flag is only ever set by the test runner (see below), so
  this is deliberately **not** wired to `prefers-reduced-motion` or a build-time env var — manual
  Storybook browsing and the shipped component's real animation behaviour are unaffected.
- **`.storybook/test-runner.ts`**:
  - a new `preVisit` hook sets the flag via `page.evaluate` before each story renders (the test runner
    navigates to `iframe.html` once and reuses that page for every story, so `preview.tsx`'s module
    body runs before any hook — the flag has to be set on the live page, not read at import time);
  - the screenshot and DOM-snapshot stability loops are unified into one bounded `waitUntilStable`
    helper (replacing the previous **unbounded** `while` loop with a **10 000 ms** poll — every story
    paid at least one 10s sleep; the new poll is 500 ms with a 20-attempt ceiling);
  - `page.screenshot()` now passes `animations: "disabled"`, `caret: "hide"`, and an explicit timeout;
  - a small retry wraps the capture to tolerate a transient `Page.captureScreenshot` protocol error
    instead of failing the test outright.
- **`typescript/package.json`**: add `motion` as an explicit devDependency (it was previously only
  hoisted transitively from `@webviz/group-tree-plot`).

## Verification

- `npm run validate` (typecheck + lint) — clean.
- `npx nx run-many -t test_correctness` — 292 passed, 6 pre-existing skips, 0 failures.
- Built Storybook locally and ran `test-storybook` directly against the static build (mirroring the CI
  `smoke_tests` job): **5 consecutive clean runs** of the `GroupTreePlot` stories (previously flaky,
  now ~5s each with no capture errors), plus a full 211-story pass with **no** `GroupTreePlot`
  failures and **no** `captureScreenshot` errors. The full run had 3 unrelated `SubsurfaceViewer`
  image-snapshot diffs (`WellsLayer`/`WellLabelLayer`, ~1.5–2.5%) that reproduce against this
  devcontainer's own Chromium/font stack rather than the pinned `mcr.microsoft.com/playwright:v1.60.0-jammy`
  CI image — a known environment-fidelity limitation, not a regression from this change (these files
  are untouched here).
- No `__image_snapshots__` baselines needed regenerating: skipping the animation snaps to the same
  final frame the animation already converges to, so `GroupTreePlot`'s existing baselines matched
  exactly in all runs above.

CI's `Storybook Smoke Tests` job (Docker + the pinned Playwright image) will provide the
authoritative screenshot-comparison result for this PR.
